### PR TITLE
feat: add typed rendering and wiki view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Welcome! This document outlines the style, hygiene, and design guidelines for ma
 ## Vault rules
 
 ### Clean filenames
-- **Rule:** Use lowercase kebab-case for all filenames (e.g., `opal-security.md`). Do not use spaces, uppercase letters, or underscores.
+- **Rule:** Default user-facing examples should prefer Wikipedia-style filenames for ordinary pages (e.g., `Opal_Security.md`). Reserve `index.md` only for folder index routes. Avoid spaces and other unsafe route characters.
 - **Enforcer:** `check:filenames` (Warning by default)
 
 ### Internal links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.5 — 2026-05-31
+
+### Added
+- `wiki view <file>` command for terminal document rendering with Rich
+- Rich dependency for ASCII-safe terminal output
+- YAML, YML, and JSON document support alongside Markdown
+- CURIE expansion for HTML microdata attributes
+- Typed HTML rendering with infoboxes and `wiki:template` support
+
+### Fixed
+- Linkify only known document slugs in SPARQL results
+- Regenerate stale SPARQL blocks in docs
+
+### Removed
+- Loose blank node resolution (`build_person_name_map`, `resolve_blank_nodes`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@
 - Regenerate stale SPARQL blocks in docs
 
 ### Removed
-- Loose blank node resolution (`build_person_name_map`, `resolve_blank_nodes`)
+- Loose blank node resolution keyed on name/givenName+familyName (`build_person_name_map`, `resolve_blank_nodes`)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Starter template repo: [github.com/wazootech/wiki-example](https://github.com/wa
 - **Deductive Reasoning**: Full OWL-RL deductive reasoning expansion powered by `owlrl`.
 - **SHACL Validation**: Rich conformance testing of markdown files against loaded shapes powered by `pyshacl` with JSON and text reporting.
 - **Dynamic SPARQL Rendering**: Scan and execute embedded SPARQL query blocks in markdown files, injecting updated results back into the documents inline.
+- **Typed HTML Rendering**: Build typed pages with template selection via `template` or `wiki:template`, plus generated infoboxes with clickable wiki and external links.
 
 ## Installation
 
@@ -79,7 +80,7 @@ Perform unified validations of your wiki, including strict SHACL schema validati
 wiki check
 
 # Check a single file specifically
-wiki check wiki/gregory.md
+wiki check wiki/Gregory_House.md
 
 # Autofix hygiene issues (rename non-kebab-case files + update wikilinks)
 wiki check --fix
@@ -128,6 +129,12 @@ wiki render -v
 
 # Check if any files are stale without modifying them (non-zero exit on stale)
 wiki render --check
+
+# Render a single file during an edit loop
+wiki render wiki/people/Gregory_House.md
+
+# Render only matching markdown files
+wiki render --glob "wiki/people/*.md"
 ```
 
 An embedded SPARQL block is defined in your markdown files like this:
@@ -207,7 +214,7 @@ _site/
     └── ...
 ```
 
-Page URLs are derived from the source path under `inputDirs`, minus `.md`, with case preserved. Folders are preserved. `index.md` maps to its containing folder route, so `wiki/index.md` owns `/wiki/` and `wiki/games/index.md` owns `/wiki/games/`. Headings do not create separate pages; they receive GitHub-compatible fragment IDs such as `#release-history`.
+Page URLs are derived from the source path under `inputDirs`, minus `.md`, with case preserved. Folders are preserved. `index.md` maps to its containing folder route, so `wiki/index.md` owns `/wiki/` and `wiki/games/index.md` owns `/wiki/games/`. For ordinary pages, the default examples use Wikipedia-style filenames such as `Gregory_House.md` and `Pokemon_Diamond.md`. Headings do not create separate pages; they receive GitHub-compatible fragment IDs such as `#release-history`.
 
 `wiki build` runs `wiki check` before cleaning output unless `--no-check` is passed. If checks fail, the previous output is left untouched. Once checks pass, the owned output path is treated as disposable build output and rebuilt.
 
@@ -221,6 +228,47 @@ exclude:
 ```
 
 Asset directories are relative to the config file and copied under the base URL preserving their configured path, e.g. `assets/items/photo.jpg` becomes `/wiki/assets/items/photo.jpg`.
+
+#### Page templates and infoboxes
+
+The HTML builder now supports lightweight typed page templates. Template selection order is:
+
+1. `wiki:template` frontmatter property
+2. `template` frontmatter property
+3. first page `type` / `@type`
+4. built-in `default`
+
+Built-in typed layouts currently include `person` and `thing`, both of which render a sidebar infobox. Infobox values become links automatically when they reference another wiki page or an external URL.
+
+```yaml
+id: wiki:Gregory_House
+type: schema:Person
+name: Gregory House
+wiki:template: person
+spouse: wiki:Bella_Davidson
+url: https://example.com/gregory
+```
+
+In the built site:
+
+- `wiki:Bella_Davidson` links to the `Bella_Davidson` page when that page exists
+- `https://example.com/gregory` renders as an external link
+- `wiki:template` controls the page layout and is hidden from the infobox itself
+
+Use SHACL to constrain template usage when needed, for example requiring at most one `wiki:template` value:
+
+```yaml
+id: wiki:PersonShape
+type: sh:NodeShape
+sh:targetClass: schema:Person
+sh:property:
+  - sh:path: schema:name
+    sh:datatype: xsd:string
+    sh:minCount: 1
+  - sh:path: wiki:template
+    sh:datatype: xsd:string
+    sh:maxCount: 1
+```
 
 #### GitHub Pages deployment
 
@@ -317,7 +365,7 @@ When run without a file argument, exports all documents in the wiki directory.
 wiki export
 
 # Export a single file
-wiki export wiki/gregory.md
+wiki export wiki/Gregory_House.md
 
 # Export as expanded JSON-LD
 wiki export wiki/rdf.md -f json-ld
@@ -346,7 +394,7 @@ Following the Unix philosophy of pipes and filters, `wiki` works seamlessly with
 * **Format and Print a Document:**
   Use `pr` to add headers, margins, and page numbers before sending to `lp`:
   ```bash
-  cat wiki/gregory.md | pr -h "Gregory Document" | lp
+  cat wiki/Gregory_House.md | pr -h "Gregory Document" | lp
   ```
 * **Format and Print Query Results:**
   Run a query and print its tabular results:
@@ -357,7 +405,7 @@ Following the Unix philosophy of pipes and filters, `wiki` works seamlessly with
 #### Windows
 * **Print a Document:**
   ```powershell
-  Get-Content wiki/gregory.md | Out-Printer
+  Get-Content wiki/Gregory_House.md | Out-Printer
   ```
 * **Print Query Results:**
   ```powershell
@@ -429,11 +477,11 @@ An Engineer is a specialized subset of Person.
 
 Declare an instance somewhere else:
 ```yaml
-# wiki/gregory.md
+# wiki/Gregory_House.md
 ---
-id: wiki:gregory
+id: wiki:Gregory_House
 type: wiki:Engineer
-name: Gregory
+name: Gregory House
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Starter template repo: [github.com/wazootech/wiki-example](https://github.com/wa
 ## Key features
 - **Modern Packaging**: Configured cleanly with standard `pyproject.toml` optimized for `uv` or `pip`.
 - **Pure Python CLI**: Comprehensive command suite — `check`, `query`, `render`, `build`, `serve`, `export`.
+- **Terminal Document View**: Render a single wiki document as a readable terminal infobox with `wiki view`.
 - **Flexible Frontmatter Parsing**: Supports YAML and JSON frontmatter blocks with standard triple-dash `---` boundaries.
 - **RDF Context Support**: Supports JSON-LD `@context` style namespace, prefix mappings, and settings.
 - **Deductive Reasoning**: Full OWL-RL deductive reasoning expansion powered by `owlrl`.
@@ -269,6 +270,24 @@ sh:property:
     sh:datatype: xsd:string
     sh:maxCount: 1
 ```
+
+### `view`
+Render a single wiki document as a terminal-friendly infobox view.
+
+```bash
+# View a markdown page with infobox and body
+wiki view wiki/Gregory_Davidson.md
+
+# View a data-only record
+wiki view wiki/Bella_Davidson.yaml
+```
+
+`wiki view` reuses the same page typing and infobox resolution as `wiki build` and `wiki serve`:
+
+- template names are shown as file-style identifiers like `Person.html`
+- internal wiki references are displayed using the target page title
+- markdown pages include their body below the infobox
+- data-only pages show their title and infobox without a markdown body
 
 #### GitHub Pages deployment
 

--- a/docs/wiki/llm-wiki-cli.md
+++ b/docs/wiki/llm-wiki-cli.md
@@ -16,7 +16,7 @@ The LLM Wiki CLI is the primary companion tool for authoring, validating, and qu
 This section covers common editing, auditing, and publishing procedures for contributing to the semantic knowledge vault.
 
 ### Create a new page
-Create a new markdown file in the `wiki/` directory with standard frontmatter. Use lowercase kebab-case for the filename (e.g., `my-new-article.md`).
+Create a new markdown file in the `wiki/` directory with standard frontmatter. By default, use Wikipedia-style filenames with preserved capitalization and underscores (e.g., `My_New_Article.md`).
 
 ### Fill in the semantic metadata
 Always specify what fields are required for your document type. For example, if your page describes a person:

--- a/docs/wiki/llm-wiki-cli.md
+++ b/docs/wiki/llm-wiki-cli.md
@@ -63,9 +63,7 @@ SELECT ?document ?type WHERE {
 ORDER BY ?type
 ```
 
-| Document | Type |
-| --- | --- |
-| wiki:microdata-example | https://schema.org/TechArticle |
+(no results)
 <!-- sparql:end -->
 
 ### `Person` shape

--- a/docs/wiki/llm-wiki-cli.md
+++ b/docs/wiki/llm-wiki-cli.md
@@ -8,7 +8,7 @@ description: Command-line interface for querying, validating, and managing the s
 
 # LLM Wiki CLI
 
-The LLM Wiki CLI is the primary companion tool for authoring, validating, and querying this semantic knowledge vault. It parses markdown files, converts YAML/JSON frontmatter into RDF graphs, resolves blank nodes, and performs deductive reasoning under OWL-RL semantics.
+The LLM Wiki CLI is the primary companion tool for authoring, validating, and querying this semantic knowledge vault. It parses markdown files, converts YAML/JSON frontmatter into RDF graphs, and performs deductive reasoning under OWL-RL semantics.
 
 
 ## Wiki workflows and authoring guide

--- a/docs/wiki/personal-knowledge.md
+++ b/docs/wiki/personal-knowledge.md
@@ -63,7 +63,7 @@ ORDER BY ?name
 | [[javascript]] | JavaScript |
 | [[llm-wiki]] | LLM Wiki |
 | [[microdata]] | Microdata |
-| [[microdata-example]] | Microdata in LLM Wiki |
+| https://wazootech.github.io/wiki/wiki/microdata-example | Microdata in LLM Wiki |
 | [[notation3]] | Notation3 |
 | [[owl]] | OWL |
 | https://schema.org/PersonShapeDefinition | Person Shape |

--- a/docs/wiki/personal-knowledge.md
+++ b/docs/wiki/personal-knowledge.md
@@ -63,7 +63,7 @@ ORDER BY ?name
 | [[javascript]] | JavaScript |
 | [[llm-wiki]] | LLM Wiki |
 | [[microdata]] | Microdata |
-| wiki:microdata-example | Microdata in LLM Wiki |
+| [[microdata-example]] | Microdata in LLM Wiki |
 | [[notation3]] | Notation3 |
 | [[owl]] | OWL |
 | https://schema.org/PersonShapeDefinition | Person Shape |

--- a/docs/wiki/shacl.md
+++ b/docs/wiki/shacl.md
@@ -49,3 +49,35 @@ schema:ProjectShape a sh:NodeShape ;
 
 When you run `wiki check`, any page with `type: Project` is automatically validated against these constraints!
 
+## Constraining page templates
+
+Page rendering can be driven from frontmatter using `wiki:template`. Because that property is part of the graph, you can validate its usage with SHACL like any other predicate.
+
+Example: allow at most one template value on a `schema:Person` page.
+
+```yaml
+id: wiki:PersonShape
+type: sh:NodeShape
+sh:targetClass: schema:Person
+sh:property:
+  - sh:path: schema:name
+    sh:datatype: xsd:string
+    sh:minCount: 1
+  - sh:path: wiki:template
+    sh:datatype: xsd:string
+    sh:maxCount: 1
+    sh:message: Person pages can declare at most one wiki:template.
+```
+
+This works well with typed HTML rendering:
+
+```yaml
+id: wiki:Gregory_House
+type: schema:Person
+name: Gregory House
+wiki:template: person
+spouse: wiki:Bella_Davidson
+```
+
+The builder uses `wiki:template` to select the page layout, while `wiki check` can enforce its cardinality.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wazootech-wiki"
-version = "0.1.4"
+version = "0.1.5"
 description = "Clean, pure, idiomatic Python CLI for managing a semantic LLM wiki"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "owlrl>=6.0.2",
     "beautifulsoup4>=4.14.3",
     "markdown-it-py>=3.0.0",
+    "rich>=13.7.0",
 ]
 
 [project.scripts]

--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/src/wiki/audit.py
+++ b/src/wiki/audit.py
@@ -17,12 +17,13 @@ from .links import is_external_link, markdown_link_is_page, resolve_page_route, 
 from .paths import (
     build_page_manifest,
     detect_output_collisions,
+    iter_document_files,
     iter_markdown_files,
-    route_for_markdown_file,
+    route_for_document_file,
     validate_filename_pattern,
     validate_route_safety,
 )
-from .parser import frontmatter_from_path, split_frontmatter_body
+from .parser import document_data_from_path
 from .graph import frontmatter_to_graph, load_graph
 
 logger = logging.getLogger(__name__)
@@ -34,9 +35,9 @@ WIKILINK_REGEX = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
 MARKDOWN_LINK_REGEX = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 
 
-def file_slug_for_path(config: WikiConfig, md_file: Path) -> str:
-    """Return nested slug for a markdown file relative to an input dir."""
-    return route_for_markdown_file(config, md_file)
+def file_slug_for_path(config: WikiConfig, file_path: Path) -> str:
+    """Return nested slug for a document file relative to an input dir."""
+    return route_for_document_file(config, file_path)
 
 
 def load_shapes(data_graph: Graph) -> Graph:
@@ -95,17 +96,17 @@ def load_shapes(data_graph: Graph) -> Graph:
 
 
 def check_shacl_file(file_path: Path, context: WikiConfig, verbose: bool = False) -> Optional[tuple[bool, str]]:
-    """Validate a single markdown file's frontmatter against loaded shapes.
+    """Validate a single document file's metadata against loaded shapes.
 
-    Returns None if no frontmatter is found, otherwise returns (conforms, results_text).
+    Returns None if no document metadata is found, otherwise returns (conforms, results_text).
     """
-    data = frontmatter_from_path(file_path)
+    data = document_data_from_path(file_path)
     if not data:
         return None
 
     source_graph = load_graph(context, infer=False) # Minimizing overhead for single file check, but loading pool shapes
     shapes_graph = load_shapes(source_graph)
-    data_graph = frontmatter_to_graph(data, context, file_id=file_path.stem)
+    data_graph = frontmatter_to_graph(data, context, file_id=file_slug_for_path(context, file_path))
 
     conforms, _, results_text = pyshacl.validate(
         data_graph,
@@ -142,11 +143,11 @@ def audit_filenames(config: WikiConfig, file_filter: set[str] | None = None) -> 
     Returns a list of warnings.
     """
     warnings = []
-    for md_file in iter_markdown_files(config):
-        slug = file_slug_for_path(config, md_file)
+    for file_path in iter_document_files(config):
+        slug = file_slug_for_path(config, file_path)
         if file_filter is not None and slug not in file_filter:
             continue
-        issue = validate_filename_pattern(config, md_file)
+        issue = validate_filename_pattern(config, file_path)
         if issue:
             warnings.append(issue)
     return warnings
@@ -163,43 +164,47 @@ def audit_internal_links(config: WikiConfig, file_filter: set[str] | None = None
 
     existing_files: set[str] = set()
     heading_ids_by_route: dict[str, set[str]] = {}
-    for md_file in iter_markdown_files(config):
-        route = file_slug_for_path(config, md_file)
+    for file_path in iter_document_files(config):
+        route = file_slug_for_path(config, file_path)
         existing_files.add(route)
-        heading_ids_by_route[route] = _heading_ids(md_file.read_text(encoding="utf-8"))
+        if file_path.suffix.lower() == ".md":
+            heading_ids_by_route[route] = _heading_ids(file_path.read_text(encoding="utf-8"))
+        else:
+            heading_ids_by_route[route] = set()
 
-    for md_file in iter_markdown_files(config):
-        md_slug = file_slug_for_path(config, md_file)
-        if file_filter is not None and md_slug not in file_filter:
+    for file_path in iter_document_files(config):
+        file_slug = file_slug_for_path(config, file_path)
+        if file_filter is not None and file_slug not in file_filter:
             continue
         try:
-            content = md_file.read_text(encoding="utf-8")
-            
-            if config.markdown_flavor == "obsidian":
+            data = document_data_from_path(file_path)
+
+            if file_path.suffix.lower() == ".md" and config.markdown_flavor == "obsidian":
+                content = file_path.read_text(encoding="utf-8")
                 wikilinks = WIKILINK_REGEX.findall(content)
                 for link in wikilinks:
-                    _audit_page_target(warnings, existing_files, heading_ids_by_route, md_slug, link, "WikiLink")
-            
-            # 2. Audit standard Markdown links
-            md_links = MARKDOWN_LINK_REGEX.findall(content)
-            for target in md_links:
-                target = unquote(target.split("?")[0])
-                if is_external_link(target):
-                    continue
-                if markdown_link_is_page(target):
-                    _audit_page_target(warnings, existing_files, heading_ids_by_route, md_slug, target, "Markdown link")
-                else:
-                    issue = asset_reference_issue(config, md_file, target)
-                    if issue:
-                        warnings.append(f"In {md_slug}.md: Broken asset link [{target}] {issue}.")
+                    _audit_page_target(warnings, existing_files, heading_ids_by_route, file_slug, link, "WikiLink")
 
-            fm_data, _ = split_frontmatter_body(content)
-            for target in _frontmatter_asset_targets(fm_data or {}):
-                issue = asset_reference_issue(config, md_file, target)
+            if file_path.suffix.lower() == ".md":
+                content = file_path.read_text(encoding="utf-8")
+                md_links = MARKDOWN_LINK_REGEX.findall(content)
+                for target in md_links:
+                    target = unquote(target.split("?")[0])
+                    if is_external_link(target):
+                        continue
+                    if markdown_link_is_page(target):
+                        _audit_page_target(warnings, existing_files, heading_ids_by_route, file_slug, target, "Markdown link")
+                    else:
+                        issue = asset_reference_issue(config, file_path, target)
+                        if issue:
+                            warnings.append(f"In {file_path.name}: Broken asset link [{target}] {issue}.")
+
+            for target in _frontmatter_asset_targets(data or {}):
+                issue = asset_reference_issue(config, file_path, target)
                 if issue:
-                    warnings.append(f"In {md_slug}.md: Broken frontmatter asset [{target}] {issue}.")
+                    warnings.append(f"In {file_path.name}: Broken frontmatter asset [{target}] {issue}.")
         except Exception as e:
-            warnings.append(f"Failed to read {md_slug}.md for link audit: {e}")
+            warnings.append(f"Failed to read {file_path.name} for link audit: {e}")
 
     warnings.extend(audit_asset_dirs(config))
     return warnings
@@ -238,12 +243,12 @@ def _audit_page_target(
     page_part, fragment = split_target(target)
     route = current_route if page_part == "" else resolve_page_route(current_route, target)
     if route is None or route not in existing_files:
-        warnings.append(f"In {current_route}.md: Broken {label} [{target}] points to non-existent document.")
+        warnings.append(f"In {current_route}: Broken {label} [{target}] points to non-existent document.")
         return
     if fragment:
         target_fragment = fragment_id(fragment)
         if target_fragment not in heading_ids_by_route.get(route, set()):
-            warnings.append(f"In {current_route}.md: Broken {label} [{target}] points to missing heading '#{target_fragment}'.")
+            warnings.append(f"In {current_route}: Broken {label} [{target}] points to missing heading '#{target_fragment}'.")
 
 
 def _frontmatter_asset_targets(data: dict[str, Any]) -> list[str]:

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -214,6 +214,26 @@ def render(context: Context, file: Optional[Path], glob_filters: tuple[str, ...]
 
 
 @main.command()
+@click.argument("file", required=True, type=click.Path(exists=True, path_type=Path))
+@click.pass_obj
+def view(config: Context, file: Path) -> None:
+    """Render a single wiki document as a terminal-friendly infobox view."""
+    if file.suffix.lower() not in {".md", ".yaml", ".yml", ".json"}:
+        click.echo(f"Error: view only supports wiki document files, got {file.name}.", err=True)
+        sys.exit(1)
+
+    from .view import render_document_view
+
+    try:
+        output = render_document_view(file, config, base_url=config.base_url, url_style=config.url_style)
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(output, nl=False)
+
+
+@main.command()
 @click.option("--output-dir", default="_site", show_default=True,
               type=click.Path(path_type=Path), help="Directory to write site files.")
 @click.option("--base-url", default=None,

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -384,14 +384,16 @@ def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_f
 @click.option("--port", default=8080, type=int, show_default=True, help="Port to serve on.")
 @click.option("--base-url", default=None,
               help="URL prefix for wiki pages. Empty string for root-level URLs.")
+@click.option("--style", default="dir", show_default=True,
+              type=click.Choice(["file", "dir"]), help="URL style: <slug>.html (file) or <slug>/ (dir).")
 @click.option("--watch", is_flag=True, help="Watch files and auto-reload the browser on rebuild.")
 @click.pass_obj
-def serve(config: Context, host: str, port: int, base_url: str | None, watch: bool) -> None:
+def serve(config: Context, host: str, port: int, base_url: str | None, style: str, watch: bool) -> None:
     """Start a local HTTP server for browsing the wiki."""
     from .serve import run_server
     resolved_base_url = (config.base_url if base_url is None else base_url).rstrip("/")
     config.base_url = resolved_base_url
-    run_server(config, host=host, port=port, base_url=resolved_base_url, watch=watch)
+    run_server(config, host=host, port=port, base_url=resolved_base_url, url_style=style, watch=watch)
 
 
 @main.command()

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -13,11 +13,12 @@ import click
 from .config import WikiConfig as Context
 from .format import run_query, process_rdf_format
 from .render import render_markdown_files
-from .parser import frontmatter_from_path
+from .parser import document_data_from_path
 from .graph import load_graph, graph_stats
 from .audit import check_shacl_file, run_checks
 from .jqfilter import resolve_path
 from .format_choice import FormatChoice
+from .paths import iter_document_files
 
 
 @click.group()
@@ -92,7 +93,7 @@ def check(config: Context, file: Optional[Path], fix: bool, verbose: bool, stric
         warnings = []
 
         if res is None:
-            errors.append(f"No frontmatter found in {file.name}")
+            errors.append(f"No valid document metadata found in {file.name}")
             conforms = False
         else:
             shacl_conforms, shacl_text = res
@@ -174,14 +175,26 @@ def query(context: Context, query_args: tuple[str, ...], output_format: str, out
 
 
 @main.command()
+@click.argument("file", required=False, type=click.Path(exists=True, path_type=Path))
+@click.option("--glob", "glob_filters", multiple=True, help="Render only markdown files matching this glob. Repeatable.")
 @click.option("--no-inference", is_flag=True, help="Skip OWL-RL inference.")
 @click.option("--check", is_flag=True, help="Check if inline SPARQL blocks are up to date without modifying files. Exits with non-zero code if any are stale.")
 @click.option("-v", "--verbose", is_flag=True, help="Print summary of updated files.")
 @click.pass_obj
-def render(context: Context, no_inference: bool, check: bool, verbose: bool) -> None:
+def render(context: Context, file: Optional[Path], glob_filters: tuple[str, ...], no_inference: bool, check: bool, verbose: bool) -> None:
     """Render inline SPARQL blocks in markdown files."""
+    if file is not None and file.suffix.lower() != ".md":
+        click.echo(f"Error: render only supports markdown files, got {file.name}.", err=True)
+        sys.exit(1)
+
     graph = load_graph(context, infer=not no_inference)
-    success_count, error_count, stale_files = render_markdown_files(context, graph, dry_run=check)
+    success_count, error_count, stale_files = render_markdown_files(
+        context,
+        graph,
+        dry_run=check,
+        file_filter=file,
+        glob_filters=glob_filters,
+    )
     
     if check:
         if stale_files:
@@ -212,7 +225,7 @@ def render(context: Context, no_inference: bool, check: bool, verbose: bool) -> 
 @click.option("-v", "--verbose", is_flag=True, help="Print generated file paths.")
 @click.pass_obj
 def build(config: Context, output_dir: Path, base_url: str | None, url_style: str | None, render: bool, no_check: bool, verbose: bool) -> None:
-    """Build static HTML site from wiki markdown files."""
+    """Build static HTML site from wiki documents."""
     from .assets import build_asset_manifest
     from .site import build_site, build_index_html, build_page_html
 
@@ -304,9 +317,9 @@ def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_f
     result_payload: Any = None
 
     if file:
-        data = frontmatter_from_path(file, content_predicate=context.content_predicate)
+        data = document_data_from_path(file, content_predicate=context.content_predicate)
         if data is None:
-            click.echo(f"No valid frontmatter block found in {file.name}", err=True)
+            click.echo(f"No valid document metadata found in {file.name}", err=True)
             sys.exit(1)
 
         processed_rdf = process_rdf_format(data, file.stem, context, rdf_format)
@@ -317,16 +330,14 @@ def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_f
     else:
         converted_list = []
         from .audit import file_slug_for_path
-        for input_dir in context.input_dirs:
-            if input_dir.exists():
-                for md_file in sorted(input_dir.rglob("*.md")):
-                    data = frontmatter_from_path(md_file, content_predicate=context.content_predicate)
-                    if data:
-                        processed_rdf = process_rdf_format(data, file_slug_for_path(context, md_file), context, rdf_format)
-                        converted_list.append({
-                            "name": md_file.name,
-                            "rdf": processed_rdf
-                        })
+        for file_path in iter_document_files(context):
+            data = document_data_from_path(file_path, content_predicate=context.content_predicate)
+            if data:
+                processed_rdf = process_rdf_format(data, file_slug_for_path(context, file_path), context, rdf_format)
+                converted_list.append({
+                    "name": file_path.name,
+                    "rdf": processed_rdf
+                })
         result_payload = converted_list
 
     # Standard serialization formats (non-JSON wrappers) get raw RDF output
@@ -418,18 +429,21 @@ def init(force: bool) -> None:
         "Welcome to your wiki.\n",
         encoding="utf-8",
     )
-    (wiki_dir / "person-shape.md").write_text(
+    (wiki_dir / "Person_Shape.md").write_text(
         "---\n"
         "id: wiki:PersonShape\n"
         "type: sh:NodeShape\n"
         "sh:targetClass: schema:Person\n"
         "sh:property:\n"
-        "  sh:path: schema:name\n"
-        "  sh:datatype: xsd:string\n"
-        "  sh:minCount: 1\n"
+        "  - sh:path: schema:name\n"
+        "    sh:datatype: xsd:string\n"
+        "    sh:minCount: 1\n"
+        "  - sh:path: wiki:template\n"
+        "    sh:datatype: xsd:string\n"
+        "    sh:maxCount: 1\n"
         "---\n\n"
         "# Person shape\n\n"
-        "A minimal starter SHACL shape.\n",
+        "A minimal starter SHACL shape, including optional wiki:template cardinality.\n",
         encoding="utf-8",
     )
 

--- a/src/wiki/format.py
+++ b/src/wiki/format.py
@@ -6,7 +6,7 @@ import json
 from typing import Any
 
 
-def _wiki_link(s: str, wiki_base: str) -> str:
+def _wiki_link(s: str, wiki_base: str, known_slugs: set[str] | None = None) -> str:
     """Convert a wiki URI to a [[slug]] wikilink if applicable."""
     if not (wiki_base and s.startswith(wiki_base)):
         return s
@@ -14,6 +14,8 @@ def _wiki_link(s: str, wiki_base: str) -> str:
     if slug.endswith(".md"):
         slug = slug[:-3]
     if "/" not in slug:
+        if known_slugs is not None and slug not in known_slugs:
+            return s
         return f"[[{slug}]]"
     return s
 
@@ -67,7 +69,7 @@ def table_format(result: Any) -> str:
     return "\n".join(lines)
 
 
-def markdown_format(result: Any, wiki_base: str | None = None) -> str:
+def markdown_format(result: Any, wiki_base: str | None = None, known_slugs: set[str] | None = None) -> str:
     """Format SPARQL SELECT results as a GitHub Flavored Markdown table, rendering wiki links when applicable."""
     rows = list(result)
     if not rows:
@@ -97,17 +99,17 @@ def markdown_format(result: Any, wiki_base: str | None = None) -> str:
     lines = [header_line, divider_line]
     for row in rows:
         if isinstance(row, tuple):
-            vals = [_wiki_link(str(v), wiki_base) if v is not None else ""
+            vals = [_wiki_link(str(v), wiki_base, known_slugs) if v is not None else ""
                     for v in row]
         else:
-            vals = [_wiki_link(str(row.get(k)), wiki_base) if row.get(k) is not None else ""
+            vals = [_wiki_link(str(row.get(k)), wiki_base, known_slugs) if row.get(k) is not None else ""
                     for k in keys]
         lines.append("| " + " | ".join(vals) + " |")
 
     return "\n".join(lines)
 
 
-def run_query(graph: Any, query: str, output_format: str = "table", wiki_base: str | None = None) -> str:
+def run_query(graph: Any, query: str, output_format: str = "table", wiki_base: str | None = None, known_slugs: set[str] | None = None) -> str:
     """Run a SPARQL SELECT or CONSTRUCT query against the graph, returning formatted output."""
     q = query.strip().upper()
     is_construct = q.startswith("CONSTRUCT") or q.startswith("DESCRIBE")
@@ -135,7 +137,7 @@ def run_query(graph: Any, query: str, output_format: str = "table", wiki_base: s
             lines.append("\t".join(vals))
         return "\n".join(lines)
     elif output_format in ("markdown", "md"):
-        return markdown_format(result, wiki_base=wiki_base)
+        return markdown_format(result, wiki_base=wiki_base, known_slugs=known_slugs)
     else:
         return table_format(result)
 

--- a/src/wiki/graph.py
+++ b/src/wiki/graph.py
@@ -155,62 +155,7 @@ def frontmatter_to_graph(data: dict[str, Any], context: Context, file_id: Option
     return graph
 
 
-def build_person_name_map(input_dirs: list[Path], context: Context, uri_ext: bool = False) -> dict[str, str]:
-    """Build a mapping from person names to their wiki @id URIs."""
-    name_map: dict[str, str] = {}
 
-    config = WikiConfig(input_dirs=input_dirs, wiki_base=context.wiki_base, context=context, uri_ext=uri_ext)
-
-    for file_path in iter_document_files(config):
-        try:
-            data = document_data_from_path(file_path)
-            if not data or data.get("@type") != "Person":
-                continue
-
-            doc_id = data.get("@id", "")
-            if not doc_id:
-                suffix = ".md" if uri_ext else ""
-                doc_id = f"{context.wiki_base}{route_for_document_file(config, file_path)}{suffix}"
-
-            name = data.get("name", "")
-            if name:
-                name_map[name.lower()] = doc_id
-
-            given = data.get("givenName", "")
-            family = data.get("familyName", "")
-            if given and family:
-                full_name = f"{given} {family}"
-                name_map[full_name.lower()] = doc_id
-                name_map[given.lower()] = doc_id
-        except Exception as e:
-            logger.warning("Failed to build name map for %s: %s", file_path.name, e)
-            continue
-
-    return name_map
-
-
-def resolve_blank_nodes(graph: Graph, input_dirs: list[Path], context: Context, uri_ext: bool = False) -> Graph:
-    """Resolve blank nodes to @id references where possible."""
-    name_map = build_person_name_map(input_dirs, context, uri_ext=uri_ext)
-
-    blank_nodes = [s for s in graph.subjects() if str(s).startswith("_:")]
-
-    for blank in blank_nodes:
-        name = graph.value(blank, context.namespaces["schema"].name)
-        if not name or str(name).lower() not in name_map:
-            continue
-
-        target_id = name_map[str(name).lower()]
-
-        for pred, obj in list(graph.predicate_objects(blank)):
-            graph.remove((blank, pred, obj))
-            graph.add((URIRef(target_id), pred, obj))
-
-        for subj, pred in list(graph.subject_predicates(blank)):
-            graph.remove((subj, pred, blank))
-            graph.add((subj, pred, URIRef(target_id)))
-
-    return graph
 
 
 
@@ -413,8 +358,6 @@ def load_graph(context: WikiConfig, infer: bool = True) -> Graph:
                         graph.parse(file_path, format=fmt)
             except Exception as e:
                 logger.warning("Failed to process %s: %s", file_path.name, e)
-
-    resolve_blank_nodes(graph, context.input_dirs, context, uri_ext=context.uri_ext)
 
     if infer:
         from .infer import apply_inference

--- a/src/wiki/graph.py
+++ b/src/wiki/graph.py
@@ -13,9 +13,11 @@ from rdflib.parser import InputSource, Parser, StringInputSource
 from rdflib.plugin import register
 
 from .config import Context, WikiConfig
-from .parser import frontmatter_from_path
+from .parser import document_data_from_path
+from .paths import iter_document_files, route_for_document_file
 
 logger = logging.getLogger(__name__)
+DEFAULT_MICRODATA_VOCAB = "https://schema.org/"
 
 
 def kebab_case(s: str) -> str:
@@ -31,14 +33,14 @@ def _slugify_path(p: Path) -> str:
     return p.with_suffix("").as_posix().strip("/").lower()
 
 
-def _file_slug(md_file: Path, input_dirs: list[Path]) -> str:
+def _file_slug(file_path: Path, input_dirs: list[Path]) -> str:
     for root in input_dirs:
         try:
-            rel = md_file.relative_to(root)
+            rel = file_path.relative_to(root)
             return _slugify_path(rel)
         except ValueError:
             continue
-    return _slugify_path(md_file)
+    return _slugify_path(file_path)
 
 
 def resolve_predicate(key: str, context: Context) -> URIRef:
@@ -157,33 +159,32 @@ def build_person_name_map(input_dirs: list[Path], context: Context, uri_ext: boo
     """Build a mapping from person names to their wiki @id URIs."""
     name_map: dict[str, str] = {}
 
-    for input_dir in input_dirs:
-        if not input_dir.exists():
-            continue
-        for md_file in input_dir.rglob("*.md"):
-            try:
-                data = frontmatter_from_path(md_file)
-                if not data or data.get("@type") != "Person":
-                    continue
+    config = WikiConfig(input_dirs=input_dirs, wiki_base=context.wiki_base, context=context, uri_ext=uri_ext)
 
-                doc_id = data.get("@id", "")
-                if not doc_id:
-                    suffix = ".md" if uri_ext else ""
-                    doc_id = f"{context.wiki_base}{_file_slug(md_file, input_dirs)}{suffix}"
-
-                name = data.get("name", "")
-                if name:
-                    name_map[name.lower()] = doc_id
-
-                given = data.get("givenName", "")
-                family = data.get("familyName", "")
-                if given and family:
-                    full_name = f"{given} {family}"
-                    name_map[full_name.lower()] = doc_id
-                    name_map[given.lower()] = doc_id
-            except Exception as e:
-                logger.warning("Failed to build name map for %s: %s", md_file.name, e)
+    for file_path in iter_document_files(config):
+        try:
+            data = document_data_from_path(file_path)
+            if not data or data.get("@type") != "Person":
                 continue
+
+            doc_id = data.get("@id", "")
+            if not doc_id:
+                suffix = ".md" if uri_ext else ""
+                doc_id = f"{context.wiki_base}{route_for_document_file(config, file_path)}{suffix}"
+
+            name = data.get("name", "")
+            if name:
+                name_map[name.lower()] = doc_id
+
+            given = data.get("givenName", "")
+            family = data.get("familyName", "")
+            if given and family:
+                full_name = f"{given} {family}"
+                name_map[full_name.lower()] = doc_id
+                name_map[given.lower()] = doc_id
+        except Exception as e:
+            logger.warning("Failed to build name map for %s: %s", file_path.name, e)
+            continue
 
     return name_map
 
@@ -244,14 +245,16 @@ class MicrodataParser(Parser):
             logger.warning("Failed to parse HTML: %s", e)
             return
 
+        namespace_map = {prefix: str(namespace) for prefix, namespace in graph.namespaces()}
+
         def process_scope(elem: Tag, parent_subject: Any = None, incoming_predicate: Any = None) -> None:
             if elem.has_attr("itemid"):
-                subject = URIRef(elem["itemid"])
+                subject = URIRef(_expand_microdata_identifier(str(elem["itemid"]), namespace_map))
             else:
                 subject = BNode()
             
             if elem.has_attr("itemtype"):
-                graph.add((subject, RDF.type, URIRef(elem["itemtype"])))
+                graph.add((subject, RDF.type, URIRef(_expand_microdata_identifier(str(elem["itemtype"]), namespace_map))))
                 
             if parent_subject and incoming_predicate:
                 graph.add((parent_subject, incoming_predicate, subject))
@@ -272,7 +275,7 @@ class MicrodataParser(Parser):
                 prop_names = str(prop_elem.get("itemprop", "")).split()
                 preds = []
                 for p in prop_names:
-                    preds.append(URIRef(p) if ":" in p else URIRef(f"https://schema.org/{p}"))
+                    preds.append(URIRef(_expand_microdata_predicate(p, namespace_map)))
                 
                 if prop_elem.has_attr("itemscope"):
                     for pred in preds:
@@ -306,35 +309,72 @@ class MicrodataParser(Parser):
             if not is_nested:
                 process_scope(s)
 
+
+def _expand_microdata_identifier(value: str, namespace_map: dict[str | None, str]) -> str:
+    value = value.strip()
+    if not value:
+        return value
+    if _is_absolute_iri(value):
+        return value
+    return _expand_bound_curie(value, namespace_map) or value
+
+
+def _expand_microdata_predicate(value: str, namespace_map: dict[str | None, str]) -> str:
+    value = value.strip()
+    if not value:
+        return value
+    if _is_absolute_iri(value):
+        return value
+    if ":" in value:
+        return _expand_bound_curie(value, namespace_map) or value
+    return f"{namespace_map.get('schema', DEFAULT_MICRODATA_VOCAB)}{value}"
+
+
+def _expand_bound_curie(value: str, namespace_map: dict[str | None, str]) -> str | None:
+    prefix, local = value.split(":", 1)
+    namespace = namespace_map.get(prefix)
+    if namespace is None:
+        return None
+    return f"{namespace}{local}"
+
+
+def _is_absolute_iri(value: str) -> bool:
+    lowered = value.lower()
+    return lowered.startswith(("http://", "https://", "urn:"))
+
 # Dynamically register our custom parser to unlock native `format="microdata"` support globally
 register("microdata", Parser, "wiki.graph", "MicrodataParser")
 
 
-def _process_md_file(graph: Graph, md_file: Path, context: WikiConfig) -> None:
-    """Parse a single markdown file into the graph: frontmatter, microdata, and turtle blocks."""
-    content = md_file.read_text(encoding="utf-8")
-
-    data = frontmatter_from_path(md_file)
+def _process_document_file(graph: Graph, file_path: Path, context: WikiConfig) -> None:
+    """Parse a supported wiki document into the graph."""
+    data = document_data_from_path(file_path)
     if data:
         body = None
-        if context.content_predicate:
+        if file_path.suffix.lower() == ".md" and context.content_predicate:
+            content = file_path.read_text(encoding="utf-8")
             parts = content.split("---", 2)
             if len(parts) > 2:
                 body = parts[2].strip()
-        file_id = _file_slug(md_file, context.input_dirs)
+        file_id = route_for_document_file(context, file_path)
         graph += frontmatter_to_graph(data, context, file_id=file_id, body=body, uri_ext=context.uri_ext)
+
+    if file_path.suffix.lower() != ".md":
+        return
+
+    content = file_path.read_text(encoding="utf-8")
 
     try:
         graph.parse(data=content, format="microdata")
     except Exception as e:
-        logger.warning("Failed to parse microdata in %s: %s", md_file.name, e)
+        logger.warning("Failed to parse microdata in %s: %s", file_path.name, e)
 
     turtle_blocks = re.findall(r"```turtle\s*([\s\S]*?)```", content)
     for block in turtle_blocks:
         try:
             graph.parse(data=block.strip(), format="turtle")
         except Exception as e:
-            logger.warning("Failed to parse turtle block in %s: %s", md_file.name, e)
+            logger.warning("Failed to parse turtle block in %s: %s", file_path.name, e)
 
 
 # Map file extensions to rdflib format names
@@ -356,17 +396,19 @@ def load_graph(context: WikiConfig, infer: bool = True) -> Graph:
     graph = Graph()
     context.bind_namespaces(graph)
 
+    document_files = set(iter_document_files(context))
+
     for input_dir in context.input_dirs:
         if not input_dir.exists():
             continue
         for file_path in sorted(input_dir.rglob("*")):
-            if not file_path.is_file():
+            if not file_path.is_file() or context.is_excluded(file_path):
                 continue
             try:
-                if file_path.suffix == ".md":
-                    _process_md_file(graph, file_path, context)
+                if file_path in document_files:
+                    _process_document_file(graph, file_path, context)
                 else:
-                    fmt = _EXT_FORMAT_MAP.get(file_path.suffix)
+                    fmt = _EXT_FORMAT_MAP.get(file_path.suffix.lower())
                     if fmt:
                         graph.parse(file_path, format=fmt)
             except Exception as e:

--- a/src/wiki/links.py
+++ b/src/wiki/links.py
@@ -11,6 +11,7 @@ from .paths import page_url
 
 
 EXTERNAL_SCHEMES = {"http", "https", "mailto", "tel"}
+PAGE_LINK_EXTENSIONS = {"", ".md", ".yaml", ".yml", ".json"}
 
 
 def is_external_link(target: str) -> bool:
@@ -34,8 +35,9 @@ def resolve_page_route(current_route: str, target: str) -> str | None:
     page_part = unquote(page_part).replace("\\", "/").strip()
     if page_part.startswith("/"):
         return None
-    if page_part.endswith(".md"):
-        page_part = page_part[:-3]
+    suffix = PurePosixPath(page_part).suffix.lower()
+    if suffix in {".md", ".yaml", ".yml", ".json"}:
+        page_part = page_part[: -len(suffix)]
     current_dir = posixpath.dirname(current_route)
     raw = page_part or "."
     combined = posixpath.normpath(posixpath.join(current_dir, raw))
@@ -66,4 +68,4 @@ def markdown_link_is_page(target: str) -> bool:
     if not page_part:
         return True
     suffix = PurePosixPath(page_part).suffix.lower()
-    return suffix in {"", ".md"}
+    return suffix in PAGE_LINK_EXTENSIONS

--- a/src/wiki/parser.py
+++ b/src/wiki/parser.py
@@ -1,4 +1,4 @@
-"""YAML and JSON frontmatter parsing, normalization, and JSON-LD conversion logic."""
+"""YAML and JSON frontmatter parsing, normalization, and document loading logic."""
 
 from __future__ import annotations
 
@@ -6,6 +6,10 @@ import json
 from pathlib import Path
 from typing import Any, Optional
 import yaml
+
+
+DOCUMENT_EXTENSIONS = {".md", ".yaml", ".yml", ".json"}
+DATA_DOCUMENT_EXTENSIONS = {".yaml", ".yml", ".json"}
 
 
 def parse_frontmatter(content: str) -> Optional[dict[str, Any]]:
@@ -52,6 +56,28 @@ def ensure_context(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def document_data_from_path(path: Path, content_predicate: Optional[str] = None) -> Optional[dict[str, Any]]:
+    """Read a supported wiki document file and return its parsed data dict with context."""
+    try:
+        suffix = path.suffix.lower()
+        if suffix == ".md":
+            return frontmatter_from_path(path, content_predicate=content_predicate)
+
+        content = path.read_text(encoding="utf-8")
+        if suffix == ".json":
+            data = json.loads(content)
+        elif suffix in DATA_DOCUMENT_EXTENSIONS:
+            data = yaml.safe_load(content)
+        else:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+        return ensure_context(data)
+    except Exception:
+        return None
+
+
 def frontmatter_from_path(path: Path, content_predicate: Optional[str] = None) -> Optional[dict[str, Any]]:
     """Read a markdown file and return its parsed frontmatter dict with context.
     
@@ -89,3 +115,16 @@ def split_frontmatter_body(content: str) -> tuple[Optional[dict[str, Any]], str]
     parts = content.split("---", 2)
     body = parts[2].strip() if len(parts) > 2 else ""
     return data, body
+
+
+def split_document_body(path: Path) -> tuple[Optional[dict[str, Any]], str]:
+    """Split a supported wiki document into (data, body_text)."""
+    suffix = path.suffix.lower()
+    if suffix == ".md":
+        try:
+            return split_frontmatter_body(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None, ""
+
+    data = document_data_from_path(path)
+    return data, ""

--- a/src/wiki/paths.py
+++ b/src/wiki/paths.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from urllib.parse import quote
 
 from .config import WikiConfig
+from .parser import DOCUMENT_EXTENSIONS
 
 
 UNSAFE_ROUTE_CHARS = set("?#%")
@@ -27,27 +28,37 @@ class OutputEntry:
     kind: str
 
 
-def iter_markdown_files(config: WikiConfig) -> list[Path]:
-    md_files: list[Path] = []
+def iter_document_files(config: WikiConfig) -> list[Path]:
+    doc_files: list[Path] = []
     for input_dir in config.input_dirs:
         if input_dir.exists():
-            for md_file in sorted(input_dir.rglob("*.md")):
-                if not config.is_excluded(md_file):
-                    md_files.append(md_file)
-    return md_files
+            for file_path in sorted(input_dir.rglob("*")):
+                if not file_path.is_file() or file_path.suffix.lower() not in DOCUMENT_EXTENSIONS:
+                    continue
+                if not config.is_excluded(file_path):
+                    doc_files.append(file_path)
+    return doc_files
 
 
-def route_for_markdown_file(config: WikiConfig, md_file: Path) -> str:
-    rel = _relative_to_input_dir(config, md_file).with_suffix("").as_posix()
+def iter_markdown_files(config: WikiConfig) -> list[Path]:
+    return [file_path for file_path in iter_document_files(config) if file_path.suffix.lower() == ".md"]
+
+
+def route_for_document_file(config: WikiConfig, file_path: Path) -> str:
+    rel = _relative_to_input_dir(config, file_path).with_suffix("").as_posix()
     parts = [part for part in rel.split("/") if part]
     if parts and parts[-1] == "index":
         parts = parts[:-1]
-    _validate_route_parts(parts, md_file)
+    _validate_route_parts(parts, file_path)
     return "/".join(parts)
 
 
+def route_for_markdown_file(config: WikiConfig, md_file: Path) -> str:
+    return route_for_document_file(config, md_file)
+
+
 def page_routes(config: WikiConfig) -> list[PageRoute]:
-    return [PageRoute(source=md_file, route=route_for_markdown_file(config, md_file)) for md_file in iter_markdown_files(config)]
+    return [PageRoute(source=file_path, route=route_for_document_file(config, file_path)) for file_path in iter_document_files(config)]
 
 
 def page_url(base_url: str, route: str, url_style: str) -> str:
@@ -119,9 +130,9 @@ def validate_filename_pattern(config: WikiConfig, md_file: Path) -> str | None:
 
 def validate_route_safety(config: WikiConfig) -> list[str]:
     issues: list[str] = []
-    for md_file in iter_markdown_files(config):
+    for file_path in iter_document_files(config):
         try:
-            route_for_markdown_file(config, md_file)
+            route_for_document_file(config, file_path)
         except ValueError as exc:
             issues.append(str(exc))
     return issues

--- a/src/wiki/render.py
+++ b/src/wiki/render.py
@@ -12,7 +12,7 @@ from markdown_it import MarkdownIt
 
 from .format import run_query
 from mdit_py_plugins.wikilink import wikilink_plugin
-from .paths import iter_markdown_files, route_for_markdown_file
+from .paths import iter_markdown_files, page_routes, route_for_markdown_file
 
 # Matches the starting comment, query inside, and ending comment block with SPARQL inside
 SPARQL_BLOCK_REGEX = re.compile(
@@ -37,6 +37,8 @@ def render_markdown_files(
     stale_files = []
     markdown_files = _select_markdown_files(context, file_filter=file_filter, glob_filters=glob_filters)
 
+    known_slugs = {pr.route for pr in page_routes(context)}
+
     for md_file in markdown_files:
         content = md_file.read_text(encoding="utf-8")
         modified = False
@@ -46,7 +48,7 @@ def render_markdown_files(
             nonlocal modified, file_errors
             query = match.group(1).strip()
             try:
-                rendered_markdown = run_query(graph, query, output_format="markdown", wiki_base=context.wiki_base)
+                rendered_markdown = run_query(graph, query, output_format="markdown", wiki_base=context.wiki_base, known_slugs=known_slugs)
                 modified = True
                 return f"<!-- sparql:start -->\n```sparql\n{query}\n```\n\n{rendered_markdown}\n<!-- sparql:end -->"
             except Exception as e:

--- a/src/wiki/render.py
+++ b/src/wiki/render.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import fnmatch
+from pathlib import Path
 import re
 from typing import Any
 
@@ -10,6 +12,7 @@ from markdown_it import MarkdownIt
 
 from .format import run_query
 from mdit_py_plugins.wikilink import wikilink_plugin
+from .paths import iter_markdown_files, route_for_markdown_file
 
 # Matches the starting comment, query inside, and ending comment block with SPARQL inside
 SPARQL_BLOCK_REGEX = re.compile(
@@ -18,50 +21,81 @@ SPARQL_BLOCK_REGEX = re.compile(
 )
 
 
-def render_markdown_files(context: Any, graph: Any, dry_run: bool = False) -> tuple[int, int, list[str]]:
+def render_markdown_files(
+    context: Any,
+    graph: Any,
+    dry_run: bool = False,
+    file_filter: Path | None = None,
+    glob_filters: tuple[str, ...] = (),
+) -> tuple[int, int, list[str]]:
     """Iterate over all markdown files, parse and replace dynamic SPARQL sections inline.
 
     Returns (success_count, error_count, stale_files).
     """
-    from pathlib import Path
     success_count = 0
     error_count = 0
     stale_files = []
+    markdown_files = _select_markdown_files(context, file_filter=file_filter, glob_filters=glob_filters)
 
-    for input_dir in context.input_dirs:
-        if not input_dir.exists():
-            continue
-        for md_file in input_dir.rglob("*.md"):
-            content = md_file.read_text(encoding="utf-8")
-            modified = False
-            file_errors = 0
+    for md_file in markdown_files:
+        content = md_file.read_text(encoding="utf-8")
+        modified = False
+        file_errors = 0
 
-            def replacer(match: re.Match) -> str:
-                nonlocal modified, file_errors
-                query = match.group(1).strip()
-                try:
-                    rendered_markdown = run_query(graph, query, output_format="markdown", wiki_base=context.wiki_base)
-                    modified = True
-                    return f"<!-- sparql:start -->\n```sparql\n{query}\n```\n\n{rendered_markdown}\n<!-- sparql:end -->"
-                except Exception as e:
-                    click.echo(f"Error rendering query in {md_file.name}: {e}", err=True)
-                    file_errors += 1
-                    return str(match.group(0))
+        def replacer(match: re.Match) -> str:
+            nonlocal modified, file_errors
+            query = match.group(1).strip()
+            try:
+                rendered_markdown = run_query(graph, query, output_format="markdown", wiki_base=context.wiki_base)
+                modified = True
+                return f"<!-- sparql:start -->\n```sparql\n{query}\n```\n\n{rendered_markdown}\n<!-- sparql:end -->"
+            except Exception as e:
+                click.echo(f"Error rendering query in {md_file.name}: {e}", err=True)
+                file_errors += 1
+                return str(match.group(0))
 
-            new_content = SPARQL_BLOCK_REGEX.sub(replacer, content)
-            if modified and new_content != content:
-                try:
-                    rel = str(md_file.relative_to(Path.cwd()))
-                except ValueError:
-                    rel = str(md_file)
-                stale_files.append(rel)
-                
-                if not dry_run:
-                    md_file.write_text(new_content, encoding="utf-8")
-                    success_count += 1
-            error_count += file_errors
+        new_content = SPARQL_BLOCK_REGEX.sub(replacer, content)
+        if modified and new_content != content:
+            try:
+                rel = str(md_file.relative_to(Path.cwd()))
+            except ValueError:
+                rel = str(md_file)
+            stale_files.append(rel)
+
+            if not dry_run:
+                md_file.write_text(new_content, encoding="utf-8")
+                success_count += 1
+        error_count += file_errors
 
     return (success_count, error_count, stale_files)
+
+
+def _select_markdown_files(context: Any, file_filter: Path | None, glob_filters: tuple[str, ...]) -> list[Path]:
+    markdown_files = iter_markdown_files(context)
+    if file_filter is None and not glob_filters:
+        return markdown_files
+
+    normalized_file = file_filter.resolve() if file_filter is not None else None
+    selected: list[Path] = []
+    for md_file in markdown_files:
+        if normalized_file is not None and md_file.resolve() == normalized_file:
+            selected.append(md_file)
+            continue
+        if glob_filters and _matches_any_glob(context, md_file, glob_filters):
+            selected.append(md_file)
+    return selected
+
+
+def _matches_any_glob(context: Any, md_file: Path, glob_filters: tuple[str, ...]) -> bool:
+    route = route_for_markdown_file(context, md_file)
+    candidates = {
+        md_file.name,
+        md_file.as_posix(),
+        context.relative_to_root(md_file),
+        route,
+        f"{route}.md" if route else "index.md",
+    }
+    return any(fnmatch.fnmatchcase(candidate, pattern) for pattern in glob_filters for candidate in candidates)
 
 
 def render_markdown(text: str) -> str:

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -31,6 +31,7 @@ class WikiHandler(BaseHTTPRequestHandler):
     site: WikiSite = None  # type: ignore[assignment]
     config: WikiConfig = None  # type: ignore[assignment]
     base_url: str = "/wiki"
+    url_style: str = "dir"
     watch_enabled: bool = False
     build_id: int = 0
 
@@ -45,14 +46,14 @@ class WikiHandler(BaseHTTPRequestHandler):
         parsed = parsed.rstrip("/")
 
         if parsed == "" or parsed == "/index":
-            self._send_html(build_index_html(self.site, base_url=base))
+            self._send_html(build_index_html(self.site, base_url=base, url_style=self.url_style))
         elif parsed == base:
-            self._send_html(build_index_html(self.site, base_url=base))
+            self._send_html(build_index_html(self.site, base_url=base, url_style=self.url_style))
         elif parsed.startswith(base + "/"):
             slug = parsed[len(base) + 1:]
             target = self._find_page(slug)
             if target:
-                self._send_html(build_page_html(target, self.site, base_url=base))
+                self._send_html(build_page_html(target, self.site, base_url=base, url_style=self.url_style))
             elif self._serve_asset(parsed[len(base) + 1:]):
                 return
             else:
@@ -164,13 +165,15 @@ def create_server(
     host: str = "127.0.0.1",
     port: int = 8080,
     base_url: str = "/wiki",
+    url_style: str = "dir",
     watch: bool = False,
 ) -> HTTPServer:
     """Build the site and return a configured HTTPServer (not yet started)."""
-    site = build_site(config, base_url=base_url)
+    site = build_site(config, base_url=base_url, url_style=url_style)
     WikiHandler.site = site
     WikiHandler.config = config
     WikiHandler.base_url = base_url
+    WikiHandler.url_style = url_style
     WikiHandler.watch_enabled = watch
     WikiHandler.build_id = 0
 
@@ -186,10 +189,11 @@ def run_server(
     host: str = "127.0.0.1",
     port: int = 8080,
     base_url: str = "/wiki",
+    url_style: str = "dir",
     watch: bool = False,
 ) -> None:
     """Create and start the wiki HTTP server, blocking until shutdown."""
-    server = create_server(config, host=host, port=port, base_url=base_url, watch=watch)
+    server = create_server(config, host=host, port=port, base_url=base_url, url_style=url_style, watch=watch)
 
     if watch:
         watch_dirs = list(config.input_dirs) + [d for d in config.asset_dirs if d.exists()]
@@ -220,7 +224,7 @@ def run_server(
                     new = snapshot()
                     if new != mtimes:
                         mtimes = new
-                        WikiHandler.site = build_site(config, base_url=base_url)
+                        WikiHandler.site = build_site(config, base_url=base_url, url_style=url_style)
                         WikiHandler.build_id += 1
                 except Exception:
                     continue

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -202,7 +202,7 @@ def run_server(
                 for p in root.rglob("*"):
                     if not p.is_file():
                         continue
-                    if p.suffix.lower() not in {".md", ".ttl", ".trig", ".nt", ".nq", ".rdf", ".xml", ".jsonld", ".html", ".htm", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".css", ".js", ".woff2", ".woff", ".ttf"}:
+                    if p.suffix.lower() not in {".md", ".yaml", ".yml", ".json", ".ttl", ".trig", ".nt", ".nq", ".rdf", ".xml", ".jsonld", ".html", ".htm", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".css", ".js", ".woff2", ".woff", ".ttf"}:
                         continue
                     try:
                         mtimes[str(p)] = p.stat().st_mtime

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from markdown_it import MarkdownIt
 from mdit_py_plugins.wikilink import wikilink_plugin
@@ -15,8 +16,8 @@ from mdit_py_plugins.wikilink import wikilink_plugin
 from .config import WikiConfig
 from .headings import GitHubHeadingSlugger, heading_slug
 from .links import is_external_link, markdown_link_is_page, resolve_page_href, resolve_page_route
-from .paths import page_url, route_for_markdown_file
-from .parser import split_frontmatter_body
+from .paths import iter_document_files, page_url, route_for_document_file
+from .parser import split_document_body
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
@@ -51,9 +52,28 @@ header{border-bottom:1px solid #e5e7eb;padding-bottom:16px;margin-bottom:24px}
 .outline-list .l6{padding-left:48px}
 .page-meta{background:#f8fafc;border:1px solid #e5e7eb;border-radius:8px;padding:16px;margin-top:32px}
 .page-meta h2{font-size:1.1em;border:none;margin-top:0}
+.page-shell{display:block}
+.page-shell.template-person,.page-shell.template-thing,.page-shell.template-pet{display:grid;gap:24px;align-items:start}
+.page-main article{min-width:0}
+.page-sidebar{min-width:0}
+.infobox{background:#fff;border:1px solid #dbe4f0;border-radius:12px;padding:18px;box-shadow:0 8px 24px rgba(15,23,42,.06)}
+.infobox h2{font-size:1rem;border:none;margin:0 0 14px}
+.infobox dl{display:grid;grid-template-columns:minmax(96px,140px) 1fr;gap:10px 14px}
+.infobox dt{font-weight:600;color:#475569}
+.infobox dd{margin:0;min-width:0}
+.infobox-list{list-style:none;padding-left:0;margin:0;display:flex;flex-wrap:wrap;gap:8px}
+.infobox-list li{margin:0}
+.infobox-chip{display:inline-flex;align-items:center;border:1px solid #dbe4f0;border-radius:999px;padding:2px 10px;background:#f8fafc}
+.infobox-dict{display:grid;gap:6px}
+.infobox-dict-row{display:grid;grid-template-columns:minmax(72px,120px) 1fr;gap:8px}
+.infobox-key{font-weight:600;color:#475569}
+.template-label{display:inline-block;margin-bottom:12px;padding:4px 10px;border-radius:999px;background:#e0f2fe;color:#075985;font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
 .index-header{margin-bottom:24px}
 .site-title{font-size:1.5em;font-weight:700;color:#1a1a2e;text-decoration:none}
+@media (min-width: 900px){.page-shell.template-person,.page-shell.template-thing,.page-shell.template-pet{grid-template-columns:minmax(0,1fr) 300px}}
 """.strip()
+
+METADATA_HIDDEN_FIELDS = {"@context", "@id", "id", "@type", "type", "template", "wiki:template"}
 
 
 def slugify_segment(text: str) -> str:
@@ -130,6 +150,9 @@ class VirtualPage:
     markdown: str
     html: str
     frontmatter: dict[str, Any]
+    type_names: list[str] = field(default_factory=list)
+    template_name: str = "default.html"
+    wiki_ids: list[str] = field(default_factory=list)
     outline: list[TocItem] = field(default_factory=list)
     backlink_slugs: list[str] = field(default_factory=list)
 
@@ -145,6 +168,8 @@ class VirtualPage:
 @dataclass
 class WikiSite:
     pages: list[VirtualPage]
+    pages_by_route: dict[str, VirtualPage] = field(default_factory=dict)
+    routes_by_wiki_id: dict[str, str] = field(default_factory=dict)
 
 
 def split_by_headings(markdown: str) -> list[tuple[int, str, str]]:
@@ -209,22 +234,19 @@ def build_site(
     else:
         dirs_arg = [input_dirs] if isinstance(input_dirs, Path) else input_dirs
         config = WikiConfig(input_dirs=dirs_arg)
-    dirs = config.input_dirs
     pages: list[VirtualPage] = []
 
-    md_files: list[Path] = []
-    for d in dirs:
-        if d.exists():
-            md_files.extend(sorted(d.rglob("*.md")))
-    md_files.sort()
+    doc_files = sorted(iter_document_files(config))
 
-    def file_slug(md: Path) -> str:
-        return route_for_markdown_file(config, md)
+    def file_slug(file_path: Path) -> str:
+        return route_for_document_file(config, file_path)
 
     backlink_index: dict[str, list[str]] = {}
-    for md in md_files:
-        content = md.read_text(encoding="utf-8")
-        source_slug = file_slug(md)
+    for file_path in doc_files:
+        if file_path.suffix.lower() != ".md":
+            continue
+        content = file_path.read_text(encoding="utf-8")
+        source_slug = file_slug(file_path)
         for match in WIKILINK_RE.finditer(content):
             target = resolve_page_route(source_slug, match.group(1).strip())
             if target is None:
@@ -234,33 +256,44 @@ def build_site(
             if source_slug not in backlink_index[target]:
                 backlink_index[target].append(source_slug)
 
-    for md in md_files:
-        raw = md.read_text(encoding="utf-8")
-        fm_data, body = split_frontmatter_body(raw)
+    for file_path in doc_files:
+        fm_data, body = split_document_body(file_path)
         frontmatter = fm_data if fm_data is not None else {}
 
-        md_slug = file_slug(md)
-        h1_title = extract_title(body, md_slug)
+        doc_slug = file_slug(file_path)
+        h1_title = frontmatter.get("name") or extract_title(body, doc_slug)
         h1_toc = extract_outline(body)
+        type_names = _page_type_names(frontmatter)
+        wiki_ids = _page_wiki_ids(config, doc_slug, frontmatter)
+        template_name = _select_template_name(frontmatter, type_names)
 
         h1_html = render_wiki_markdown(
             body,
             base_url=base_url,
             url_style=url_style,
             markdown_flavor=config.markdown_flavor,
-            current_route=md_slug,
+            current_route=doc_slug,
         )
         pages.append(VirtualPage(
-            file_slug=md_slug,
+            file_slug=doc_slug,
             title=h1_title,
             markdown=body,
             html=h1_html,
             frontmatter=frontmatter,
+            type_names=type_names,
+            template_name=template_name,
+            wiki_ids=wiki_ids,
             outline=h1_toc,
-            backlink_slugs=backlink_index.get(md_slug, []),
+            backlink_slugs=backlink_index.get(doc_slug, []),
         ))
 
-    return WikiSite(pages=pages)
+    pages_by_route = {page.file_slug: page for page in pages}
+    routes_by_wiki_id: dict[str, str] = {}
+    for page in pages:
+        for wiki_id in page.wiki_ids:
+            routes_by_wiki_id[wiki_id] = page.file_slug
+
+    return WikiSite(pages=pages, pages_by_route=pages_by_route, routes_by_wiki_id=routes_by_wiki_id)
 
 
 def build_index_html(site: WikiSite, base_url: str = "/wiki", url_style: str = "file") -> str:
@@ -297,43 +330,13 @@ def build_index_html(site: WikiSite, base_url: str = "/wiki", url_style: str = "
 
 def build_page_html(page: VirtualPage, site: WikiSite, base_url: str = "/wiki", url_style: str = "file") -> str:
     """Compile individual page HTML."""
-    toc_html = ""
-    if page.outline:
-        items = ""
-        for item in page.outline:
-            items += f'<li class="l{item.level}"><a href="#{item.slug}">{html_module.escape(item.title)}</a></li>\n'
-        toc_html = f"""<section class="page-meta">
-<h2>On this page</h2>
-<ul class="outline-list">
-{items}
-</ul>
-</section>"""
-
-    bl_html = ""
-    if page.backlink_slugs:
-        items = ""
-        for bl in page.backlink_slugs:
-            target: str | None = None
-            for p in site.pages:
-                if p.file_slug == bl:
-                    target = p.full_slug
-                    break
-            if target is None:
-                target = bl
-            items += f'<li><a href="{_url(base_url, target, url_style)}">{html_module.escape(bl.replace("-", " ").title())}</a></li>\n'
-        bl_html = f"""<section class="page-meta">
-<h2>Backlinks</h2>
-<ul class="backlinks-list">
-{items}
-</ul>
-</section>"""
-
-    fm_html = ""
-    if page.frontmatter:
-        fm_html = f"""<section class="page-meta">
-<h2>Metadata</h2>
-<pre><code>{html_module.escape(json.dumps(page.frontmatter, indent=2, default=str))}</code></pre>
-</section>"""
+    toc_html = _build_toc_html(page)
+    bl_html = _build_backlinks_html(page, site, base_url, url_style)
+    infobox_html = _build_infobox_html(page, site, base_url, url_style)
+    fm_html = _build_metadata_json_html(page)
+    content_html = page.html
+    template_label = _template_label(page)
+    shell_html = _render_page_shell(page, content_html, infobox_html, toc_html, bl_html, fm_html, template_label)
 
     nav_html = f'<a href="{base_url}/">Index</a>'
 
@@ -351,12 +354,266 @@ def build_page_html(page: VirtualPage, site: WikiSite, base_url: str = "/wiki", 
 <nav>{nav_html}</nav>
 </header>
 <main>
-<article>
-{page.html}
-</article>
-{toc_html}
-{bl_html}
-{fm_html}
+{shell_html}
 </main>
 </body>
 </html>"""
+
+
+def _page_type_names(frontmatter: dict[str, Any]) -> list[str]:
+    raw_types = frontmatter.get("@type") or frontmatter.get("type")
+    if raw_types is None:
+        return []
+    values = raw_types if isinstance(raw_types, list) else [raw_types]
+    return [_type_template_name(value) for value in values if _type_template_name(value)]
+
+
+def _type_template_name(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if not text:
+        return ""
+    if ":" in text:
+        text = text.split(":", 1)[1]
+    elif "/" in text:
+        text = text.rstrip("/").rsplit("/", 1)[-1]
+    return f"{text}.html"
+
+
+def _select_template_name(frontmatter: dict[str, Any], type_names: list[str]) -> str:
+    override = frontmatter.get("wiki:template") or frontmatter.get("template")
+    if isinstance(override, str) and override.strip():
+        return _normalize_template_name(override)
+    for type_name in type_names:
+        if _template_stem(type_name) in {"person", "thing", "pet"}:
+            return type_name
+    return type_names[0] if type_names else "default.html"
+
+
+def _normalize_template_name(value: str) -> str:
+    template_name = value.strip().replace("\\", "/")
+    if not template_name:
+        return "default.html"
+    template_name = template_name.rsplit("/", 1)[-1]
+    if "." not in template_name:
+        return f"{template_name}.html"
+    return template_name
+
+
+def _template_stem(template_name: str) -> str:
+    stem = Path(template_name).stem
+    return heading_slug(stem)
+
+
+def _page_wiki_ids(config: WikiConfig, route: str, frontmatter: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in ("@id", "id"):
+        raw = frontmatter.get(key)
+        if isinstance(raw, str) and raw.strip():
+            raw_value = raw.strip()
+            values.append(raw_value)
+            expanded = _expand_known_curie(raw_value, config)
+            if expanded != raw_value:
+                values.append(expanded)
+    suffix = ".md" if config.uri_ext else ""
+    values.append(f"{config.wiki_base}{route}{suffix}")
+    return list(dict.fromkeys(values))
+
+
+def _expand_known_curie(value: str, config: WikiConfig) -> str:
+    if ":" not in value or is_external_link(value) or value.lower().startswith("urn:"):
+        return value
+    prefix, local = value.split(":", 1)
+    namespace = config.context.namespaces.get(prefix)
+    if namespace is None:
+        return value
+    return f"{namespace}{local}"
+
+
+def _build_toc_html(page: VirtualPage) -> str:
+    if not page.outline:
+        return ""
+    items = ""
+    for item in page.outline:
+        items += f'<li class="l{item.level}"><a href="#{item.slug}">{html_module.escape(item.title)}</a></li>\n'
+    return f"""<section class="page-meta">
+<h2>On this page</h2>
+<ul class="outline-list">
+{items}
+</ul>
+</section>"""
+
+
+def _build_backlinks_html(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
+    if not page.backlink_slugs:
+        return ""
+    items = ""
+    for bl in page.backlink_slugs:
+        target = site.pages_by_route.get(bl)
+        title = target.title if target is not None else bl.replace("-", " ").title()
+        route = target.full_slug if target is not None else bl
+        items += f'<li><a href="{_url(base_url, route, url_style)}">{html_module.escape(title)}</a></li>\n'
+    return f"""<section class="page-meta">
+<h2>Backlinks</h2>
+<ul class="backlinks-list">
+{items}
+</ul>
+</section>"""
+
+
+def _build_metadata_json_html(page: VirtualPage) -> str:
+    if not page.frontmatter:
+        return ""
+    return f"""<section class="page-meta">
+<h2>Metadata</h2>
+<pre><code>{html_module.escape(json.dumps(page.frontmatter, indent=2, default=str))}</code></pre>
+</section>"""
+
+
+def _build_infobox_html(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
+    rows = []
+    for key, value in page.frontmatter.items():
+        if key in METADATA_HIDDEN_FIELDS:
+            continue
+        rendered = _render_metadata_value(value, page, site, base_url, url_style)
+        if rendered:
+            rows.append(f"<dt>{html_module.escape(_humanize_field_name(key))}</dt><dd>{rendered}</dd>")
+    if not rows:
+        return ""
+    return f"""<section class="infobox page-meta">
+<h2>Infobox</h2>
+<dl>
+{''.join(rows)}
+</dl>
+</section>"""
+
+
+def _humanize_field_name(key: str) -> str:
+    clean = key.split(":", 1)[-1] if ":" in key else key
+    clean = clean.lstrip("@")
+    return clean.replace("_", " ").strip().title()
+
+
+def _render_metadata_value(value: Any, page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        items = [item for item in (_render_metadata_value(v, page, site, base_url, url_style) for v in value) if item]
+        if not items:
+            return ""
+        return '<ul class="infobox-list">' + ''.join(f'<li><span class="infobox-chip">{item}</span></li>' for item in items) + '</ul>'
+    if isinstance(value, dict):
+        target_id = value.get("@id") or value.get("id")
+        label = value.get("name") or target_id
+        if isinstance(target_id, str) and label:
+            return _render_link_like(str(label), str(target_id), page, site, base_url, url_style)
+        rows = []
+        for nested_key, nested_value in value.items():
+            if str(nested_key).startswith("@"):
+                continue
+            rendered = _render_metadata_value(nested_value, page, site, base_url, url_style)
+            if rendered:
+                rows.append(
+                    f'<div class="infobox-dict-row"><span class="infobox-key">{html_module.escape(_humanize_field_name(str(nested_key)))}</span><span>{rendered}</span></div>'
+                )
+        if not rows:
+            return ""
+        return '<div class="infobox-dict">' + ''.join(rows) + '</div>'
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, (int, float)):
+        return html_module.escape(str(value))
+    return _render_link_like(str(value), str(value), page, site, base_url, url_style)
+
+
+def _render_link_like(label: str, target: str, page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
+    href, external, target_page = _metadata_value_href(target, page, site, base_url, url_style)
+    display_label = _display_label_for_target(label, target, target_page)
+    escaped_label = html_module.escape(display_label)
+    if href is None:
+        return escaped_label
+    if external:
+        return f'<a href="{html_module.escape(href)}">{escaped_label}</a>'
+    return f'<a class="wikilink" href="{html_module.escape(href)}">{escaped_label}</a>'
+
+
+def _metadata_value_href(target: str, page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> tuple[str | None, bool, VirtualPage | None]:
+    candidate = target.strip()
+    if not candidate:
+        return None, False, None
+    if is_external_link(candidate):
+        return candidate, True, None
+
+    direct_route = site.routes_by_wiki_id.get(candidate)
+    if direct_route is not None:
+        target_page = site.pages_by_route.get(direct_route)
+        return _url(base_url, direct_route, url_style), False, target_page
+
+    if candidate.startswith(page_url(base_url, "", url_style).rstrip("/")):
+        return candidate, False, None
+
+    if candidate.startswith(page.full_slug):
+        target_page = site.pages_by_route.get(candidate)
+        return _url(base_url, candidate, url_style), False, target_page
+
+    route = resolve_page_route(page.full_slug, candidate)
+    if route is not None and route in site.pages_by_route:
+        target_page = site.pages_by_route.get(route)
+        return _url(base_url, route, url_style), False, target_page
+
+    if candidate in site.pages_by_route:
+        target_page = site.pages_by_route.get(candidate)
+        return _url(base_url, candidate, url_style), False, target_page
+
+    return None, False, None
+
+
+def _display_label_for_target(label: str, target: str, target_page: VirtualPage | None) -> str:
+    if target_page is None:
+        return label
+    normalized_label = label.strip()
+    normalized_target = target.strip()
+    if normalized_label == normalized_target or normalized_label in target_page.wiki_ids or normalized_label == target_page.file_slug:
+        return target_page.title
+    return label
+
+
+def _template_label(page: VirtualPage) -> str:
+    label = humanize_route(Path(page.template_name).stem)
+    if label == "Default":
+        return ""
+    return f'<div class="template-label">{html_module.escape(label)}</div>'
+
+
+def _render_page_shell(
+    page: VirtualPage,
+    content_html: str,
+    infobox_html: str,
+    toc_html: str,
+    bl_html: str,
+    fm_html: str,
+    template_label: str,
+) -> str:
+    sidebar = infobox_html + toc_html + bl_html + fm_html
+    template_class = html_module.escape(_template_stem(page.template_name))
+    if _template_stem(page.template_name) in {"person", "thing", "pet"}:
+        return f"""<div class="page-shell template-{template_class}">
+<section class="page-main">
+{template_label}
+<article>
+{content_html}
+</article>
+</section>
+<aside class="page-sidebar">
+{sidebar}
+</aside>
+</div>"""
+
+    return f"""<div class="page-shell template-{template_class}">
+{template_label}
+<article>
+{content_html}
+</article>
+{sidebar}
+</div>"""

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -490,7 +490,8 @@ def _build_infobox_html(page: VirtualPage, site: WikiSite, base_url: str, url_st
 </section>"""
 
 
-def _build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> list[InfoboxRow]:
+def build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> list[InfoboxRow]:
+    """Return reusable infobox rows for HTML and terminal rendering."""
     rows: list[InfoboxRow] = []
     for key, value in page.frontmatter.items():
         if key in METADATA_HIDDEN_FIELDS:
@@ -500,11 +501,6 @@ def _build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_st
         if html:
             rows.append(InfoboxRow(label=label, text=text, html=html))
     return rows
-
-
-def build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> list[InfoboxRow]:
-    """Return reusable infobox rows for HTML and terminal rendering."""
-    return _build_infobox_rows(page, site, base_url, url_style)
 
 
 def _humanize_field_name(key: str) -> str:

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -479,7 +479,7 @@ def _build_metadata_json_html(page: VirtualPage) -> str:
 
 
 def _build_infobox_html(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
-    rows = _build_infobox_rows(page, site, base_url, url_style)
+    rows = build_infobox_rows(page, site, base_url, url_style)
     if not rows:
         return ""
     return f"""<section class="infobox page-meta">
@@ -500,6 +500,11 @@ def _build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_st
         if html:
             rows.append(InfoboxRow(label=label, text=text, html=html))
     return rows
+
+
+def build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> list[InfoboxRow]:
+    """Return reusable infobox rows for HTML and terminal rendering."""
+    return _build_infobox_rows(page, site, base_url, url_style)
 
 
 def _humanize_field_name(key: str) -> str:

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -144,6 +144,13 @@ class TocItem:
 
 
 @dataclass
+class InfoboxRow:
+    label: str
+    text: str
+    html: str
+
+
+@dataclass
 class VirtualPage:
     file_slug: str
     title: str
@@ -472,21 +479,27 @@ def _build_metadata_json_html(page: VirtualPage) -> str:
 
 
 def _build_infobox_html(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
-    rows = []
-    for key, value in page.frontmatter.items():
-        if key in METADATA_HIDDEN_FIELDS:
-            continue
-        rendered = _render_metadata_value(value, page, site, base_url, url_style)
-        if rendered:
-            rows.append(f"<dt>{html_module.escape(_humanize_field_name(key))}</dt><dd>{rendered}</dd>")
+    rows = _build_infobox_rows(page, site, base_url, url_style)
     if not rows:
         return ""
     return f"""<section class="infobox page-meta">
 <h2>Infobox</h2>
 <dl>
-{''.join(rows)}
+{''.join(f'<dt>{html_module.escape(row.label)}</dt><dd>{row.html}</dd>' for row in rows)}
 </dl>
 </section>"""
+
+
+def _build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> list[InfoboxRow]:
+    rows: list[InfoboxRow] = []
+    for key, value in page.frontmatter.items():
+        if key in METADATA_HIDDEN_FIELDS:
+            continue
+        label = _humanize_field_name(key)
+        text, html = _render_metadata_value_parts(value, page, site, base_url, url_style)
+        if html:
+            rows.append(InfoboxRow(label=label, text=text, html=html))
+    return rows
 
 
 def _humanize_field_name(key: str) -> str:
@@ -495,47 +508,65 @@ def _humanize_field_name(key: str) -> str:
     return clean.replace("_", " ").strip().title()
 
 
-def _render_metadata_value(value: Any, page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
+def _render_metadata_value_parts(
+    value: Any,
+    page: VirtualPage,
+    site: WikiSite,
+    base_url: str,
+    url_style: str,
+) -> tuple[str, str]:
     if value is None:
-        return ""
+        return "", ""
     if isinstance(value, list):
-        items = [item for item in (_render_metadata_value(v, page, site, base_url, url_style) for v in value) if item]
+        rendered_items = [
+            item for item in (_render_metadata_value_parts(v, page, site, base_url, url_style) for v in value)
+            if item[1]
+        ]
+        items = [html for _, html in rendered_items]
         if not items:
-            return ""
-        return '<ul class="infobox-list">' + ''.join(f'<li><span class="infobox-chip">{item}</span></li>' for item in items) + '</ul>'
+            return "", ""
+        text = ", ".join(text for text, _ in rendered_items if text)
+        html = '<ul class="infobox-list">' + ''.join(f'<li><span class="infobox-chip">{item}</span></li>' for item in items) + '</ul>'
+        return text, html
     if isinstance(value, dict):
         target_id = value.get("@id") or value.get("id")
         label = value.get("name") or target_id
         if isinstance(target_id, str) and label:
             return _render_link_like(str(label), str(target_id), page, site, base_url, url_style)
         rows = []
+        text_parts = []
         for nested_key, nested_value in value.items():
             if str(nested_key).startswith("@"):
                 continue
-            rendered = _render_metadata_value(nested_value, page, site, base_url, url_style)
-            if rendered:
+            nested_text, nested_html = _render_metadata_value_parts(nested_value, page, site, base_url, url_style)
+            if nested_html:
+                nested_label = _humanize_field_name(str(nested_key))
                 rows.append(
-                    f'<div class="infobox-dict-row"><span class="infobox-key">{html_module.escape(_humanize_field_name(str(nested_key)))}</span><span>{rendered}</span></div>'
+                    f'<div class="infobox-dict-row"><span class="infobox-key">{html_module.escape(nested_label)}</span><span>{nested_html}</span></div>'
                 )
+                if nested_text:
+                    text_parts.append(f"{nested_label}: {nested_text}")
         if not rows:
-            return ""
-        return '<div class="infobox-dict">' + ''.join(rows) + '</div>'
+            return "", ""
+        return "; ".join(text_parts), '<div class="infobox-dict">' + ''.join(rows) + '</div>'
     if isinstance(value, bool):
-        return "True" if value else "False"
+        text = "True" if value else "False"
+        return text, text
     if isinstance(value, (int, float)):
-        return html_module.escape(str(value))
+        text = str(value)
+        return text, html_module.escape(text)
     return _render_link_like(str(value), str(value), page, site, base_url, url_style)
 
 
-def _render_link_like(label: str, target: str, page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:
+def _render_link_like(label: str, target: str, page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> tuple[str, str]:
     href, external, target_page = _metadata_value_href(target, page, site, base_url, url_style)
     display_label = _display_label_for_target(label, target, target_page)
     escaped_label = html_module.escape(display_label)
     if href is None:
-        return escaped_label
+        return display_label, escaped_label
     if external:
-        return f'<a href="{html_module.escape(href)}">{escaped_label}</a>'
-    return f'<a class="wikilink" href="{html_module.escape(href)}">{escaped_label}</a>'
+        return display_label, f'<a href="{html_module.escape(href)}">{escaped_label}</a>'
+    return display_label, f'<a class="wikilink" href="{html_module.escape(href)}">{escaped_label}</a>'
 
 
 def _metadata_value_href(target: str, page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> tuple[str | None, bool, VirtualPage | None]:

--- a/src/wiki/view.py
+++ b/src/wiki/view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from io import StringIO
 from pathlib import Path
 
+from rich import box
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -32,11 +33,11 @@ def render_document_view(file_path: Path, config: object, base_url: str | None =
     panel_text = Text(page.title)
     if template_name:
         panel_text.append(f"\nTemplate: {template_name}", style="dim")
-    console.print(Panel(panel_text, expand=False))
+    console.print(Panel(panel_text, expand=False, box=box.ASCII))
 
     rows = build_infobox_rows(page, site, resolved_base_url, resolved_url_style)
     if rows:
-        table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+        table = Table(show_header=True, header_style="bold", box=box.ASCII, pad_edge=False)
         table.add_column("Field", style="cyan", no_wrap=True)
         table.add_column("Value")
         for row in rows:

--- a/src/wiki/view.py
+++ b/src/wiki/view.py
@@ -1,0 +1,50 @@
+"""Terminal rendering helpers for wiki documents."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from .paths import route_for_document_file
+from .site import WikiSite, build_infobox_rows, build_site
+
+
+def render_document_view(file_path: Path, config: object, base_url: str | None = None, url_style: str | None = None) -> str:
+    """Render a single wiki document as terminal-friendly rich text."""
+    resolved_base_url = "/wiki" if base_url is None else base_url
+    resolved_url_style = "dir" if url_style is None else url_style
+    site = build_site(config, base_url=resolved_base_url, url_style=resolved_url_style)
+    route = route_for_document_file(config, file_path)
+    page = site.pages_by_route.get(route)
+    if page is None:
+        raise ValueError(f"Document is not part of the configured wiki inputs: {file_path.name}")
+
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=False, color_system=None, width=100)
+
+    template_name = page.template_name
+    panel_text = Text(page.title)
+    if template_name:
+        panel_text.append(f"\nTemplate: {template_name}", style="dim")
+    console.print(Panel(panel_text, expand=False))
+
+    rows = build_infobox_rows(page, site, resolved_base_url, resolved_url_style)
+    if rows:
+        table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+        table.add_column("Field", style="cyan", no_wrap=True)
+        table.add_column("Value")
+        for row in rows:
+            table.add_row(row.label, row.text)
+        console.print(table)
+
+    if page.markdown.strip():
+        console.print()
+        console.print(Markdown(page.markdown))
+
+    return buffer.getvalue()

--- a/src/wiki/view.py
+++ b/src/wiki/view.py
@@ -13,7 +13,7 @@ from rich.table import Table
 from rich.text import Text
 
 from .paths import route_for_document_file
-from .site import WikiSite, build_infobox_rows, build_site
+from .site import build_infobox_rows, build_site
 
 
 def render_document_view(file_path: Path, config: object, base_url: str | None = None, url_style: str | None = None) -> str:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -58,6 +58,30 @@ And a valid Markdown link [Target](target-page.md) and a broken Markdown link [B
             self.assertTrue(any("Broken WikiLink [non-existent-page]" in w for w in warnings))
             self.assertTrue(any("Broken Markdown link [missing.md]" in w for w in warnings))
 
+    def test_markdown_can_link_to_yaml_document(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            config = WikiConfig(input_dirs=[tmpdir])
+
+            target_path = Path(tmpdir) / "target-page.yaml"
+            target_path.write_text("type: Thing\nname: Target\n", encoding="utf-8")
+
+            source_path = Path(tmpdir) / "source-page.md"
+            source_path.write_text("See [[target-page]] and [Target](target-page.yaml).", encoding="utf-8")
+
+            warnings = audit_internal_links(config)
+            self.assertEqual(warnings, [])
+
+    def test_audit_filenames_includes_yaml_documents(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            config = WikiConfig(input_dirs=[tmpdir], filename_pattern="[a-z0-9-]+")
+
+            invalid_path = Path(tmpdir) / "Invalid_Name.yaml"
+            invalid_path.write_text("type: Thing\n", encoding="utf-8")
+
+            warnings = audit_filenames(config)
+            self.assertEqual(len(warnings), 1)
+            self.assertIn("Invalid_Name.yaml", warnings[0])
+
     def test_load_shapes_edge_cases(self) -> None:
         """Test load_shapes behaves predictably with different underlying graph states."""
         from wiki.graph import load_graph

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -82,6 +82,64 @@ class TestWikiBuild(unittest.TestCase):
             self.assertIn("Custom Home", index_content)
             self.assertNotIn("All Pages", index_content)
 
+    def test_build_writes_pages_for_yaml_documents(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            output_dir = root / "_site"
+            wiki.mkdir()
+            (root / "wiki.yaml").write_text("inputDirs: wiki\n", encoding="utf-8")
+            (wiki / "person.yaml").write_text("type: Person\nname: Gregory House\n", encoding="utf-8")
+
+            result = runner.invoke(main, ["--config", str(root), "build", "--output-dir", str(output_dir)])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue((output_dir / "wiki" / "person" / "index.html").exists())
+
+    def test_build_renders_infobox_links_for_typed_pages(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            output_dir = root / "_site"
+            wiki.mkdir()
+            (root / "wiki.yaml").write_text("inputDirs: wiki\n", encoding="utf-8")
+            (wiki / "Gregory_Davidson.yaml").write_text(
+                """id: wiki:Gregory_Davidson
+type: schema:Person
+name: Gregory Davidson
+knows: wiki:Ethan_Davidson
+owns: wiki:Bella_Davidson
+url: https://example.com/gregory-davidson
+""",
+                encoding="utf-8",
+            )
+            (wiki / "Ethan_Davidson.yaml").write_text(
+                """id: wiki:Ethan_Davidson
+type: schema:Person
+name: Ethan Davidson
+""",
+                encoding="utf-8",
+            )
+            (wiki / "Bella_Davidson.yaml").write_text(
+                """id: wiki:Bella_Davidson
+type: schema:Thing
+name: Bella Davidson
+""",
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(main, ["--config", str(root), "build", "--output-dir", str(output_dir)])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            html = (output_dir / "wiki" / "Gregory_Davidson" / "index.html").read_text(encoding="utf-8")
+            self.assertIn('class="page-shell template-person"', html)
+            self.assertIn('>Ethan Davidson</a>', html)
+            self.assertIn('>Bella Davidson</a>', html)
+            self.assertIn('href="/wiki/Bella_Davidson/"', html)
+            self.assertIn('href="https://example.com/gregory-davidson"', html)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -389,6 +389,70 @@ SELECT ?name WHERE {{ ?s <https://schema.org/name> ?name }}
             self.assertEqual(result.exit_code, 1)
             self.assertIn("render only supports markdown files", result.output)
 
+    def test_cli_view_markdown_document(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            (wiki_dir / "Ethan_Davidson.yaml").write_text(
+                """id: wiki:Ethan_Davidson
+type: schema:Person
+name: Ethan Davidson
+""",
+                encoding="utf-8",
+            )
+            page = wiki_dir / "Gregory_Davidson.md"
+            page.write_text(
+                """---
+id: wiki:Gregory_Davidson
+type: schema:Person
+name: Gregory Davidson
+knows: wiki:Ethan_Davidson
+---
+# Gregory Davidson
+
+Gregory knows Ethan.
+""",
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "view", str(page)])
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Gregory Davidson", result.output)
+            self.assertIn("Template: Person.html", result.output)
+            self.assertIn("Knows", result.output)
+            self.assertIn("Ethan Davidson", result.output)
+            self.assertIn("Gregory knows Ethan.", result.output)
+
+    def test_cli_view_data_document(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            (wiki_dir / "Ethan_Davidson.yaml").write_text(
+                """id: wiki:Ethan_Davidson
+type: schema:Person
+name: Ethan Davidson
+""",
+                encoding="utf-8",
+            )
+            page = wiki_dir / "Bella_Davidson.yaml"
+            page.write_text(
+                """id: wiki:Bella_Davidson
+type: wiki:Pet
+name: Bella Davidson
+owner: wiki:Ethan_Davidson
+""",
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "view", str(page)])
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Bella Davidson", result.output)
+            self.assertIn("Template: Pet.html", result.output)
+            self.assertIn("Owner", result.output)
+            self.assertIn("Ethan Davidson", result.output)
+
     def test_cli_export(self) -> None:
         """Test that wiki export supports bulk and single file exports."""
         runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,6 +307,88 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
             self.assertEqual(result_clean.exit_code, 0)
             self.assertIn("All dynamic SPARQL blocks are fully up to date", result_clean.output)
 
+    def test_cli_init_scaffolds_person_shape_with_template_constraint(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            with runner.isolated_filesystem(temp_dir=tmpdir):
+                result = runner.invoke(
+                    main,
+                    ["init", "--force"],
+                    input="https://wiki.example.org/\ny\ny\n",
+                    catch_exceptions=False,
+                )
+
+                self.assertEqual(result.exit_code, 0)
+                shape_content = Path("wiki") / "Person_Shape.md"
+                content = shape_content.read_text(encoding="utf-8")
+                self.assertIn("sh:path: wiki:template", content)
+                self.assertIn("sh:maxCount: 1", content)
+
+    def test_cli_render_single_file_scope(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            alpha = wiki_dir / "alpha.md"
+            beta = wiki_dir / "beta.md"
+            source = """---
+type: Person
+name: {name}
+---
+<!-- sparql:start -->
+```sparql
+SELECT ?name WHERE {{ ?s <https://schema.org/name> ?name }}
+```
+<!-- sparql:end -->
+"""
+            alpha.write_text(source.format(name="Alpha"), encoding="utf-8")
+            beta.write_text(source.format(name="Beta"), encoding="utf-8")
+
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "render", str(alpha), "--no-inference"])
+            self.assertEqual(result.exit_code, 0)
+
+            self.assertIn("Alpha", alpha.read_text(encoding="utf-8"))
+            self.assertNotIn("| Name |", beta.read_text(encoding="utf-8"))
+
+    def test_cli_render_glob_scope(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir) / "wiki"
+            people_dir = wiki_dir / "people"
+            projects_dir = wiki_dir / "projects"
+            people_dir.mkdir(parents=True)
+            projects_dir.mkdir()
+            source = """---
+type: Person
+name: {name}
+---
+<!-- sparql:start -->
+```sparql
+SELECT ?name WHERE {{ ?s <https://schema.org/name> ?name }}
+```
+<!-- sparql:end -->
+"""
+            person = people_dir / "alpha.md"
+            project = projects_dir / "beta.md"
+            person.write_text(source.format(name="Alpha"), encoding="utf-8")
+            project.write_text(source.format(name="Beta"), encoding="utf-8")
+
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "render", "--glob", "people/*.md", "--no-inference"])
+            self.assertEqual(result.exit_code, 0)
+
+            self.assertIn("| Name |", person.read_text(encoding="utf-8"))
+            self.assertNotIn("| Name |", project.read_text(encoding="utf-8"))
+
+    def test_cli_render_rejects_non_markdown_file(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            record = wiki_dir / "person.yaml"
+            record.write_text("type: Person\nname: Gregory\n", encoding="utf-8")
+
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "render", str(record), "--no-inference"])
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("render only supports markdown files", result.output)
+
     def test_cli_export(self) -> None:
         """Test that wiki export supports bulk and single file exports."""
         runner = CliRunner()
@@ -339,6 +421,28 @@ name: Gregory
             no_fm_file.write_text("Hello", encoding="utf-8")
             result_fail = runner.invoke(main, ["--input-dir", str(wiki_dir), "export", str(no_fm_file)])
             self.assertEqual(result_fail.exit_code, 1)
+
+    def test_cli_export_supports_yaml_and_json_documents(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            yaml_file = wiki_dir / "gregory.yaml"
+            json_file = wiki_dir / "alice.json"
+            yaml_file.write_text("type: Person\nname: Gregory\n", encoding="utf-8")
+            json_file.write_text('{"type": "Person", "name": "Alice"}', encoding="utf-8")
+
+            result_bulk = runner.invoke(main, ["--input-dir", str(wiki_dir), "export"])
+            self.assertEqual(result_bulk.exit_code, 0)
+            data_bulk = json.loads(result_bulk.output)
+            self.assertEqual(len(data_bulk), 2)
+
+            result_yaml = runner.invoke(main, ["--input-dir", str(wiki_dir), "export", str(yaml_file)])
+            self.assertEqual(result_yaml.exit_code, 0)
+            self.assertEqual(json.loads(result_yaml.output)["rdf"]["name"], "Gregory")
+
+            result_json = runner.invoke(main, ["--input-dir", str(wiki_dir), "export", str(json_file)])
+            self.assertEqual(result_json.exit_code, 0)
+            self.assertEqual(json.loads(result_json.output)["rdf"]["name"], "Alice")
     
     def test_cli_export_formats(self) -> None:
         """Test that wiki export supports various --format options."""

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 from rdflib import Graph, URIRef, RDF, Literal
 from rdflib.namespace import XSD
 
-from wiki.config import WikiConfig
+from wiki.config import Context, WikiConfig
 from wiki.graph import (
     frontmatter_to_graph,
     kebab_case,
@@ -144,6 +144,23 @@ class TestRDFFrontmatter(unittest.TestCase):
                 self.assertEqual(str(o), "https://microdata.io")
         
         self.assertTrue(found_name, "Failed to find Microdata name literal in graph.")
+
+    def test_microdata_curies_expand_using_bound_namespaces(self) -> None:
+        html_content = """
+        <div itemscope itemtype="schema:Person" itemid="wiki:john_microdata">
+            <span itemprop="schema:name">John Microdata</span>
+            <span itemprop="unknown:role">Tester</span>
+        </div>
+        """
+        g = Graph()
+        g.bind("schema", "https://schema.org/")
+        g.bind("wiki", "https://wiki.example.org/")
+        g.parse(data=html_content, format="microdata")
+
+        subject = URIRef("https://wiki.example.org/john_microdata")
+        self.assertTrue((subject, RDF.type, URIRef("https://schema.org/Person")) in g)
+        self.assertTrue((subject, URIRef("https://schema.org/name"), Literal("John Microdata")) in g)
+        self.assertTrue((subject, URIRef("unknown:role"), Literal("Tester")) in g)
 
     def test_nested_typed_dict_creates_typed_blank_node(self) -> None:
         """Test that a nested dictionary with @type creates a typed blank node."""
@@ -449,6 +466,44 @@ name: Good Page
                 if str(p) == "https://schema.org/name"
             )
             self.assertTrue(found, "Microdata from .html file not found in graph")
+
+    def test_html_microdata_curies_use_configured_context(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            html_file = wiki_dir / "data.html"
+            html_file.write_text("""<html><body>
+<div itemscope itemtype="schema:Person" itemid="wiki:Bella_Davidson">
+    <span itemprop="schema:name">Bella Davidson</span>
+</div>
+</body></html>""", encoding="utf-8")
+
+            config = WikiConfig(
+                input_dirs=[wiki_dir],
+                wiki_base="https://example.test/wiki/",
+                context=Context({"schema": "https://schema.org/", "wiki": "https://example.test/wiki/"}, wiki_base="https://example.test/wiki/"),
+            )
+            g = load_graph(config, infer=False)
+
+            subject = URIRef("https://example.test/wiki/Bella_Davidson")
+            self.assertTrue((subject, RDF.type, URIRef("https://schema.org/Person")) in g)
+            self.assertTrue((subject, URIRef("https://schema.org/name"), Literal("Bella Davidson")) in g)
+
+    def test_load_graph_reads_yaml_and_json_documents(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            (wiki_dir / "gregory.yaml").write_text("type: Person\nname: Gregory\n", encoding="utf-8")
+            (wiki_dir / "alice.json").write_text('{"type": "Person", "name": "Alice"}', encoding="utf-8")
+
+            config = WikiConfig(input_dirs=[wiki_dir])
+            g = load_graph(config, infer=False)
+
+            self.assertTrue((None, None, Literal("Gregory")) in g)
+            self.assertTrue((None, None, Literal("Alice")) in g)
+
+            gregory_uri = URIRef("https://wiki.example.org/gregory")
+            alice_uri = URIRef("https://wiki.example.org/alice")
+            self.assertTrue((gregory_uri, RDF.type, config.context.namespaces["schema"]["Person"]) in g)
+            self.assertTrue((alice_uri, RDF.type, config.context.namespaces["schema"]["Person"]) in g)
 
     def test_uri_ext_config_appends_md(self) -> None:
         """Test that uri_ext=True produces .md in auto-generated page URIs."""

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,7 +10,6 @@ from wiki.graph import (
     kebab_case,
     resolve_predicate,
     resolve_object,
-    build_person_name_map,
     load_graph,
     graph_stats,
 )
@@ -261,62 +260,12 @@ class TestRDFFrontmatter(unittest.TestCase):
 
 
 class TestRDFLoadingAndResolution(unittest.TestCase):
-    def test_resolve_blank_nodes_and_load_graph(self) -> None:
-        """Test build_person_name_map, resolve_blank_nodes, and load_graph integration."""
-        with TemporaryDirectory() as tmpdir:
-            wiki_dir = Path(tmpdir)
-            
-            # Create a person file that has an explicit @id (using valid YAML syntax with quoted @ keys)
-            person1 = wiki_dir / "gregory.md"
-            person1_content = """---
-"@type": Person
-"@id": "wiki:gregory"
-name: Gregory Smith
-givenName: Gregory
-familyName: Smith
----
-"""
-            person1.write_text(person1_content, encoding="utf-8")
-            
-            # Create another person file with a blank node relation to Gregory
-            person2 = wiki_dir / "bella.md"
-            person2_content = """---
-"@type": Person
-"@id": "wiki:bella"
-name: Bella
-spouse:
-  name: Gregory Smith
----
-"""
-            person2.write_text(person2_content, encoding="utf-8")
-            
-            config = WikiConfig(input_dirs=[wiki_dir])
-            
-            # 1. Test build_person_name_map
-            name_map = build_person_name_map(config.input_dirs, config.context)
-            self.assertEqual(name_map.get("gregory smith"), "wiki:gregory")
-            self.assertEqual(name_map.get("gregory"), "wiki:gregory")
-            
-            # 2. Test load_graph and blank node resolution
-            graph = load_graph(config, infer=False)
-            
-            # Spouse blank node should resolve correctly
-            subject = URIRef(config.namespaces["wiki"]["bella"])
-            spouse_pred = config.namespaces["schema"]["spouse"]
-            spouse_objs = list(graph.objects(subject, spouse_pred))
-            self.assertEqual(len(spouse_objs), 1)
-            self.assertEqual(spouse_objs[0], URIRef("wiki:gregory"))
-            
-            # Test graph stats
-            stats = graph_stats(graph)
-            self.assertGreater(stats["triples"], 0)
-
     def test_multi_type_and_implicit_id_mapping(self) -> None:
         """Test multi-type arrays in frontmatter and implicit ID mapping fallback in loading sequence."""
         config = WikiConfig()
         ctx = config.context
         
-        # 1. Verify multi-type parsing logic executes and adds multiple types
+        # Verify multi-type parsing logic executes and adds multiple types
         data = {
             "@type": ["Person", "Developer"],
             "@id": "wiki:multi",
@@ -328,29 +277,6 @@ spouse:
         self.assertEqual(len(types), 2)
         self.assertIn(ctx.namespaces["schema"]["Person"], types)
         self.assertIn(ctx.namespaces["schema"]["Developer"], types)
-
-        # 2. Verify implicit fallback ID generation inside name-to-id mapper (uses file stem)
-        with TemporaryDirectory() as tmpdir:
-            wiki_dir = Path(tmpdir)
-            implicit_person = wiki_dir / "jimmy-neutron.md"
-            implicit_content = """---
-"@type": Person
-givenName: Jimmy
-familyName: Neutron
----
-"""
-            implicit_person.write_text(implicit_content, encoding="utf-8")
-            name_map = build_person_name_map([wiki_dir], ctx)
-            
-            # The fallback format uses the file stem: {wiki_base}{stem} (no .md by default)
-            expected_fallback = f"{config.wiki_base}jimmy-neutron"
-            self.assertEqual(name_map.get("jimmy neutron"), expected_fallback)
-
-            # 3. Verify implicit fallback for Person with only standalone name
-            single_person = wiki_dir / "zendaya.md"
-            single_person.write_text("---\n\"@type\": Person\nname: Zendaya\n---\n", encoding="utf-8")
-            name_map_2 = build_person_name_map([wiki_dir], ctx)
-            self.assertEqual(name_map_2.get("zendaya"), f"{config.wiki_base}zendaya")
 
     def test_load_graph_advanced_sources(self) -> None:
         """Test the unified graph loader handles multiple input dirs and gracefully ignores broken internal Turtle."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,8 +2,10 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from wiki.parser import (
+    document_data_from_path,
     parse_frontmatter,
     split_frontmatter_body,
+    split_document_body,
     ensure_context,
 )
 
@@ -106,6 +108,45 @@ Body with --- dashes --- in text"""
         data, body = split_frontmatter_body(content)
         self.assertIsNotNone(data)
         self.assertEqual(body, "Body with --- dashes --- in text")
+
+    def test_document_data_from_yaml_and_json_files(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            yaml_file = root / "person.yaml"
+            json_file = root / "person.json"
+            yaml_file.write_text('type: Person\nname: Gregory\n', encoding="utf-8")
+            json_file.write_text('{"type": "Person", "name": "Alice"}', encoding="utf-8")
+
+            yaml_data = document_data_from_path(yaml_file)
+            json_data = document_data_from_path(json_file)
+
+            self.assertEqual(yaml_data["name"], "Gregory")
+            self.assertEqual(json_data["name"], "Alice")
+            self.assertIn("@context", yaml_data)
+            self.assertIn("@context", json_data)
+
+    def test_document_data_rejects_non_mapping_data_files(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            yaml_file = root / "items.yaml"
+            json_file = root / "items.json"
+            yaml_file.write_text('- one\n- two\n', encoding="utf-8")
+            json_file.write_text('[1, 2, 3]', encoding="utf-8")
+
+            self.assertIsNone(document_data_from_path(yaml_file))
+            self.assertIsNone(document_data_from_path(json_file))
+
+    def test_split_document_body_returns_empty_body_for_data_files(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            yaml_file = root / "person.yaml"
+            yaml_file.write_text('type: Person\nname: Gregory\n', encoding="utf-8")
+
+            data, body = split_document_body(yaml_file)
+
+            self.assertIsNotNone(data)
+            self.assertEqual(data["name"], "Gregory")
+            self.assertEqual(body, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -10,6 +10,7 @@ from wiki.paths import (
     page_output_path,
     page_routes,
     page_url,
+    route_for_document_file,
     route_for_markdown_file,
     validate_filename_pattern,
     validate_route_safety,
@@ -105,6 +106,21 @@ class TestWikiPaths(unittest.TestCase):
             issues = detect_output_collisions(entries)
             self.assertGreaterEqual(len(issues), 1)
             self.assertTrue(any("About" in issue for issue in issues))
+
+    def test_markdown_and_yaml_with_same_slug_collide(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir(parents=True)
+            (wiki / "About.md").write_text("# About", encoding="utf-8")
+            (wiki / "About.yaml").write_text("type: Thing\nname: About data\n", encoding="utf-8")
+            config = WikiConfig(input_dirs=[wiki], config_root=root)
+
+            entries = build_page_manifest(config, root / "_site" / "wiki", "/wiki", "dir")
+            issues = detect_output_collisions(entries)
+
+            self.assertGreaterEqual(len(issues), 1)
+            self.assertTrue(any("About.md" in issue and "About.yaml" in issue for issue in issues))
 
     def test_case_only_output_paths_collide(self) -> None:
         entries = [

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from wiki.config import WikiConfig
-from wiki.site import build_site, render_wiki_markdown
+from wiki.site import build_page_html, build_site, render_wiki_markdown
 
 
 class TestWikiSite(unittest.TestCase):
@@ -36,6 +36,128 @@ class TestWikiSite(unittest.TestCase):
             site = build_site(config)
 
             self.assertEqual(site.pages[0].title, "Pokemon Diamond (copy 1)")
+
+    def test_build_site_creates_pages_for_data_documents(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "person.yaml").write_text("type: Person\nname: Gregory House\n", encoding="utf-8")
+            (wiki / "index.md").write_text("# Home", encoding="utf-8")
+            config = WikiConfig(input_dirs=[wiki], config_root=root)
+
+            site = build_site(config)
+
+            page_by_slug = {page.full_slug: page for page in site.pages}
+            self.assertIn("person", page_by_slug)
+            self.assertEqual(page_by_slug["person"].title, "Gregory House")
+            self.assertIn("Gregory House", page_by_slug["person"].html + str(page_by_slug["person"].frontmatter))
+
+    def test_build_page_html_uses_person_template_and_clickable_infobox_links(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "Gregory_Davidson.yaml").write_text(
+                """id: wiki:Gregory_Davidson
+type: schema:Person
+name: Gregory Davidson
+knows: wiki:Ethan_Davidson
+owns: wiki:Bella_Davidson
+url: https://example.com/gregory-davidson
+""",
+                encoding="utf-8",
+            )
+            (wiki / "Ethan_Davidson.yaml").write_text(
+                """id: wiki:Ethan_Davidson
+type: schema:Person
+name: Ethan Davidson
+""",
+                encoding="utf-8",
+            )
+            (wiki / "Bella_Davidson.yaml").write_text(
+                """id: wiki:Bella_Davidson
+type: schema:Thing
+name: Bella Davidson
+""",
+                encoding="utf-8",
+            )
+            config = WikiConfig(input_dirs=[wiki], config_root=root)
+
+            site = build_site(config, base_url="/wiki", url_style="dir")
+            page = next(page for page in site.pages if page.full_slug == "Gregory_Davidson")
+            html = build_page_html(page, site, base_url="/wiki", url_style="dir")
+
+            self.assertEqual(page.template_name, "Person.html")
+            self.assertIn('class="page-shell template-person"', html)
+            self.assertIn('>Ethan Davidson</a>', html)
+            self.assertIn('>Bella Davidson</a>', html)
+            self.assertNotIn('>wiki:Ethan_Davidson</a>', html)
+            self.assertNotIn('>wiki:Bella_Davidson</a>', html)
+            self.assertIn('href="/wiki/Ethan_Davidson/"', html)
+            self.assertIn('href="/wiki/Bella_Davidson/"', html)
+            self.assertIn('href="https://example.com/gregory-davidson"', html)
+            self.assertIn("Infobox", html)
+
+    def test_template_frontmatter_override_is_applied(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "project.md").write_text(
+                """---
+type: schema:CreativeWork
+template: Thing.html
+name: Project Atlas
+related:
+  - wiki:Project_Atlas
+---
+# Project Atlas
+""",
+                encoding="utf-8",
+            )
+            (wiki / "Project_Atlas.yaml").write_text(
+                """id: wiki:Project_Atlas
+type: schema:CreativeWork
+name: Project Atlas Record
+""",
+                encoding="utf-8",
+            )
+            config = WikiConfig(input_dirs=[wiki], config_root=root)
+
+            site = build_site(config, base_url="/wiki", url_style="dir")
+            page = next(page for page in site.pages if page.full_slug == "project")
+            html = build_page_html(page, site, base_url="/wiki", url_style="dir")
+
+            self.assertEqual(page.template_name, "Thing.html")
+            self.assertIn('class="page-shell template-thing"', html)
+            self.assertIn('href="/wiki/Project_Atlas/"', html)
+
+    def test_wiki_template_frontmatter_override_takes_precedence(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "project.md").write_text(
+                """---
+type: schema:CreativeWork
+template: default.html
+wiki:template: Person.html
+name: Project Atlas
+---
+# Project Atlas
+""",
+                encoding="utf-8",
+            )
+            config = WikiConfig(input_dirs=[wiki], config_root=root)
+
+            site = build_site(config, base_url="/wiki", url_style="dir")
+            page = next(page for page in site.pages if page.full_slug == "project")
+            html = build_page_html(page, site, base_url="/wiki", url_style="dir")
+
+            self.assertEqual(page.template_name, "Person.html")
+            self.assertIn('class="page-shell template-person"', html)
+            self.assertNotIn("Wiki:Template", html)
 
     def test_render_adds_github_heading_ids_to_all_heading_levels(self) -> None:
         html = render_wiki_markdown("# Title\n\n### API: read/write?\n")

--- a/uv.lock
+++ b/uv.lock
@@ -100,6 +100,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -187,6 +196,19 @@ html = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -216,6 +238,7 @@ dependencies = [
     { name = "pyshacl" },
     { name = "pyyaml" },
     { name = "rdflib" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -227,6 +250,7 @@ requires-dist = [
     { name = "pyshacl", specifier = ">=0.25.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rdflib", specifier = ">=7.0.0" },
+    { name = "rich", specifier = ">=13.7.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add wiki document support for YAML, YML, and JSON alongside Markdown
- add scoped \wiki render <file>\ and \wiki render --glob\ support
- add CURIE expansion for HTML microdata attributes
- add typed HTML rendering with infoboxes and \wiki:template\ support
- add \wiki view <file>\ terminal rendering with Rich and ASCII-safe output
- update docs, starter scaffold, and tests for the new rendering/document behavior
- remove loose blank node resolution (build_person_name_map + resolve_blank_nodes)
- bump to 0.1.5, add CHANGELOG

## Testing
- python -m pytest (179 passed)

## Notes
- this branch includes the local-only \eat: add typed rendering and data documents\ commit because local \main\ was ahead of \origin/main\ when the branch was created
- \wiki view\ output is ASCII-safe for Windows console compatibility