### PR TITLE
feat: cache RDF graph and incremental wiki render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ env/
 
 # Static site build output
 _site/
+
+# Wiki CLI graph and render caches
+.wiki/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- On-disk RDF graph cache (`.wiki/cache/`) keyed on vault fingerprint; `--no-cache` and `--rebuild-cache` flags on `query`, `render`, and `build --render`
+- Incremental `wiki render` (stale files only by default); `wiki render --all` for a full pass
+
 ## 0.1.5 — 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -119,24 +119,40 @@ wiki query "SELECT ?name WHERE { ?s schema:name ?name }" --jq 'results.bindings[
 ```
 
 ### `render`
-Identify all embedded SPARQL blocks in your markdown files, run their queries against the reasoning-expanded RDF graph, and replace the outputs inline. Under the "silence is golden" Unix philosophy, this command exits silently with code 0 upon success.
+Identify embedded SPARQL blocks in your markdown files, run their queries against the reasoning-expanded RDF graph, and replace the outputs inline. Under the "silence is golden" Unix philosophy, this command exits silently with code 0 upon success.
+
+By default, `wiki render` is **incremental**: it reloads the RDF graph from a local cache when the vault is unchanged, and only re-executes blocks in markdown files that are new or modified since the last successful render. Any change anywhere in the vault (or in `wiki.yaml`) marks all SPARQL pages stale so query results stay consistent.
 
 ```bash
-# Render silently (default)
+# Incremental render (default): stale files only
 wiki render
+
+# Full pass over every file with SPARQL blocks
+wiki render --all
 
 # Render with verbose summary output
 wiki render -v
 
-# Check if any files are stale without modifying them (non-zero exit on stale)
+# Check if any stale blocks need updating (non-zero exit on stale)
 wiki render --check
 
-# Render a single file during an edit loop
+# Render a single file during an edit loop (always processes that file)
 wiki render wiki/people/Gregory_House.md
 
 # Render only matching markdown files
 wiki render --glob "wiki/people/*.md"
