### PR TITLE
fix: honor urlStyle config for index and serve links

### DIFF
--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -384,16 +384,18 @@ def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_f
 @click.option("--port", default=8080, type=int, show_default=True, help="Port to serve on.")
 @click.option("--base-url", default=None,
               help="URL prefix for wiki pages. Empty string for root-level URLs.")
-@click.option("--style", default="dir", show_default=True,
-              type=click.Choice(["file", "dir"]), help="URL style: <slug>.html (file) or <slug>/ (dir).")
+@click.option("--style", "url_style", default=None,
+              type=click.Choice(["file", "dir"]), help="URL style: <slug>.html (file) or <slug>/ (dir). Defaults to urlStyle in config.")
 @click.option("--watch", is_flag=True, help="Watch files and auto-reload the browser on rebuild.")
 @click.pass_obj
-def serve(config: Context, host: str, port: int, base_url: str | None, style: str, watch: bool) -> None:
+def serve(config: Context, host: str, port: int, base_url: str | None, url_style: str | None, watch: bool) -> None:
     """Start a local HTTP server for browsing the wiki."""
     from .serve import run_server
     resolved_base_url = (config.base_url if base_url is None else base_url).rstrip("/")
+    resolved_url_style = config.url_style if url_style is None else url_style
     config.base_url = resolved_base_url
-    run_server(config, host=host, port=port, base_url=resolved_base_url, url_style=style, watch=watch)
+    config.url_style = resolved_url_style
+    run_server(config, host=host, port=port, base_url=resolved_base_url, url_style=resolved_url_style, watch=watch)
 
 
 @main.command()

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -163,16 +163,18 @@ def create_server(
     config: WikiConfig,
     host: str = "127.0.0.1",
     port: int = 8080,
-    base_url: str = "/wiki",
-    url_style: str = "dir",
+    base_url: str | None = None,
+    url_style: str | None = None,
     watch: bool = False,
 ) -> HTTPServer:
     """Build the site and return a configured HTTPServer (not yet started)."""
-    site = build_site(config, base_url=base_url, url_style=url_style)
+    resolved_base_url = config.base_url if base_url is None else base_url
+    resolved_url_style = config.url_style if url_style is None else url_style
+    site = build_site(config, base_url=resolved_base_url, url_style=resolved_url_style)
     WikiHandler.site = site
     WikiHandler.config = config
-    WikiHandler.base_url = base_url
-    WikiHandler.url_style = url_style
+    WikiHandler.base_url = resolved_base_url
+    WikiHandler.url_style = resolved_url_style
     WikiHandler.watch_enabled = watch
     WikiHandler.build_id = 0
 
@@ -189,12 +191,21 @@ def run_server(
     config: WikiConfig,
     host: str = "127.0.0.1",
     port: int = 8080,
-    base_url: str = "/wiki",
-    url_style: str = "dir",
+    base_url: str | None = None,
+    url_style: str | None = None,
     watch: bool = False,
 ) -> None:
     """Create and start the wiki HTTP server, blocking until shutdown."""
-    server = create_server(config, host=host, port=port, base_url=base_url, url_style=url_style, watch=watch)
+    resolved_base_url = config.base_url if base_url is None else base_url
+    resolved_url_style = config.url_style if url_style is None else url_style
+    server = create_server(
+        config,
+        host=host,
+        port=port,
+        base_url=resolved_base_url,
+        url_style=resolved_url_style,
+        watch=watch,
+    )
 
     if watch:
         watch_dirs = list(config.input_dirs) + [d for d in config.asset_dirs if d.exists()]
