### PR TITLE
fix: float infobox beside article body (Wikipedia-style)

### DIFF
--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -56,8 +56,9 @@ header{border-bottom:1px solid #e5e7eb;padding-bottom:16px;margin-bottom:24px}
 .page-shell{max-width:100%}
 .wiki-article{max-width:100%}
 .wiki-article-title{margin-bottom:.25em}
-.wiki-article-body{display:flow-root}
-.wiki-article.has-infobox .infobox{float:right;clear:right;width:280px;max-width:min(280px,42%);margin:0 0 1em 1.5em;background:#fff;border:1px solid #dbe4f0;border-radius:12px;padding:18px;box-shadow:0 8px 24px rgba(15,23,42,.06)}
+.wiki-article-body.has-infobox{display:grid;grid-template-columns:minmax(0,1fr) 280px;column-gap:1.5em;align-items:start}
+.wiki-article-body.has-infobox .wiki-article-content{grid-column:1;grid-row:1;min-width:0}
+.wiki-article-body.has-infobox .infobox{grid-column:2;grid-row:1;align-self:start;width:100%}
 .wiki-article-content{min-width:0}
 .infobox{background:#fff;border:1px solid #dbe4f0;border-radius:12px;padding:18px;box-shadow:0 8px 24px rgba(15,23,42,.06)}
 .infobox h2{font-size:1rem;border:none;margin:0 0 14px}
@@ -73,7 +74,7 @@ header{border-bottom:1px solid #e5e7eb;padding-bottom:16px;margin-bottom:24px}
 .template-label{display:inline-block;margin-bottom:12px;padding:4px 10px;border-radius:999px;background:#e0f2fe;color:#075985;font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
 .index-header{margin-bottom:24px}
 .site-title{font-size:1.5em;font-weight:700;color:#1a1a2e;text-decoration:none}
-@media (max-width: 768px){.wiki-article.has-infobox .infobox{float:none;clear:none;width:100%;max-width:100%;margin:0 0 16px 0}}
+@media (max-width: 768px){.wiki-article-body.has-infobox{grid-template-columns:1fr;row-gap:16px}.wiki-article-body.has-infobox .wiki-article-content,.wiki-article-body.has-infobox .infobox{grid-column:1}.wiki-article-body.has-infobox .infobox{grid-row:1}.wiki-article-body.has-infobox .wiki-article-content{grid-row:2}}
 """.strip()
 
 METADATA_HIDDEN_FIELDS = {"@context", "@id", "id", "@type", "type", "template", "wiki:template"}
@@ -654,9 +655,9 @@ def _render_page_shell(
     title_html, body_html = _split_leading_h1(content_html, page.title)
     title_block = f'<div class="wiki-article-title">{title_html}</div>' if title_html else ""
     if infobox_html:
-        body_block = f"""<div class="wiki-article-body">
-{infobox_html}
+        body_block = f"""<div class="wiki-article-body has-infobox">
 <div class="wiki-article-content">{body_html}</div>
+{infobox_html}
 </div>"""
         article_class = "wiki-article has-infobox"
     else:

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -20,6 +20,7 @@ from .paths import iter_document_files, page_url, route_for_document_file
 from .parser import split_document_body
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+LEADING_H1_RE = re.compile(r"^\s*(<h1\b[^>]*>.*?</h1>)", re.IGNORECASE | re.DOTALL)
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
 
 INLINE_CSS = """
@@ -53,7 +54,12 @@ header{border-bottom:1px solid #e5e7eb;padding-bottom:16px;margin-bottom:24px}
 .page-meta{background:#f8fafc;border:1px solid #e5e7eb;border-radius:8px;padding:16px;margin-top:32px}
 .page-meta h2{font-size:1.1em;border:none;margin-top:0}
 .page-shell{max-width:100%}
-.infobox{float:right;max-width:300px;margin:0 0 16px 24px;background:#fff;border:1px solid #dbe4f0;border-radius:12px;padding:18px;box-shadow:0 8px 24px rgba(15,23,42,.06);clear:none}
+.wiki-article{max-width:100%}
+.wiki-article-title{margin-bottom:.25em}
+.wiki-article-body{display:flow-root}
+.wiki-article.has-infobox .infobox{float:right;clear:right;width:280px;max-width:min(280px,42%);margin:0 0 1em 1.5em;background:#fff;border:1px solid #dbe4f0;border-radius:12px;padding:18px;box-shadow:0 8px 24px rgba(15,23,42,.06)}
+.wiki-article-content{min-width:0}
+.infobox{background:#fff;border:1px solid #dbe4f0;border-radius:12px;padding:18px;box-shadow:0 8px 24px rgba(15,23,42,.06)}
 .infobox h2{font-size:1rem;border:none;margin:0 0 14px}
 .infobox dl{display:grid;grid-template-columns:minmax(96px,140px) 1fr;gap:10px 14px}
 .infobox dt{font-weight:600;color:#475569}
@@ -67,7 +73,7 @@ header{border-bottom:1px solid #e5e7eb;padding-bottom:16px;margin-bottom:24px}
 .template-label{display:inline-block;margin-bottom:12px;padding:4px 10px;border-radius:999px;background:#e0f2fe;color:#075985;font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
 .index-header{margin-bottom:24px}
 .site-title{font-size:1.5em;font-weight:700;color:#1a1a2e;text-decoration:none}
-@media (max-width: 768px){.infobox{float:none;max-width:100%;margin:0 0 16px 0}}
+@media (max-width: 768px){.wiki-article.has-infobox .infobox{float:none;clear:none;width:100%;max-width:100%;margin:0 0 16px 0}}
 """.strip()
 
 METADATA_HIDDEN_FIELDS = {"@context", "@id", "id", "@type", "type", "template", "wiki:template"}
@@ -481,12 +487,12 @@ def _build_infobox_html(page: VirtualPage, site: WikiSite, base_url: str, url_st
     rows = build_infobox_rows(page, site, base_url, url_style)
     if not rows:
         return ""
-    return f"""<section class="infobox page-meta">
+    return f"""<aside class="infobox">
 <h2>Infobox</h2>
 <dl>
 {''.join(f'<dt>{html_module.escape(row.label)}</dt><dd>{row.html}</dd>' for row in rows)}
 </dl>
-</section>"""
+</aside>"""
 
 
 def build_infobox_rows(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> list[InfoboxRow]:
@@ -625,6 +631,16 @@ def _template_label(page: VirtualPage) -> str:
     return f'<div class="template-label">{html_module.escape(label)}</div>'
 
 
+def _split_leading_h1(content_html: str, fallback_title: str) -> tuple[str, str]:
+    """Split rendered HTML into a full-width title and remaining body."""
+    match = LEADING_H1_RE.match(content_html)
+    if match:
+        return match.group(1), content_html[match.end() :].lstrip()
+    if fallback_title:
+        return f"<h1>{html_module.escape(fallback_title)}</h1>", content_html.strip()
+    return "", content_html.strip()
+
+
 def _render_page_shell(
     page: VirtualPage,
     content_html: str,
@@ -635,11 +651,22 @@ def _render_page_shell(
     template_label: str,
 ) -> str:
     template_class = html_module.escape(_template_stem(page.template_name))
+    title_html, body_html = _split_leading_h1(content_html, page.title)
+    title_block = f'<div class="wiki-article-title">{title_html}</div>' if title_html else ""
+    if infobox_html:
+        body_block = f"""<div class="wiki-article-body">
+{infobox_html}
+<div class="wiki-article-content">{body_html}</div>
+</div>"""
+        article_class = "wiki-article has-infobox"
+    else:
+        body_block = f'<div class="wiki-article-content">{body_html}</div>' if body_html else ""
+        article_class = "wiki-article"
+    article_body = f"{title_block}\n{body_block}".strip()
     return f"""<div class="page-shell template-{template_class}">
 {template_label}
-<article>
-{infobox_html}
-{content_html}
+<article class="{article_class}">
+{article_body}
 </article>
 {toc_html}
 {bl_html}

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -102,6 +102,42 @@ name: Bella Davidson
             self.assertIn('href="https://example.com/gregory-davidson"', html)
             self.assertIn("Infobox", html)
 
+    def test_infobox_uses_wikipedia_style_article_grid(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "Example.md").write_text(
+                """---
+type: schema:TechArticle
+name: Example page
+description: A sample article
+---
+# Example page
+
+Body text beside the infobox.
+""",
+                encoding="utf-8",
+            )
+            config = WikiConfig(input_dirs=[wiki], config_root=root)
+            site = build_site(config, base_url="/wiki", url_style="dir")
+            page = next(page for page in site.pages if page.full_slug == "Example")
+            html = build_page_html(page, site, base_url="/wiki", url_style="dir")
+
+            self.assertIn('class="wiki-article has-infobox"', html)
+            self.assertIn('<aside class="infobox">', html)
+            self.assertNotIn("infobox page-meta", html)
+            self.assertIn('<div class="wiki-article-title">', html)
+            self.assertIn('<div class="wiki-article-body">', html)
+            self.assertIn("float:right", html)
+            article_html = html[html.index("<article") : html.index("</article>") + len("</article>")]
+            title_pos = article_html.index("wiki-article-title")
+            body_pos = article_html.index("wiki-article-body")
+            infobox_pos = article_html.index('<aside class="infobox">')
+            content_pos = article_html.index("wiki-article-content")
+            self.assertLess(title_pos, body_pos)
+            self.assertLess(infobox_pos, content_pos)
+
     def test_template_frontmatter_override_is_applied(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -128,15 +128,15 @@ Body text beside the infobox.
             self.assertIn('<aside class="infobox">', html)
             self.assertNotIn("infobox page-meta", html)
             self.assertIn('<div class="wiki-article-title">', html)
-            self.assertIn('<div class="wiki-article-body">', html)
-            self.assertIn("float:right", html)
+            self.assertIn('class="wiki-article-body has-infobox"', html)
+            self.assertIn("grid-template-columns", html)
             article_html = html[html.index("<article") : html.index("</article>") + len("</article>")]
             title_pos = article_html.index("wiki-article-title")
             body_pos = article_html.index("wiki-article-body")
-            infobox_pos = article_html.index('<aside class="infobox">')
             content_pos = article_html.index("wiki-article-content")
+            infobox_pos = article_html.index('<aside class="infobox">')
             self.assertLess(title_pos, body_pos)
-            self.assertLess(infobox_pos, content_pos)
+            self.assertLess(content_pos, infobox_pos)
 
     def test_template_frontmatter_override_is_applied(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Fixes #26. Typed pages now render the frontmatter infobox in a Wikipedia-style layout: full-width title, infobox floated top-right beside the body, footer sections unchanged below the article.

## Changes

- Split rendered HTML into `wiki-article-title` and `wiki-article-body`
- Wrap infobox + content in a `display: flow-root` body container
- Use `<aside class="infobox">` without `page-meta` footer styles
- Float infobox right on desktop; stack full width on narrow viewports
- Add regression test for structure and float CSS

## Test plan

- [x] `pytest tests/test_site.py`
- [ ] `wiki -c docs/wiki.json serve --watch` → open `/wiki/farzapedia/` and confirm infobox is top-right beside intro text
- [ ] Hard refresh if a prior `serve` session was cached