+
+# Skip OWL-RL during editing when queries use asserted triples only
+wiki render --no-inference
+
+# Force a fresh graph build (ignore cache)
+wiki render --rebuild-cache
+
+# Disable graph cache read/write
+wiki render --no-cache
 ```
+
+**Graph cache:** Serialized graphs are stored under `.wiki/cache/` at the wiki config root (next to `wiki.yaml`). The cache key includes file mtimes and config fields that affect triple generation. Use `--rebuild-cache` after ontology changes if results look wrong.
 
 An embedded SPARQL block is defined in your markdown files like this:
 ````html

--- a/src/wiki/audit.py
+++ b/src/wiki/audit.py
@@ -104,7 +104,7 @@ def check_shacl_file(file_path: Path, context: WikiConfig, verbose: bool = False
     if not data:
         return None
 
-    source_graph = load_graph(context, infer=False) # Minimizing overhead for single file check, but loading pool shapes
+    source_graph = load_graph(context, infer=False)
     shapes_graph = load_shapes(source_graph)
     data_graph = frontmatter_to_graph(data, context, file_id=file_slug_for_path(context, file_path))
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -137,10 +137,22 @@ def check(config: Context, file: Optional[Path], fix: bool, verbose: bool, stric
 @click.option("-f", "--format", "output_format", type=FormatChoice(["table", "json", "csv", "tsv", "turtle", "n3", "markdown"], case_sensitive=False), default="table", show_default=True, help="Output format for query results.")
 @click.option("-o", "--output", type=click.Path(path_type=Path), help="Write output to specified file.")
 @click.option("--no-inference", is_flag=True, help="Skip OWL-RL inference.")
+@click.option("--no-cache", is_flag=True, help="Do not read or write the on-disk graph cache.")
+@click.option("--rebuild-cache", is_flag=True, help="Force rebuild and overwrite the graph cache.")
 @click.option("--jq", default=None, help="Extract values from JSON output using a key-path filter (implies -f json).")
 @click.option("-v", "--verbose", is_flag=True, help="Print graph statistics before query results.")
 @click.pass_obj
-def query(context: Context, query_args: tuple[str, ...], output_format: str, output: Optional[Path], no_inference: bool, jq: Optional[str], verbose: bool) -> None:
+def query(
+    context: Context,
+    query_args: tuple[str, ...],
+    output_format: str,
+    output: Optional[Path],
+    no_inference: bool,
+    no_cache: bool,
+    rebuild_cache: bool,
+    jq: Optional[str],
+    verbose: bool,
+) -> None:
     """Run a SPARQL SELECT or CONSTRUCT query."""
     if query_args:
         sparql_query = " ".join(query_args)
@@ -150,7 +162,12 @@ def query(context: Context, query_args: tuple[str, ...], output_format: str, out
         click.echo("Error: No query provided.", err=True)
         sys.exit(1)
 
-    graph = load_graph(context, infer=not no_inference)
+    graph = load_graph(
+        context,
+        infer=not no_inference,
+        use_cache=not no_cache,
+        rebuild_cache=rebuild_cache,
+    )
 
     if verbose:
         stats = graph_stats(graph)
@@ -178,22 +195,41 @@ def query(context: Context, query_args: tuple[str, ...], output_format: str, out
 @click.argument("file", required=False, type=click.Path(exists=True, path_type=Path))
 @click.option("--glob", "glob_filters", multiple=True, help="Render only markdown files matching this glob. Repeatable.")
 @click.option("--no-inference", is_flag=True, help="Skip OWL-RL inference.")
+@click.option("--no-cache", is_flag=True, help="Do not read or write the on-disk graph cache.")
+@click.option("--rebuild-cache", is_flag=True, help="Force rebuild and overwrite the graph cache.")
+@click.option("--all", "render_all", is_flag=True, help="Render SPARQL blocks in every matching file, not only stale ones.")
 @click.option("--check", is_flag=True, help="Check if inline SPARQL blocks are up to date without modifying files. Exits with non-zero code if any are stale.")
 @click.option("-v", "--verbose", is_flag=True, help="Print summary of updated files.")
 @click.pass_obj
-def render(context: Context, file: Optional[Path], glob_filters: tuple[str, ...], no_inference: bool, check: bool, verbose: bool) -> None:
+def render(
+    context: Context,
+    file: Optional[Path],
+    glob_filters: tuple[str, ...],
+    no_inference: bool,
+    no_cache: bool,
+    rebuild_cache: bool,
+    render_all: bool,
+    check: bool,
+    verbose: bool,
+) -> None:
     """Render inline SPARQL blocks in markdown files."""
     if file is not None and file.suffix.lower() != ".md":
         click.echo(f"Error: render only supports markdown files, got {file.name}.", err=True)
         sys.exit(1)
 
-    graph = load_graph(context, infer=not no_inference)
+    graph = load_graph(
+        context,
+        infer=not no_inference,
+        use_cache=not no_cache,
+        rebuild_cache=rebuild_cache,
+    )
     success_count, error_count, stale_files = render_markdown_files(
         context,
         graph,
         dry_run=check,
         file_filter=file,
         glob_filters=glob_filters,
+        render_all=render_all,
     )
     
     if check:
@@ -241,17 +277,34 @@ def view(config: Context, file: Path) -> None:
 @click.option("--url-style", type=click.Choice(["file", "dir"]), default=None,
               help="File naming: <slug>.html (file) or <slug>/index.html (dir).")
 @click.option("--render", is_flag=True, help="Run SPARQL dynamic block rendering on markdown files before building.")
+@click.option("--no-cache", is_flag=True, help="Do not read or write the on-disk graph cache.")
+@click.option("--rebuild-cache", is_flag=True, help="Force rebuild and overwrite the graph cache.")
 @click.option("--no-check", is_flag=True, help="Skip configurable wiki checks before building.")
 @click.option("-v", "--verbose", is_flag=True, help="Print generated file paths.")
 @click.pass_obj
-def build(config: Context, output_dir: Path, base_url: str | None, url_style: str | None, render: bool, no_check: bool, verbose: bool) -> None:
+def build(
+    config: Context,
+    output_dir: Path,
+    base_url: str | None,
+    url_style: str | None,
+    render: bool,
+    no_cache: bool,
+    rebuild_cache: bool,
+    no_check: bool,
+    verbose: bool,
+) -> None:
     """Build static HTML site from wiki documents."""
     from .assets import build_asset_manifest
     from .site import build_site, build_index_html, build_page_html
 
     if render:
-        graph = load_graph(config, infer=True)
-        success, errors, stale = render_markdown_files(config, graph)
+        graph = load_graph(
+            config,
+            infer=True,
+            use_cache=not no_cache,
+            rebuild_cache=rebuild_cache,
+        )
+        success, errors, stale = render_markdown_files(config, graph, render_all=True)
         if verbose and success > 0:
             click.echo(f"Rendered SPARQL dynamic blocks in {success} files.")
 

--- a/src/wiki/graph.py
+++ b/src/wiki/graph.py
@@ -335,18 +335,22 @@ _EXT_FORMAT_MAP = {
 }
 
 
-def load_graph(context: WikiConfig, infer: bool = True) -> Graph:
-    """Load all markdown, RDF, and data files into a unified Graph, resolving blank nodes."""
+def _build_graph_from_vault(context: WikiConfig) -> Graph:
+    """Load asserted triples from all vault sources without OWL-RL inference."""
     graph = Graph()
     context.bind_namespaces(graph)
 
     document_files = set(iter_document_files(context))
+
+    from .graph_cache import _is_cache_path
 
     for input_dir in context.input_dirs:
         if not input_dir.exists():
             continue
         for file_path in sorted(input_dir.rglob("*")):
             if not file_path.is_file() or context.is_excluded(file_path):
+                continue
+            if _is_cache_path(context, file_path):
                 continue
             try:
                 if file_path in document_files:
@@ -358,9 +362,31 @@ def load_graph(context: WikiConfig, infer: bool = True) -> Graph:
             except Exception as e:
                 logger.warning("Failed to process %s: %s", file_path.name, e)
 
+    return graph
+
+
+def load_graph(
+    context: WikiConfig,
+    infer: bool = True,
+    *,
+    use_cache: bool = True,
+    rebuild_cache: bool = False,
+) -> Graph:
+    """Load all markdown, RDF, and data files into a unified Graph, resolving blank nodes."""
+    from .graph_cache import load_cached_graph, save_cached_graph
+
+    if use_cache and not rebuild_cache:
+        cached = load_cached_graph(context, infer)
+        if cached is not None:
+            return cached
+
+    graph = _build_graph_from_vault(context)
     if infer:
         from .infer import apply_inference
         apply_inference(graph, context)
+
+    if use_cache:
+        save_cached_graph(context, graph, infer)
 
     return graph
 

--- a/src/wiki/graph_cache.py
+++ b/src/wiki/graph_cache.py
@@ -1,0 +1,184 @@
+"""Persistent RDF graph cache keyed on vault fingerprint."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+import shutil
+from pathlib import Path
+from typing import Any
+
+from rdflib import Graph
+
+from . import __version__
+from .config import WikiConfig
+
+CACHE_DIR_NAME = ".wiki/cache"
+MANIFEST_ASSERTED_NAME = "manifest-asserted.json"
+MANIFEST_INFERRED_NAME = "manifest-inferred.json"
+GRAPH_ASSERTED_NAME = "graph-asserted.pkl"
+GRAPH_INFERRED_NAME = "graph-inferred.pkl"
+RENDER_STATE_NAME = "render-state.json"
+
+
+def get_cache_dir(config: WikiConfig) -> Path:
+    return config.config_root / CACHE_DIR_NAME
+
+
+def _graph_cache_path(config: WikiConfig, infer: bool) -> Path:
+    name = GRAPH_INFERRED_NAME if infer else GRAPH_ASSERTED_NAME
+    return get_cache_dir(config) / name
+
+
+def _manifest_path(config: WikiConfig, infer: bool) -> Path:
+    name = MANIFEST_INFERRED_NAME if infer else MANIFEST_ASSERTED_NAME
+    return get_cache_dir(config) / name
+
+
+def _config_fingerprint(config: WikiConfig) -> dict[str, Any]:
+    namespaces = {
+        prefix: str(ns)
+        for prefix, ns in sorted(config.context.namespaces.items(), key=lambda item: item[0])
+    }
+    return {
+        "wiki_base": config.wiki_base,
+        "uri_ext": config.uri_ext,
+        "content_predicate": config.content_predicate,
+        "exclude": sorted(config.exclude),
+        "namespaces": namespaces,
+    }
+
+
+def _is_cache_path(config: WikiConfig, file_path: Path) -> bool:
+    cache_dir = get_cache_dir(config).resolve()
+    resolved = file_path.resolve()
+    return resolved == cache_dir or cache_dir in resolved.parents
+
+
+def iter_vault_files(config: WikiConfig) -> list[Path]:
+    """All non-excluded files under input_dirs that contribute to the graph."""
+    files: list[Path] = []
+    for input_dir in config.input_dirs:
+        if not input_dir.exists():
+            continue
+        for file_path in sorted(input_dir.rglob("*")):
+            if not file_path.is_file() or config.is_excluded(file_path):
+                continue
+            if _is_cache_path(config, file_path):
+                continue
+            files.append(file_path)
+    return files
+
+
+def vault_manifest(config: WikiConfig) -> dict[str, Any]:
+    """Build a stable manifest describing vault inputs (without infer flag)."""
+    entries = []
+    for file_path in iter_vault_files(config):
+        stat = file_path.stat()
+        entries.append(
+            {
+                "path": config.relative_to_root(file_path),
+                "size": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+            }
+        )
+    return {
+        "version": __version__,
+        "config": _config_fingerprint(config),
+        "files": entries,
+    }
+
+
+def vault_fingerprint(config: WikiConfig) -> str:
+    """SHA-256 hex digest of the vault manifest."""
+    payload = json.dumps(vault_manifest(config), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _read_manifest(config: WikiConfig, infer: bool) -> dict[str, Any] | None:
+    path = _manifest_path(config, infer)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def load_cached_graph(config: WikiConfig, infer: bool) -> Graph | None:
+    """Return a cached graph when manifest and serialized graph match the vault."""
+    current_fp = vault_fingerprint(config)
+    manifest = _read_manifest(config, infer)
+    graph_path = _graph_cache_path(config, infer)
+
+    if manifest is None or not graph_path.is_file():
+        return None
+
+    if manifest.get("vault_fingerprint") != current_fp:
+        return None
+    if manifest.get("version") != __version__:
+        return None
+
+    try:
+        with graph_path.open("rb") as handle:
+            loaded = pickle.load(handle)
+    except (OSError, pickle.PickleError, TypeError, AttributeError):
+        return None
+    if not isinstance(loaded, Graph):
+        return None
+    config.bind_namespaces(loaded)
+    return loaded
+
+
+def save_cached_graph(config: WikiConfig, graph: Graph, infer: bool) -> None:
+    """Serialize graph and write manifest for the current vault fingerprint."""
+    cache_dir = get_cache_dir(config)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    graph_path = _graph_cache_path(config, infer)
+    with graph_path.open("wb") as handle:
+        pickle.dump(graph, handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+    manifest = {
+        "version": __version__,
+        "vault_fingerprint": vault_fingerprint(config),
+        "infer": infer,
+    }
+    _manifest_path(config, infer).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def invalidate_cache(config: WikiConfig) -> None:
+    """Remove the entire graph cache directory."""
+    cache_dir = get_cache_dir(config)
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+
+
+def render_state_path(config: WikiConfig) -> Path:
+    return get_cache_dir(config) / RENDER_STATE_NAME
+
+
+def load_render_state(config: WikiConfig) -> dict[str, Any] | None:
+    path = render_state_path(config)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def save_render_state(config: WikiConfig, state: dict[str, Any]) -> None:
+    path = render_state_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+def file_stat_entry(config: WikiConfig, md_file: Path) -> dict[str, int]:
+    stat = md_file.stat()
+    return {
+        "mtime_ns": stat.st_mtime_ns,
+        "size": stat.st_size,
+    }

--- a/src/wiki/render.py
+++ b/src/wiki/render.py
@@ -12,6 +12,12 @@ from markdown_it import MarkdownIt
 
 from .format import run_query
 from mdit_py_plugins.wikilink import wikilink_plugin
+from .graph_cache import (
+    file_stat_entry,
+    load_render_state,
+    save_render_state,
+    vault_fingerprint,
+)
 from .paths import iter_markdown_files, page_routes, route_for_markdown_file
 
 # Matches the starting comment, query inside, and ending comment block with SPARQL inside
@@ -21,23 +27,92 @@ SPARQL_BLOCK_REGEX = re.compile(
 )
 
 
+def has_sparql_blocks(md_file: Path) -> bool:
+    """Return True if the markdown file contains at least one SPARQL block."""
+    try:
+        content = md_file.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return SPARQL_BLOCK_REGEX.search(content) is not None
+
+
+def _is_file_stale(
+    context: Any,
+    md_file: Path,
+    vault_fp: str,
+    state: dict[str, Any] | None,
+) -> bool:
+    if state is None or state.get("vault_fingerprint") != vault_fp:
+        return True
+    rel = context.relative_to_root(md_file)
+    recorded = (state.get("files") or {}).get(rel)
+    if not isinstance(recorded, dict):
+        return True
+    current = file_stat_entry(context, md_file)
+    return (
+        recorded.get("mtime_ns") != current["mtime_ns"]
+        or recorded.get("size") != current["size"]
+    )
+
+
+def select_markdown_files_for_render(
+    context: Any,
+    *,
+    file_filter: Path | None = None,
+    glob_filters: tuple[str, ...] = (),
+    render_all: bool = False,
+) -> list[Path]:
+    """Choose markdown files to process for SPARQL rendering."""
+    candidates = _select_markdown_files(context, file_filter=file_filter, glob_filters=glob_filters)
+    with_sparql = [md_file for md_file in candidates if has_sparql_blocks(md_file)]
+
+    explicit_target = file_filter is not None or bool(glob_filters)
+    if render_all or explicit_target:
+        return with_sparql
+
+    vault_fp = vault_fingerprint(context)
+    state = load_render_state(context)
+    return [md_file for md_file in with_sparql if _is_file_stale(context, md_file, vault_fp, state)]
+
+
+def _commit_render_state(context: Any, processed_files: list[Path]) -> None:
+    if not processed_files:
+        return
+    vault_fp = vault_fingerprint(context)
+    state = load_render_state(context) or {"vault_fingerprint": vault_fp, "files": {}}
+    files_state = dict(state.get("files") or {})
+    state["vault_fingerprint"] = vault_fp
+    for md_file in processed_files:
+        rel = context.relative_to_root(md_file)
+        files_state[rel] = file_stat_entry(context, md_file)
+    state["files"] = files_state
+    save_render_state(context, state)
+
+
 def render_markdown_files(
     context: Any,
     graph: Any,
     dry_run: bool = False,
     file_filter: Path | None = None,
     glob_filters: tuple[str, ...] = (),
+    render_all: bool = False,
 ) -> tuple[int, int, list[str]]:
-    """Iterate over all markdown files, parse and replace dynamic SPARQL sections inline.
+    """Iterate over markdown files, parse and replace dynamic SPARQL sections inline.
 
     Returns (success_count, error_count, stale_files).
     """
     success_count = 0
     error_count = 0
-    stale_files = []
-    markdown_files = _select_markdown_files(context, file_filter=file_filter, glob_filters=glob_filters)
+    stale_files: list[str] = []
+    markdown_files = select_markdown_files_for_render(
+        context,
+        file_filter=file_filter,
+        glob_filters=glob_filters,
+        render_all=render_all,
+    )
 
     known_slugs = {pr.route for pr in page_routes(context)}
+    processed_files: list[Path] = []
 
     for md_file in markdown_files:
         content = md_file.read_text(encoding="utf-8")
@@ -56,6 +131,7 @@ def render_markdown_files(
                 file_errors += 1
                 return str(match.group(0))
         new_content = SPARQL_BLOCK_REGEX.sub(replacer, content)
+        processed_files.append(md_file)
         if modified and new_content != content:
             try:
                 rel = str(md_file.relative_to(Path.cwd()))
@@ -67,6 +143,9 @@ def render_markdown_files(
                 md_file.write_text(new_content, encoding="utf-8")
                 success_count += 1
         error_count += file_errors
+
+    if not dry_run:
+        _commit_render_state(context, processed_files)
 
     return (success_count, error_count, stale_files)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -389,6 +389,64 @@ SELECT ?name WHERE {{ ?s <https://schema.org/name> ?name }}
             self.assertEqual(result.exit_code, 1)
             self.assertIn("render only supports markdown files", result.output)
 
+    def test_cli_render_incremental_skips_fresh_vault(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            source = """---
+type: Person
+name: Gregory
+---
+<!-- sparql:start -->
+```sparql
+SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
+```
+<!-- sparql:end -->
+"""
+            (wiki_dir / "gregory.md").write_text(source, encoding="utf-8")
+            runner.invoke(main, ["--input-dir", str(wiki_dir), "render", "--no-inference", "--all"])
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "render", "--no-inference", "-v"])
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Updated 0 files", result.output)
+
+    def test_cli_render_incremental_only_changed_file(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            source = """---
+type: Person
+name: {name}
+---
+<!-- sparql:start -->
+```sparql
+SELECT ?name WHERE {{ ?s <https://schema.org/name> ?name }}
+```
+<!-- sparql:end -->
+"""
+            alpha = wiki_dir / "alpha.md"
+            beta = wiki_dir / "beta.md"
+            alpha.write_text(source.format(name="Alpha"), encoding="utf-8")
+            beta.write_text(source.format(name="Beta"), encoding="utf-8")
+            runner.invoke(main, ["--input-dir", str(wiki_dir), "render", "--no-inference", "--all"])
+            beta_before = beta.read_text(encoding="utf-8")
+            rendered_alpha = alpha.read_text(encoding="utf-8")
+            self.assertIn("| Name |", rendered_alpha)
+            # Strip generated table but keep the query; mtime change marks alpha stale only.
+            stripped = """---
+type: Person
+name: Alpha
+---
+<!-- sparql:start -->
+```sparql
+SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
+```
+<!-- sparql:end -->
+"""
+            alpha.write_text(stripped, encoding="utf-8")
+            runner.invoke(main, ["--input-dir", str(wiki_dir), "render", "--no-inference"])
+            self.assertEqual(beta.read_text(encoding="utf-8"), beta_before)
+            self.assertIn("| Name |", alpha.read_text(encoding="utf-8"))
+
     def test_cli_view_markdown_document(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_graph_cache.py
+++ b/tests/test_graph_cache.py
@@ -1,0 +1,130 @@
+"""Tests for vault fingerprinting and on-disk graph cache."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from wiki.config import WikiConfig
+from wiki.graph import load_graph, graph_stats
+from wiki.graph_cache import (
+    get_cache_dir,
+    invalidate_cache,
+    load_cached_graph,
+    save_cached_graph,
+    vault_fingerprint,
+)
+
+
+class TestGraphCache(unittest.TestCase):
+    def _config(self, wiki_dir: Path) -> WikiConfig:
+        return WikiConfig(input_dirs=[wiki_dir], config_root=wiki_dir)
+
+    def test_cache_miss_then_hit(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            (wiki_dir / "page.md").write_text(
+                "---\ntype: Person\nname: Ada\n---\n",
+                encoding="utf-8",
+            )
+            config = self._config(wiki_dir)
+            invalidate_cache(config)
+
+            g1 = load_graph(config, infer=False, use_cache=True)
+            self.assertGreater(graph_stats(g1)["triples"], 0)
+
+            cached = load_cached_graph(config, infer=False)
+            self.assertIsNotNone(cached)
+            self.assertEqual(graph_stats(g1)["triples"], graph_stats(cached)["triples"])
+
+            g2 = load_graph(config, infer=False, use_cache=True)
+            self.assertEqual(graph_stats(g1)["triples"], graph_stats(g2)["triples"])
+
+    def test_file_change_invalidates_cache(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            page = wiki_dir / "page.md"
+            page.write_text("---\ntype: Person\nname: Ada\n---\n", encoding="utf-8")
+            config = self._config(wiki_dir)
+            invalidate_cache(config)
+
+            fp1 = vault_fingerprint(config)
+            load_graph(config, infer=False, use_cache=True)
+            self.assertIsNotNone(load_cached_graph(config, infer=False))
+
+            page.write_text("---\ntype: Person\nname: Grace\n---\n", encoding="utf-8")
+            fp2 = vault_fingerprint(config)
+            self.assertNotEqual(fp1, fp2)
+            self.assertIsNone(load_cached_graph(config, infer=False))
+
+    def test_no_cache_skips_persisted_graph(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            (wiki_dir / "page.md").write_text(
+                "---\ntype: Person\nname: Ada\n---\n",
+                encoding="utf-8",
+            )
+            config = self._config(wiki_dir)
+            invalidate_cache(config)
+
+            load_graph(config, infer=False, use_cache=False)
+            self.assertFalse(get_cache_dir(config).exists())
+
+    def test_infer_and_asserted_caches_are_separate(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            (wiki_dir / "page.md").write_text(
+                "---\ntype: Person\nname: Ada\n---\n",
+                encoding="utf-8",
+            )
+            config = self._config(wiki_dir)
+            invalidate_cache(config)
+
+            asserted = load_graph(config, infer=False, use_cache=True)
+            inferred = load_graph(config, infer=True, use_cache=True)
+            self.assertGreaterEqual(graph_stats(inferred)["triples"], graph_stats(asserted)["triples"])
+            self.assertIsNotNone(load_cached_graph(config, infer=False))
+            self.assertIsNotNone(load_cached_graph(config, infer=True))
+
+    def test_rebuild_cache_overwrites(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            page = wiki_dir / "page.md"
+            page.write_text("---\ntype: Person\nname: Ada\n---\n", encoding="utf-8")
+            config = self._config(wiki_dir)
+            invalidate_cache(config)
+
+            load_graph(config, infer=False, use_cache=True)
+            page.write_text("---\ntype: Person\nname: Grace\n---\n", encoding="utf-8")
+
+            stale_cached = load_cached_graph(config, infer=False)
+            self.assertIsNone(stale_cached)
+
+            rebuilt = load_graph(config, infer=False, use_cache=True, rebuild_cache=True)
+            self.assertIsNotNone(load_cached_graph(config, infer=False))
+            subjects = {str(s) for s in rebuilt.subjects()}
+            self.assertTrue(any("Grace" in s for s in subjects) or len(rebuilt) > 0)
+
+    def test_config_change_invalidates_fingerprint(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            (wiki_dir / "page.md").write_text(
+                "---\ntype: Person\nname: Ada\n---\n",
+                encoding="utf-8",
+            )
+            config_a = WikiConfig(input_dirs=[wiki_dir], config_root=wiki_dir, wiki_base="https://a.example/")
+            config_b = WikiConfig(input_dirs=[wiki_dir], config_root=wiki_dir, wiki_base="https://b.example/")
+            invalidate_cache(config_a)
+
+            fp_a = vault_fingerprint(config_a)
+            fp_b = vault_fingerprint(config_b)
+            self.assertNotEqual(fp_a, fp_b)
+
+            g = load_graph(config_a, infer=False, use_cache=True)
+            save_cached_graph(config_a, g, infer=False)
+            self.assertIsNone(load_cached_graph(config_b, infer=False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add on-disk graph cache under \.wiki/cache/\ keyed on vault fingerprint (asserted and inferred graphs stored separately).
- \wiki render\ is incremental by default: only stale markdown files with SPARQL blocks are processed; use \--all\ for a full pass.
- Add \--no-cache\ and \--rebuild-cache\ to \query\, \ender\, and \uild --render\.

## Test plan
- [x] \pytest tests/test_graph_cache.py tests/test_cli.py -k render\
- [x] Full test suite (191 passed)
- [ ] Second \wiki render\ on a large vault is fast (cache hit, 0 file updates with \-v\)
- [ ] Edit one page with SPARQL blocks; only that file re-renders
- [ ] \wiki render --check\ passes after a clean render

Closes #22