@@ -225,7 +236,11 @@ def run_server(
                     new = snapshot()
                     if new != mtimes:
                         mtimes = new
-                        WikiHandler.site = build_site(config, base_url=base_url, url_style=url_style)
+                        WikiHandler.site = build_site(
+                            config,
+                            base_url=resolved_base_url,
+                            url_style=resolved_url_style,
+                        )
                         WikiHandler.build_id += 1
                 except Exception:
                     continue

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -13,7 +13,7 @@ from urllib.parse import quote
 from markdown_it import MarkdownIt
 from mdit_py_plugins.wikilink import wikilink_plugin
 
-from .config import WikiConfig
+from .config import DEFAULT_URL_STYLE, WikiConfig
 from .headings import GitHubHeadingSlugger, heading_slug
 from .links import is_external_link, markdown_link_is_page, resolve_page_href, resolve_page_route
 from .paths import iter_document_files, page_url, route_for_document_file
@@ -90,7 +90,7 @@ def _url(base_url: str, slug: str, style: str) -> str:
 def render_wiki_markdown(
     text: str,
     base_url: str = "/wiki",
-    url_style: str = "file",
+    url_style: str = DEFAULT_URL_STYLE,
     markdown_flavor: str = "obsidian",
     current_route: str = "",
 ) -> str:
@@ -229,8 +229,8 @@ def extract_outline(markdown: str) -> list[TocItem]:
 
 def build_site(
     input_dirs: WikiConfig | list[Path] | Path,
-    base_url: str = "/wiki",
-    url_style: str = "file",
+    base_url: str | None = None,
+    url_style: str | None = None,
 ) -> WikiSite:
     """Build in-memory representation of the wiki site."""
     if isinstance(input_dirs, WikiConfig):
@@ -238,6 +238,8 @@ def build_site(
     else:
         dirs_arg = [input_dirs] if isinstance(input_dirs, Path) else input_dirs
         config = WikiConfig(input_dirs=dirs_arg)
+    resolved_base_url = config.base_url if base_url is None else base_url
+    resolved_url_style = config.url_style if url_style is None else url_style
     pages: list[VirtualPage] = []
 
     doc_files = sorted(iter_document_files(config))
@@ -273,8 +275,8 @@ def build_site(
 
         h1_html = render_wiki_markdown(
             body,
-            base_url=base_url,
-            url_style=url_style,
+            base_url=resolved_base_url,
+            url_style=resolved_url_style,
             markdown_flavor=config.markdown_flavor,
             current_route=doc_slug,
         )
@@ -300,7 +302,7 @@ def build_site(
     return WikiSite(pages=pages, pages_by_route=pages_by_route, routes_by_wiki_id=routes_by_wiki_id)
 
 
-def build_index_html(site: WikiSite, base_url: str = "/wiki", url_style: str = "file") -> str:
+def build_index_html(site: WikiSite, base_url: str = "/wiki", url_style: str = DEFAULT_URL_STYLE) -> str:
     """Compile root Index page HTML."""
     links_html = ""
     seen_files: set[str] = set()
@@ -332,7 +334,7 @@ def build_index_html(site: WikiSite, base_url: str = "/wiki", url_style: str = "
 </html>"""
 
 
-def build_page_html(page: VirtualPage, site: WikiSite, base_url: str = "/wiki", url_style: str = "file") -> str:
+def build_page_html(page: VirtualPage, site: WikiSite, base_url: str = "/wiki", url_style: str = DEFAULT_URL_STYLE) -> str:
     """Compile individual page HTML."""
     toc_html = _build_toc_html(page)
     bl_html = _build_backlinks_html(page, site, base_url, url_style)

--- a/src/wiki/view.py
+++ b/src/wiki/view.py
@@ -12,14 +12,17 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from .config import WikiConfig
 from .paths import route_for_document_file
 from .site import build_infobox_rows, build_site
 
 
 def render_document_view(file_path: Path, config: object, base_url: str | None = None, url_style: str | None = None) -> str:
     """Render a single wiki document as terminal-friendly rich text."""
-    resolved_base_url = "/wiki" if base_url is None else base_url
-    resolved_url_style = "dir" if url_style is None else url_style
+    if not isinstance(config, WikiConfig):
+        raise TypeError("render_document_view requires a WikiConfig instance")
+    resolved_base_url = config.base_url if base_url is None else base_url
+    resolved_url_style = config.url_style if url_style is None else url_style
     site = build_site(config, base_url=resolved_base_url, url_style=resolved_url_style)
     route = route_for_document_file(config, file_path)
     page = site.pages_by_route.get(route)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -75,8 +75,30 @@ class TestServe(unittest.TestCase):
         self.assertIn("All Pages", body)
         self.assertIn("Hello World", body)
         self.assertIn("Foo Bar", body)
-        self.assertIn("/wiki/hello-world", body)
-        self.assertIn("/wiki/foo-bar", body)
+        self.assertIn("/wiki/hello-world/", body)
+        self.assertIn("/wiki/foo-bar/", body)
+
+    def test_index_links_use_config_file_url_style(self) -> None:
+        self._write("hello-world.md", "# Hello World\n\nSome content.")
+        config = WikiConfig(input_dirs=[self.wiki_dir], url_style="file", config_root=self.wiki_dir)
+        port = _free_port()
+        server = create_server(config, host="127.0.0.1", port=port)
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        for _ in range(100):
+            try:
+                conn = HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except ConnectionRefusedError:
+                sleep(0.05)
+        status, body = self._get(port, "/")
+        server.shutdown()
+        self.assertEqual(status, 200)
+        self.assertIn("/wiki/hello-world.html", body)
+        self.assertNotIn("/wiki/hello-world/", body)
 
     def test_render_page(self) -> None:
         self._write("hello.md", "# Hello\n\nParagraph text.")

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from wiki.config import WikiConfig
-from wiki.site import build_page_html, build_site, render_wiki_markdown
+from wiki.site import build_index_html, build_page_html, build_site, render_wiki_markdown
 
 
 class TestWikiSite(unittest.TestCase):
@@ -200,6 +200,27 @@ name: Project Atlas
         )
 
         self.assertIn('href="/wiki/games/Pokemon_Diamond/#release-history"', html)
+
+    def test_build_index_html_respects_url_style(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "alice.md").write_text("# Alice\n", encoding="utf-8")
+            (wiki / "bob.md").write_text("# Bob\n", encoding="utf-8")
+
+            dir_config = WikiConfig(input_dirs=[wiki], config_root=root, url_style="dir")
+            dir_site = build_site(dir_config)
+            dir_index = build_index_html(dir_site, base_url="/wiki", url_style=dir_config.url_style)
+            self.assertIn('href="/wiki/alice/"', dir_index)
+            self.assertIn('href="/wiki/bob/"', dir_index)
+            self.assertNotIn(".html", dir_index)
+
+            file_config = WikiConfig(input_dirs=[wiki], config_root=root, url_style="file")
+            file_site = build_site(file_config)
+            file_index = build_index_html(file_site, base_url="/wiki", url_style=file_config.url_style)
+            self.assertIn('href="/wiki/alice.html"', file_index)
+            self.assertIn('href="/wiki/bob.html"', file_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- \wiki serve\ reads \urlStyle\ from config when \--style\ is omitted (aligned with \wiki build --url-style\).
- \uild_site\ resolves \url_style\ and \ase_url\ from \WikiConfig\ when not passed explicitly.
- Index and page HTML helpers default to \DEFAULT_URL_STYLE\ (\dir\) instead of \ile\, so the All Pages list uses \/wiki/page/\ links unless config says otherwise.

## Test plan
- [x] \	est_build_index_html_respects_url_style\
- [x] \	est_index_links_use_config_file_url_style\
- [x] Full \unittest discover\ passes