### PR TITLE
Add wiki serve SPARQL endpoint and sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ cd my-wiki
 # Interactive scaffold: creates wiki.yaml and wiki/ starter files
 wiki init
 
+# Also initialize a Git repository explicitly
+wiki init --git
+
 # Run unified checks (silent on success)
 wiki check
 
@@ -398,6 +401,9 @@ Interactively scaffold a new wiki workspace (`wiki.yaml` + starter `wiki/` conte
 
 ```bash
 wiki init
+
+# Also initialize a Git repository explicitly
+wiki init --git
 ```
 
 ### `export`

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ uv pip install -e /path/to/wiki
 
 Once installed globally, the `wiki` command is available in any directory that has a `wiki.yaml` configuration file. You can also point to a config explicitly with `-c <path>`.
 
+## Local development
+
+Use this repo's docs wiki as the main contributor sandbox.
+
+```bash
+# Install the project in editable mode
+uv pip install -e .
+
+# Run the docs wiki checks from the repo root
+wiki -c docs/wiki.yaml check
+
+# Start the docs wiki local preview with auto-reload
+python -m wiki -c docs/wiki.yaml serve --watch
+```
+
+Suggested contributor loop:
+
+- Edit files under `docs/wiki/`.
+- Use `python -m wiki -c docs/wiki.yaml serve --watch` for the main live-preview workflow.
+- Run `wiki -c docs/wiki.yaml check --strict -v` before landing documentation changes.
+- Use `wiki render --cache` or `wiki build --render --cache` when you want faster repeated one-shot SPARQL runs across fresh shells.
+
 ## Quickstart
 
 ```bash

--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -25,9 +25,12 @@ From an empty directory:
 
 ```bash
 wiki init
+
+# Also initialize a Git repository explicitly
+wiki init --git
 ```
 
-`wiki init` interactively writes `wiki.yaml` and a starter `wiki/` folder (`index.md`, `Person_Shape.md`). See [Wiki_Subcommand_init](Wiki_Subcommand_init.md) for prompts and `--force` behavior.
+`wiki init` interactively writes `wiki.yaml`, `README.md`, `index.html`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). By default it does not create a Git repository; use `--git` if you want that explicitly. See [Wiki_Subcommand_init](Wiki_Subcommand_init.md) for prompts and `--force` behavior.
 
 ## Daily workflow
 
@@ -38,8 +41,14 @@ wiki check
 # Refresh embedded SPARQL tables
 wiki render
 
+# Reuse a warm graph across repeated one-shot shells
+wiki render --cache
+
 # Preview at http://127.0.0.1:8080/wiki/ (default)
 wiki serve
+
+# Preferred long-lived preview loop while editing
+wiki serve --watch
 
 # Or build static HTML for deployment
 wiki build --output-dir _site
@@ -53,7 +62,8 @@ The published site under `docs/wiki/` is built with:
 
 ```bash
 wiki -c docs/wiki.yaml check --strict -v
-wiki -c docs/wiki.yaml render
+python -m wiki -c docs/wiki.yaml serve --watch
+wiki -c docs/wiki.yaml render --cache
 wiki -c docs/wiki.yaml build --output-dir _site --base-url /wiki
 ```
 

--- a/docs/wiki/Graph_Cache.md
+++ b/docs/wiki/Graph_Cache.md
@@ -1,7 +1,7 @@
 ---
 type: TechArticle
 name: Graph cache
-description: In-process RDF graph reuse across query and render in one CLI run.
+description: In-process RDF graph reuse plus optional on-disk warm-start across repeated CLI runs.
 ---
 
 # Graph cache
@@ -14,20 +14,31 @@ Each `wiki` process builds the vault RDF graph **once** (unless you pass `--relo
 
 OWL-RL expansion runs when inference is enabled (default for most commands; use `--no-inference` on `query` / `render` when debugging asserted triples only).
 
-## What is not cached
+## Cross-process reuse
 
-- There is **no on-disk** graph cache. A new shell always loads from vault files.
-- `--reload` forces a fresh build in the **same** process after you change sources mid-session.
+- By default, a new shell still starts cold.
+- Pass `--cache` on [Wiki_Subcommand_query](Wiki_Subcommand_query.md), [Wiki_Subcommand_render](Wiki_Subcommand_render.md), or `wiki build --render` to persist a warm graph under `.wiki/cache/`.
+- The persisted graph is reused only when the vault fingerprint still matches.
+- `--reload` forces a fresh build and refreshes the current cache entry.
 
 ## Long-lived workflows
 
 `wiki serve --watch` keeps one process alive. On file changes it rebuilds the graph, re-runs SPARQL rendering, and reloads the browser.
 
+## Tradeoffs
+
+- In-process reuse is still the default and simplest model.
+- `--cache` helps repeated one-shot commands across fresh shells.
+- The disk cache is invalidated automatically on vault or config changes.
+- `.wiki/cache/` is excluded from vault fingerprinting so cache artifacts do not invalidate themselves.
+
 ## CI tips
 
 ```bash
-wiki render --check    # fail if any inline block is stale
-wiki query "..."       # same graph as a prior render in one script if you chain in one shell
+wiki render --check            # fail if any inline block is stale
+wiki render --cache            # repeated one-shot render loop across shells
+wiki build --render --cache    # repeated one-shot render + build loop across shells
+wiki query "..."              # same graph as a prior render in one script if you chain in one shell
 ```
 
 ## Related

--- a/docs/wiki/HTML_Template.md
+++ b/docs/wiki/HTML_Template.md
@@ -1,114 +1,17 @@
 ---
 type: TechArticle
 name: HTML template reference
-description: Placeholders, CSS classes, IDs, and JS hooks for custom HTML shells.
+description: Moved under Wiki configuration.
 ---
 
 # HTML template reference
 
-When `html_template` is set in [Wiki_Configuration](Wiki_Configuration.md), the CLI uses your HTML file
-as the document shell instead of the built-in minimal fallback.
+This content now lives under [Wiki_Configuration](Wiki_Configuration.md#html-template).
 
-## Template strategy
+Use that page for:
 
-The current first-class template contract in this repository is the optional `index.html` / `html_template` shell.
-
-- The Wiki CLI owns the semantic markdown-to-HTML pipeline and placeholder contract.
-- This repository treats custom HTML shells as the primary built-in extension point for presentation.
-- Framework-specific sites such as Next.js, Mintlify, or other external docs stacks are better treated as downstream integrations or separate template repositories unless they need core CLI changes.
-
-## Minimal fallback
-
-Without a custom template, every page is rendered as:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>{page_title}</title>
-</head>
-<body>
-  <h1>{page_title}</h1>
-  {page_content}
-</body>
-</html>
-```
-
-No CSS, JavaScript, infobox, table of contents, backlinks, or categories are included.
-
-## Placeholders
-
-Replace `{key}` tokens in your HTML shell:
-
-| Placeholder               | Type         | Description                                                                                                |
-| ------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
-| `{page_title}`            | escaped text | Page title (frontmatter `name` or document H1).                                                            |
-| `{page_content}`          | raw HTML     | Rendered page body. For index pages: `<ul>…</ul>` of all page links. For articles: full rendered markdown. |
-| `{page_kind}`             | text string  | `"index"` or `"article"`. Use in JS or CSS selectors.                                                      |
-| `{body_class}`            | text string  | CSS classes for the `<body>` element. `wiki-index` for index, `wiki-page template-{slug}` for articles.    |
-| `{base_url}`              | text string  | URL prefix from config (e.g. `/wiki`).                                                                     |
-| `{url_style}`             | text string  | `"dir"` or `"file"`.                                                                                       |
-| `{inline_css}`            | raw CSS      | Wiki CLI's bundled Wikipedia-style CSS.                                                                    |
-| `{logo_svg}`              | raw SVG      | Wikipedia-style globe logo.                                                                                |
-| `{all_pages_json}`        | JSON string  | Array of `{slug, title}` for all pages.                                                                    |
-| `{current_slug_json}`     | JSON string  | Current page slug as a JSON string literal.                                                                |
-| `{template_label}`        | raw HTML     | Typed template label (e.g. `<div>Template: Person.html</div>`).                                            |
-| `{template_class}`        | text string  | CSS-safe slug of the template name.                                                                        |
-| `{infobox_html}`          | raw HTML     | Typed frontmatter property table (empty for index).                                                        |
-| `{toc_html}`              | raw HTML     | Table of contents `<div>` with heading links (empty if no headings).                                       |
-| `{backlinks_html}`        | raw HTML     | Backlinks section (empty if none).                                                                         |
-| `{categories_html}`       | raw HTML     | Category links `<div>` (empty if none).                                                                    |
-| `{sidebar_contents_html}` | raw HTML     | Extra sidebar links from typed properties.                                                                 |
-| `{source_markdown}`       | escaped text | Raw markdown source for the "view source" tab.                                                             |
-| `{metadata_tool_html}`    | raw HTML     | Sidebar "View metadata" link `<li>` (empty if no frontmatter).                                             |
-| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON)" `<li>` (empty if no frontmatter).                                                |
-| `{metadata_pane_html}`    | raw HTML     | Full metadata display pane `<div>` (empty if no frontmatter).                                              |
-
-Unknown `{placeholders}` are left untouched in the output. This lets you use literal braces in JavaScript or CSS without escaping.
-
-## Built-in CSS classes and IDs
-
-The wiki builder generates these selectors in the rendered page content:
-
-| Selector                    | Where                                                   |
-| --------------------------- | ------------------------------------------------------- |
-| `#firstHeading`             | The `<h1>` with the page title (in article body).       |
-| `#siteSub`                  | Subtitle line under the heading.                        |
-| `article`                   | Wrapper around the rendered markdown body.              |
-| `.toc` / `#toc`             | Table of contents container.                            |
-| `#catlinks` / `.catlinks`   | Category links box.                                     |
-| `.backlinks` / `#backlinks` | Backlinks section.                                      |
-| `.catlinks-label`           | Categories heading label.                               |
-| `.catlinks-list`            | Categories `<ul>`.                                      |
-| `.infobox`                  | Typed frontmatter property table.                       |
-| `.page-meta`                | Infobox class (used for styling).                       |
-| `.template-SLUG`            | Per-template class on infobox (e.g. `template-person`). |
-| `toclevel-N` / `lN`         | TOC list item classes for heading level N.              |
-| `.wikilink`                 | Internal wiki page links.                               |
-
-## JavaScript hooks
-
-The bundled seed template (`index.html` created by `wiki init`) provides:
-
-| Function                       | Purpose                                              |
-| ------------------------------ | ---------------------------------------------------- |
-| `switchTab(viewName)`          | Switch between read / talk / source / metadata tabs. |
-| `loadTalkNotes()`              | Load per-page local-storage notes.                   |
-| `saveTalkNotes()`              | Save per-page notes to localStorage.                 |
-| `clearTalkNotes()`             | Clear per-page notes.                                |
-| `copySourceCode()`             | Copy markdown source to clipboard.                   |
-| `toggleToc()`                  | Show/hide table of contents.                         |
-| `goToRandomArticle()`          | Navigate to a random page.                           |
-| `triggerSearch()`              | Execute search and navigate to first match.          |
-| `onSearchInput(e)`             | Live search suggestions.                             |
-| `handleSearchKey(e)`           | Keyboard navigation for search suggestions.          |
-| `navigateSearch(slug)`         | Navigate to a search result.                         |
-| `applyCategoryFilterFromUrl()` | Filter index page by `?category=` URL parameter.     |
-
-## Related
-
-- [Wiki_Configuration](Wiki_Configuration.md) — `html_template` config key.
-- [Wiki_Subcommand_build](Wiki_Subcommand_build.md) — building with custom templates.
-- [Wiki_Subcommand_init](Wiki_Subcommand_init.md) — seeding a custom template.
+- `html_template` config behavior
+- placeholder reference
+- built-in CSS selectors and IDs
+- bundled `index.html` JavaScript hooks
+- template strategy notes

--- a/docs/wiki/HTML_Template.md
+++ b/docs/wiki/HTML_Template.md
@@ -9,6 +9,14 @@ description: Placeholders, CSS classes, IDs, and JS hooks for custom HTML shells
 When `html_template` is set in [Wiki_Configuration](Wiki_Configuration.md), the CLI uses your HTML file
 as the document shell instead of the built-in minimal fallback.
 
+## Template strategy
+
+The current first-class template contract in this repository is the optional `index.html` / `html_template` shell.
+
+- The Wiki CLI owns the semantic markdown-to-HTML pipeline and placeholder contract.
+- This repository treats custom HTML shells as the primary built-in extension point for presentation.
+- Framework-specific sites such as Next.js, Mintlify, or other external docs stacks are better treated as downstream integrations or separate template repositories unless they need core CLI changes.
+
 ## Minimal fallback
 
 Without a custom template, every page is rendered as:

--- a/docs/wiki/RDF.md
+++ b/docs/wiki/RDF.md
@@ -14,6 +14,7 @@ RDF extends the linking structure of the Web to use URIs to name the relationshi
 
 ## Related standards
 
+- [RDF_XML](RDF_XML.md): The XML-based W3C serialization for RDF.
 - [Turtle](Turtle.md): A compact, human-friendly serialization syntax for RDF.
 - [JSON_LD](JSON_LD.md): A lightweight Linked Data format that uses JSON.
 - [Notation3](Notation3.md): A readable superset of Turtle, with rules and quoted graphs.

--- a/docs/wiki/RDF_XML.md
+++ b/docs/wiki/RDF_XML.md
@@ -1,0 +1,42 @@
+---
+type: TechArticle
+name: RDF XML
+description: XML-based W3C serialization for RDF graphs.
+---
+
+# RDF XML
+
+**RDF/XML** is a W3C-standard XML serialization of [RDF](RDF.md). It is designed primarily for **machine-to-machine interchange**, not for hand authoring. The underlying data model is still RDF triples; RDF/XML is just one concrete syntax for writing them down.
+
+Compared with [Turtle](Turtle.md) or [JSON_LD](JSON_LD.md), RDF/XML is usually more verbose and less pleasant for humans to edit directly, but it remains important for compatibility with older semantic-web tools and XML-oriented systems.
+
+## Hello world
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:schema="https://schema.org/">
+  <rdf:Description rdf:about="https://example.org/people/alice">
+    <schema:name>Alice</schema:name>
+  </rdf:Description>
+</rdf:RDF>
+```
+
+This expresses the RDF statement:
+
+- subject: `https://example.org/people/alice`
+- predicate: `https://schema.org/name`
+- object: `Alice`
+
+## In Wiki CLI
+
+Use `wiki export -f xml` when you want RDF serialized in RDF/XML form.
+
+## Related
+
+- [RDF](RDF.md)
+- [XML](XML.md)
+- [Turtle](Turtle.md)
+- [JSON_LD](JSON_LD.md)
+- [Wiki_Subcommand_export](Wiki_Subcommand_export.md)

--- a/docs/wiki/Semantic_Web.md
+++ b/docs/wiki/Semantic_Web.md
@@ -11,9 +11,11 @@ The **Semantic Web** is an extension of the World Wide Web through standards set
 To enable this, the Semantic Web stack relies on a group of technologies, including:
 
 - [RDF](RDF.md)
+- [RDF_XML](RDF_XML.md)
 - [Turtle](Turtle.md)
 - [JSON_LD](JSON_LD.md)
 - [Notation3](Notation3.md)
+- [XML](XML.md)
 - [SPARQL](SPARQL.md)
 - [OWL](OWL.md)
 - [SHACL](SHACL.md)

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -63,6 +63,23 @@ Page URLs come from paths under `inputDirs`: `wiki/Alice.md` → `/wiki/Alice/` 
 | `urlStyle`      | `url_style` | `dir`   | `dir` → `slug/index.html`; `file` → `slug.html`        |
 | `html_template` | —           | —       | Path (relative to config) to a custom HTML shell file  |
 
+## Serve API
+
+| Key               | Default        | Purpose                                              |
+| ----------------- | -------------- | ---------------------------------------------------- |
+| `serveApi.enabled`| `true`         | Enable or disable the SPARQL endpoint on `wiki serve` |
+| `serveApi.path`   | `/api/sparql`  | Reserved route for the SPARQL endpoint               |
+
+Example:
+
+```yaml
+serveApi:
+  enabled: true
+  path: /api/sparql
+```
+
+The endpoint reuses the same SPARQL engine as `wiki query`. It is read-only and intended for local or development-oriented use through `wiki serve`.
+
 When `html_template` is set, the CLI renders every page through that file using `{placeholder}` tokens.
 See [HTML_Template](HTML_Template.md) for the full list of placeholders and hooks.
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -67,7 +67,7 @@ Page URLs come from paths under `inputDirs`: `wiki/Alice.md` → `/wiki/Alice/` 
 
 | Key                | Default       | Purpose                                               |
 | ------------------ | ------------- | ----------------------------------------------------- |
-| `serveApi.enabled` | `true`        | Enable or disable the SPARQL endpoint on `wiki serve` |
+| `serveApi.enabled` | `false`       | Enable or disable the SPARQL endpoint on `wiki serve` |
 | `serveApi.path`    | `/api/sparql` | Reserved route for the SPARQL endpoint                |
 
 Example:
@@ -79,6 +79,10 @@ serveApi:
 ```
 
 The endpoint reuses the same SPARQL engine as `wiki query`. It is read-only and intended for local or development-oriented use through `wiki serve`.
+
+It is **opt-in by default** because enabling it exposes raw graph-query access in addition to HTML preview.
+
+`serveApi.path` must not collide with the effective `baseUrl` page routes or the watch endpoint. Invalid values such as `/`, `/wiki`, `/wiki/foo`, or `/wiki/__watch` are rejected when `wiki serve` starts.
 
 ## HTML template
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -80,8 +80,107 @@ serveApi:
 
 The endpoint reuses the same SPARQL engine as `wiki query`. It is read-only and intended for local or development-oriented use through `wiki serve`.
 
+## HTML template
+
 When `html_template` is set, the CLI renders every page through that file using `{placeholder}` tokens.
-See [HTML_Template](HTML_Template.md) for the full list of placeholders and hooks.
+
+### Template strategy
+
+The current first-class template contract in this repository is the optional `index.html` / `html_template` shell.
+
+- The Wiki CLI owns the semantic markdown-to-HTML pipeline and placeholder contract.
+- This repository treats custom HTML shells as the primary built-in extension point for presentation.
+- Framework-specific sites such as Next.js, Mintlify, or other external docs stacks are better treated as downstream integrations or separate template repositories unless they need core CLI changes.
+
+### Minimal fallback
+
+Without a custom template, every page is rendered as:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>{page_title}</title>
+</head>
+<body>
+  <h1>{page_title}</h1>
+  {page_content}
+</body>
+</html>
+```
+
+No CSS, JavaScript, infobox, table of contents, backlinks, or categories are included.
+
+### Placeholders
+
+Replace `{key}` tokens in your HTML shell:
+
+| Placeholder               | Type         | Description                                                                                                |
+| ------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
+| `{page_title}`            | escaped text | Page title (frontmatter `name` or document H1).                                                            |
+| `{page_content}`          | raw HTML     | Rendered page body. For index pages: `<ul>…</ul>` of all page links. For articles: full rendered markdown. |
+| `{page_kind}`             | text string  | `"index"` or `"article"`. Use in JS or CSS selectors.                                                  |
+| `{body_class}`            | text string  | CSS classes for the `<body>` element. `wiki-index` for index, `wiki-page template-{slug}` for articles.    |
+| `{base_url}`              | text string  | URL prefix from config (e.g. `/wiki`).                                                                     |
+| `{url_style}`             | text string  | `"dir"` or `"file"`.                                                                                   |
+| `{inline_css}`            | raw CSS      | Wiki CLI's bundled Wikipedia-style CSS.                                                                    |
+| `{logo_svg}`              | raw SVG      | Wikipedia-style globe logo.                                                                                |
+| `{all_pages_json}`        | JSON string  | Array of `{slug, title}` for all pages.                                                                    |
+| `{current_slug_json}`     | JSON string  | Current page slug as a JSON string literal.                                                                |
+| `{template_label}`        | raw HTML     | Typed template label (e.g. `<div>Template: Person.html</div>`).                                            |
+| `{template_class}`        | text string  | CSS-safe slug of the template name.                                                                        |
+| `{infobox_html}`          | raw HTML     | Typed frontmatter property table (empty for index).                                                        |
+| `{toc_html}`              | raw HTML     | Table of contents `<div>` with heading links (empty if no headings).                                       |
+| `{backlinks_html}`        | raw HTML     | Backlinks section (empty if none).                                                                         |
+| `{categories_html}`       | raw HTML     | Category links `<div>` (empty if none).                                                                    |
+| `{sidebar_contents_html}` | raw HTML     | Extra sidebar links from typed properties.                                                                 |
+| `{source_markdown}`       | escaped text | Raw markdown source for the "view source" tab.                                                           |
+| `{metadata_tool_html}`    | raw HTML     | Sidebar "View metadata" link `<li>` (empty if no frontmatter).                                           |
+| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON)" `<li>` (empty if no frontmatter).                                              |
+| `{metadata_pane_html}`    | raw HTML     | Full metadata display pane `<div>` (empty if no frontmatter).                                              |
+
+Unknown `{placeholders}` are left untouched in the output. This lets you use literal braces in JavaScript or CSS without escaping.
+
+### Built-in CSS classes and IDs
+
+The wiki builder generates these selectors in the rendered page content:
+
+| Selector                    | Where                                                   |
+| --------------------------- | ------------------------------------------------------- |
+| `#firstHeading`             | The `<h1>` with the page title (in article body).       |
+| `#siteSub`                  | Subtitle line under the heading.                        |
+| `article`                   | Wrapper around the rendered markdown body.              |
+| `.toc` / `#toc`             | Table of contents container.                            |
+| `#catlinks` / `.catlinks`   | Category links box.                                     |
+| `.backlinks` / `#backlinks` | Backlinks section.                                      |
+| `.catlinks-label`           | Categories heading label.                               |
+| `.catlinks-list`            | Categories `<ul>`.                                      |
+| `.infobox`                  | Typed frontmatter property table.                       |
+| `.page-meta`                | Infobox class (used for styling).                       |
+| `.template-SLUG`            | Per-template class on infobox (e.g. `template-person`). |
+| `toclevel-N` / `lN`         | TOC list item classes for heading level N.              |
+| `.wikilink`                 | Internal wiki page links.                               |
+
+### JavaScript hooks
+
+The bundled seed template (`index.html` created by `wiki init`) provides:
+
+| Function                       | Purpose                                              |
+| ------------------------------ | ---------------------------------------------------- |
+| `switchTab(viewName)`          | Switch between read / talk / source / metadata tabs. |
+| `loadTalkNotes()`              | Load per-page local-storage notes.                   |
+| `saveTalkNotes()`              | Save per-page notes to localStorage.                 |
+| `clearTalkNotes()`             | Clear per-page notes.                                |
+| `copySourceCode()`             | Copy markdown source to clipboard.                   |
+| `toggleToc()`                  | Show/hide table of contents.                         |
+| `goToRandomArticle()`          | Navigate to a random page.                           |
+| `triggerSearch()`              | Execute search and navigate to first match.          |
+| `onSearchInput(e)`             | Live search suggestions.                             |
+| `handleSearchKey(e)`           | Keyboard navigation for search suggestions.          |
+| `navigateSearch(slug)`         | Navigate to a search result.                         |
+| `applyCategoryFilterFromUrl()` | Filter index page by `?category=` URL parameter.     |
 
 If the configured template file does not exist, the built-in minimal shell is used silently — no error.
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -65,10 +65,10 @@ Page URLs come from paths under `inputDirs`: `wiki/Alice.md` → `/wiki/Alice/` 
 
 ## Serve API
 
-| Key               | Default        | Purpose                                              |
-| ----------------- | -------------- | ---------------------------------------------------- |
-| `serveApi.enabled`| `true`         | Enable or disable the SPARQL endpoint on `wiki serve` |
-| `serveApi.path`   | `/api/sparql`  | Reserved route for the SPARQL endpoint               |
+| Key                | Default       | Purpose                                               |
+| ------------------ | ------------- | ----------------------------------------------------- |
+| `serveApi.enabled` | `true`        | Enable or disable the SPARQL endpoint on `wiki serve` |
+| `serveApi.path`    | `/api/sparql` | Reserved route for the SPARQL endpoint                |
 
 Example:
 
@@ -121,10 +121,10 @@ Replace `{key}` tokens in your HTML shell:
 | ------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
 | `{page_title}`            | escaped text | Page title (frontmatter `name` or document H1).                                                            |
 | `{page_content}`          | raw HTML     | Rendered page body. For index pages: `<ul>…</ul>` of all page links. For articles: full rendered markdown. |
-| `{page_kind}`             | text string  | `"index"` or `"article"`. Use in JS or CSS selectors.                                                  |
+| `{page_kind}`             | text string  | `"index"` or `"article"`. Use in JS or CSS selectors.                                                      |
 | `{body_class}`            | text string  | CSS classes for the `<body>` element. `wiki-index` for index, `wiki-page template-{slug}` for articles.    |
 | `{base_url}`              | text string  | URL prefix from config (e.g. `/wiki`).                                                                     |
-| `{url_style}`             | text string  | `"dir"` or `"file"`.                                                                                   |
+| `{url_style}`             | text string  | `"dir"` or `"file"`.                                                                                       |
 | `{inline_css}`            | raw CSS      | Wiki CLI's bundled Wikipedia-style CSS.                                                                    |
 | `{logo_svg}`              | raw SVG      | Wikipedia-style globe logo.                                                                                |
 | `{all_pages_json}`        | JSON string  | Array of `{slug, title}` for all pages.                                                                    |
@@ -136,9 +136,9 @@ Replace `{key}` tokens in your HTML shell:
 | `{backlinks_html}`        | raw HTML     | Backlinks section (empty if none).                                                                         |
 | `{categories_html}`       | raw HTML     | Category links `<div>` (empty if none).                                                                    |
 | `{sidebar_contents_html}` | raw HTML     | Extra sidebar links from typed properties.                                                                 |
-| `{source_markdown}`       | escaped text | Raw markdown source for the "view source" tab.                                                           |
-| `{metadata_tool_html}`    | raw HTML     | Sidebar "View metadata" link `<li>` (empty if no frontmatter).                                           |
-| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON)" `<li>` (empty if no frontmatter).                                              |
+| `{source_markdown}`       | escaped text | Raw markdown source for the "view source" tab.                                                             |
+| `{metadata_tool_html}`    | raw HTML     | Sidebar "View metadata" link `<li>` (empty if no frontmatter).                                             |
+| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON)" `<li>` (empty if no frontmatter).                                                |
 | `{metadata_pane_html}`    | raw HTML     | Full metadata display pane `<div>` (empty if no frontmatter).                                              |
 
 Unknown `{placeholders}` are left untouched in the output. This lets you use literal braces in JavaScript or CSS without escaping.

--- a/docs/wiki/Wiki_Subcommand_build.md
+++ b/docs/wiki/Wiki_Subcommand_build.md
@@ -16,6 +16,7 @@ wiki build --output-dir _site --base-url /wiki -v
 wiki build --url-style file
 wiki build --base-url ''
 wiki build --render --reload
+wiki build --render --cache
 wiki build --no-check
 ```
 
@@ -28,6 +29,7 @@ wiki build --no-check
 | `--url-style`     | from config | `dir` or `file`                                                         |
 | `--render`        | off         | Run [Wiki_Subcommand_render](Wiki_Subcommand_render.md) before building |
 | `--reload`        | off         | Rebuild graph when using `--render`                                     |
+| `--cache`         | off         | Persist a warm graph under `.wiki/cache/` when using `--render`         |
 | `--no-check`      | off         | Skip pre-build [Wiki_Subcommand_check](Wiki_Subcommand_check.md)        |
 | `-v`, `--verbose` | off         | List output paths                                                       |
 

--- a/docs/wiki/Wiki_Subcommand_build.md
+++ b/docs/wiki/Wiki_Subcommand_build.md
@@ -45,8 +45,8 @@ Assets from `assetDirs` copy under the same prefix. See [Wiki_Configuration](Wik
 
 ## Custom HTML shell
 
-If your [Wiki_Configuration](Wiki_Configuration.md) sets `html_template`, every page is rendered through that file.
-The builder passes page content and metadata as `{placeholder}` tokens. See [HTML_Template](HTML_Template.md).
+If your [Wiki_Configuration](Wiki_Configuration.md#html-template) sets `html_template`, every page is rendered through that file.
+The builder passes page content and metadata as `{placeholder}` tokens.
 
 If the configured template file is missing, the fallback shell is used silently.
 
@@ -58,4 +58,4 @@ By default, checks must pass before the output directory is wiped and rebuilt. O
 
 - [Deploying_to_GitHub_Pages](Deploying_to_GitHub_Pages.md)
 - [Wiki_Subcommand_serve](Wiki_Subcommand_serve.md)
-- [HTML_Template](HTML_Template.md)
+- [Wiki_Configuration](Wiki_Configuration.md#html-template)

--- a/docs/wiki/Wiki_Subcommand_export.md
+++ b/docs/wiki/Wiki_Subcommand_export.md
@@ -33,5 +33,7 @@ Raw RDF formats (`turtle`, etc.) on a **single** file write plain serialization 
 
 ## Related
 
+- [RDF_XML](RDF_XML.md)
+- [XML](XML.md)
 - [JSON_LD](JSON_LD.md)
 - [Style_Guide](Style_Guide.md)

--- a/docs/wiki/Wiki_Subcommand_init.md
+++ b/docs/wiki/Wiki_Subcommand_init.md
@@ -6,7 +6,7 @@ description: Scaffold wiki.yaml and starter wiki pages interactively.
 
 # `wiki init`
 
-Create a new workspace in the **current directory**: `wiki.yaml` plus starter files under `wiki/`.
+Create a new workspace in the **current directory**: `wiki.yaml`, `README.md`, `index.html`, and starter files under `wiki/`.
 
 Does not use loaded WikiConfig; safe to run before a config exists.
 
@@ -15,6 +15,7 @@ Does not use loaded WikiConfig; safe to run before a config exists.
 ```bash
 wiki init
 wiki init --force
+wiki init --git
 ```
 
 ## Options
@@ -22,14 +23,13 @@ wiki init --force
 | Flag      | Description                                         |
 | --------- | --------------------------------------------------- |
 | `--force` | Overwrite existing `wiki.yaml` or non-empty `wiki/` |
+| `--git`   | Run `git init` after scaffolding                    |
 
 ## Prompts
 
 1. **Custom base URI prefix** (default `https://wiki.example.org/`) → `wikiBase` and `wiki:` in `context`
-1. **Include foaf prefix?** (default yes)
-1. **Include dc/dcterms prefixes?** (default yes)
 
-Always includes `schema` and `wiki` prefixes.
+Always includes `schema`, `wiki`, `foaf`, `dc`, `dcterms`, `sh`, and `xsd` prefixes.
 
 ## Generated config
 
@@ -41,8 +41,11 @@ Always includes `schema` and `wiki` prefixes.
 ## Generated files
 
 - `index.html` — packaged HTML shell with search, tabs, backlinks, and TOC. Edit to customize the look and feel.
-- `wiki/index.md` — vault home (`wiki:index`)
+- `README.md` — starter workspace overview and common commands
 - `wiki/Person_Shape.md` — starter `sh:NodeShape` for `schema:Person` with optional `wiki:template`
+- `wiki/Ethan_Davidson.md` — starter `schema:Person` example document
+
+By default `wiki init` does **not** create a Git repository. Use `--git` if you want to run `git init` immediately.
 
 ## Related
 

--- a/docs/wiki/Wiki_Subcommand_query.md
+++ b/docs/wiki/Wiki_Subcommand_query.md
@@ -20,16 +20,16 @@ wiki query "..." --cache
 
 ## Options
 
-| Flag              | Description                                                         |
-| ----------------- | ------------------------------------------------------------------- |
-| `QUERY`           | SPARQL string, or omit to read stdin                                |
-| `-f`, `--format`  | `table` (default), `json`, `csv`, `tsv`, `turtle`, `n3`, `markdown` |
-| `-o`, `--output`  | Write results to a file                                             |
-| `--no-inference`  | Skip OWL-RL                                                         |
-| `--reload`        | Rebuild in-memory graph in this process                             |
+| Flag              | Description                                                              |
+| ----------------- | ------------------------------------------------------------------------ |
+| `QUERY`           | SPARQL string, or omit to read stdin                                     |
+| `-f`, `--format`  | `table` (default), `json`, `csv`, `tsv`, `turtle`, `n3`, `markdown`      |
+| `-o`, `--output`  | Write results to a file                                                  |
+| `--no-inference`  | Skip OWL-RL                                                              |
+| `--reload`        | Rebuild in-memory graph in this process                                  |
 | `--cache`         | Persist a warm graph under `.wiki/cache/` for reuse across new processes |
-| `--jq`            | Filter JSON output (implies `-f json`)                              |
-| `-v`, `--verbose` | Print triple/subject counts first                                   |
+| `--jq`            | Filter JSON output (implies `-f json`)                                   |
+| `-v`, `--verbose` | Print triple/subject counts first                                        |
 
 ## Graph reuse
 

--- a/docs/wiki/Wiki_Subcommand_query.md
+++ b/docs/wiki/Wiki_Subcommand_query.md
@@ -15,6 +15,7 @@ wiki query "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
 cat query.sparql | wiki query -f json
 wiki query "SELECT ?name WHERE { ?s schema:name ?name }" --jq 'results.bindings[].name.value'
 wiki query "..." --reload -v
+wiki query "..." --cache
 ```
 
 ## Options
@@ -26,12 +27,13 @@ wiki query "..." --reload -v
 | `-o`, `--output`  | Write results to a file                                             |
 | `--no-inference`  | Skip OWL-RL                                                         |
 | `--reload`        | Rebuild in-memory graph in this process                             |
+| `--cache`         | Persist a warm graph under `.wiki/cache/` for reuse across new processes |
 | `--jq`            | Filter JSON output (implies `-f json`)                              |
 | `-v`, `--verbose` | Print triple/subject counts first                                   |
 
 ## Graph reuse
 
-See [Graph_Cache](Graph_Cache.md) — one graph per process unless `--reload`.
+See [Graph_Cache](Graph_Cache.md) — one graph per process unless `--reload`, plus optional cross-process warm-start via `--cache`.
 
 ## Related
 

--- a/docs/wiki/Wiki_Subcommand_render.md
+++ b/docs/wiki/Wiki_Subcommand_render.md
@@ -25,15 +25,15 @@ wiki render --cache
 
 ## Options
 
-| Flag              | Description                           |
-| ----------------- | ------------------------------------- |
-| `FILE`            | Single `.md` file only                |
-| `--glob`          | Repeatable; limit to matching paths   |
-| `--check`         | Dry-run; exit 1 if any block is stale |
-| `--no-inference`  | Skip OWL-RL                           |
-| `--reload`        | Rebuild graph before rendering        |
+| Flag              | Description                                                              |
+| ----------------- | ------------------------------------------------------------------------ |
+| `FILE`            | Single `.md` file only                                                   |
+| `--glob`          | Repeatable; limit to matching paths                                      |
+| `--check`         | Dry-run; exit 1 if any block is stale                                    |
+| `--no-inference`  | Skip OWL-RL                                                              |
+| `--reload`        | Rebuild graph before rendering                                           |
 | `--cache`         | Persist a warm graph under `.wiki/cache/` for reuse across new processes |
-| `-v`, `--verbose` | Print update counts                   |
+| `-v`, `--verbose` | Print update counts                                                      |
 
 ## Block format
 

--- a/docs/wiki/Wiki_Subcommand_render.md
+++ b/docs/wiki/Wiki_Subcommand_render.md
@@ -20,6 +20,7 @@ wiki render -v
 wiki render --check
 wiki render --no-inference
 wiki render --reload
+wiki render --cache
 ```
 
 ## Options
@@ -31,6 +32,7 @@ wiki render --reload
 | `--check`         | Dry-run; exit 1 if any block is stale |
 | `--no-inference`  | Skip OWL-RL                           |
 | `--reload`        | Rebuild graph before rendering        |
+| `--cache`         | Persist a warm graph under `.wiki/cache/` for reuse across new processes |
 | `-v`, `--verbose` | Print update counts                   |
 
 ## Block format

--- a/docs/wiki/Wiki_Subcommand_serve.md
+++ b/docs/wiki/Wiki_Subcommand_serve.md
@@ -57,11 +57,10 @@ The endpoint reuses the same query engine as [Wiki_Subcommand_query](Wiki_Subcom
 
 ## Custom HTML shell
 
-The same `html_template` from [Wiki_Configuration](Wiki_Configuration.md) applies to the dev server.
-See [HTML_Template](HTML_Template.md) for the placeholder reference.
+The same `html_template` from [Wiki_Configuration](Wiki_Configuration.md#html-template) applies to the dev server.
 
 ## Related
 
 - [Wiki_Subcommand_build](Wiki_Subcommand_build.md)
 - [Graph_Cache](Graph_Cache.md)
-- [HTML_Template](HTML_Template.md)
+- [Wiki_Configuration](Wiki_Configuration.md#html-template)

--- a/docs/wiki/Wiki_Subcommand_serve.md
+++ b/docs/wiki/Wiki_Subcommand_serve.md
@@ -30,6 +30,31 @@ python -m wiki serve --watch
 
 Default URL with config `baseUrl: /wiki`: `http://127.0.0.1:8080/wiki/`.
 
+## SPARQL endpoint
+
+When `serveApi.enabled` is on (default), `wiki serve` also exposes a read-only SPARQL endpoint at `serveApi.path` (default `/api/sparql`).
+
+Supported request forms:
+
+```bash
+# GET with query string
+curl "http://127.0.0.1:8080/api/sparql?query=SELECT%20*%20WHERE%20%7B%20?s%20?p%20?o%20%7D" \
+  -H "Accept: application/sparql-results+json"
+
+# POST raw SPARQL query
+curl "http://127.0.0.1:8080/api/sparql" \
+  -H "Content-Type: application/sparql-query" \
+  -H "Accept: text/turtle" \
+  --data "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"
+```
+
+Wiki-specific extensions:
+
+- `inference=true|false`
+- `reload=true|false`
+
+The endpoint reuses the same query engine as [Wiki_Subcommand_query](Wiki_Subcommand_query.md). SPARQL Update operations are rejected.
+
 ## Custom HTML shell
 
 The same `html_template` from [Wiki_Configuration](Wiki_Configuration.md) applies to the dev server.

--- a/docs/wiki/Wiki_Subcommand_serve.md
+++ b/docs/wiki/Wiki_Subcommand_serve.md
@@ -32,7 +32,15 @@ Default URL with config `baseUrl: /wiki`: `http://127.0.0.1:8080/wiki/`.
 
 ## SPARQL endpoint
 
-When `serveApi.enabled` is on (default), `wiki serve` also exposes a read-only SPARQL endpoint at `serveApi.path` (default `/api/sparql`).
+When `serveApi.enabled` is on, `wiki serve` also exposes a read-only SPARQL endpoint at `serveApi.path` (default `/api/sparql`).
+
+Example config:
+
+```yaml
+serveApi:
+  enabled: true
+  path: /api/sparql
+```
 
 Supported request forms:
 
@@ -54,6 +62,8 @@ Wiki-specific extensions:
 - `reload=true|false`
 
 The endpoint reuses the same query engine as [Wiki_Subcommand_query](Wiki_Subcommand_query.md). SPARQL Update operations are rejected.
+
+For safety, the endpoint is **disabled by default**. Its path is also validated at startup and rejected if it would shadow page routes or the `__watch` endpoint.
 
 ## Custom HTML shell
 

--- a/docs/wiki/XML.md
+++ b/docs/wiki/XML.md
@@ -1,0 +1,32 @@
+---
+type: TechArticle
+name: XML
+description: Extensible Markup Language, a structured text format for machine-readable documents.
+---
+
+# XML
+
+**XML** (Extensible Markup Language) is a W3C standard for representing structured data as nested tagged text. It is widely used for **machine-to-machine communication**, configuration, document exchange, and data interchange between systems that need a strict tree-shaped format.
+
+XML itself is only a syntax. Specific vocabularies such as [RDF_XML](RDF_XML.md), RSS, SVG, or custom application schemas define what the tags actually mean.
+
+## Hello world
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<greeting>
+  <message>Hello, world!</message>
+</greeting>
+```
+
+This is a tiny XML document with one root element (`greeting`) and one child element (`message`).
+
+## Why it matters here
+
+In the semantic-web context, XML is relevant because some W3C standards use it as their serialization surface. [RDF_XML](RDF_XML.md) is one example: RDF data encoded using XML syntax.
+
+## Related
+
+- [RDF_XML](RDF_XML.md)
+- [RDF](RDF.md)
+- [Semantic_Web](Semantic_Web.md)

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -467,8 +467,11 @@ def serve(config: Context, host: str, port: int, base_url: str | None, url_style
 
 @main.command()
 @click.option("--force", is_flag=True, help="Overwrite existing scaffold files if present.")
-def init(force: bool) -> None:
+@click.option("--git", "init_git", is_flag=True, help="Run git init after scaffolding the workspace.")
+def init(force: bool, init_git: bool) -> None:
     """Interactively scaffold a new wiki workspace in the current directory."""
+    import shutil
+    import subprocess
     import yaml
 
     cwd = Path.cwd()
@@ -577,7 +580,21 @@ def init(force: bool) -> None:
         except Exception as exc:
             click.echo(f"Warning: could not seed index.html template: {exc}", err=True)
 
-    click.echo("Initialized wiki.yaml, README.md, wiki/ starter files, and index.html template.")
+    if init_git:
+        if shutil.which("git") is None:
+            click.echo("Error: git was requested with --git, but no git executable was found on PATH.", err=True)
+            sys.exit(1)
+        try:
+            subprocess.run(["git", "init"], cwd=cwd, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.strip() if exc.stderr else "unknown git init error"
+            click.echo(f"Error: git init failed: {stderr}", err=True)
+            sys.exit(1)
+
+    message = "Initialized wiki.yaml, README.md, wiki/ starter files, and index.html template."
+    if init_git:
+        message += " Ran git init."
+    click.echo(message)
 
 
 @main.command()

--- a/src/wiki/config.py
+++ b/src/wiki/config.py
@@ -91,7 +91,7 @@ class WikiConfig:
         exclude: list[str] | None = None,
         config_root: str | Path | None = None,
         html_template: Path | None = None,
-        serve_api_enabled: bool = True,
+        serve_api_enabled: bool = False,
         serve_api_path: str = "/api/sparql",
     ) -> None:
         self.config_root = Path(config_root) if config_root is not None else Path.cwd()
@@ -197,7 +197,7 @@ class WikiConfig:
                             html_template_path = (p if p.is_absolute() else base_dir / p).resolve()
 
                         serve_api_data = data.get("serveApi") if isinstance(data.get("serveApi"), dict) else {}
-                        serve_api_enabled = serve_api_data.get("enabled", True)
+                        serve_api_enabled = serve_api_data.get("enabled", False)
                         if not isinstance(serve_api_enabled, bool):
                             serve_api_enabled = True
                         serve_api_path = serve_api_data.get("path", "/api/sparql")

--- a/src/wiki/config.py
+++ b/src/wiki/config.py
@@ -91,6 +91,8 @@ class WikiConfig:
         exclude: list[str] | None = None,
         config_root: str | Path | None = None,
         html_template: Path | None = None,
+        serve_api_enabled: bool = True,
+        serve_api_path: str = "/api/sparql",
     ) -> None:
         self.config_root = Path(config_root) if config_root is not None else Path.cwd()
         self.input_dirs = [Path(d) for d in (input_dirs or ["wiki"])]
@@ -107,6 +109,8 @@ class WikiConfig:
         self.url_style = normalize_url_style(url_style)
         self.exclude = [str(p).replace("\\", "/") for p in (exclude or [])]
         self.html_template = html_template
+        self.serve_api_enabled = bool(serve_api_enabled)
+        self.serve_api_path = normalize_api_path(serve_api_path)
 
     def relative_to_root(self, path: Path) -> str:
         """Return a config-root-relative POSIX path for glob matching."""
@@ -192,6 +196,12 @@ class WikiConfig:
                             p = Path(html_template_raw.strip())
                             html_template_path = (p if p.is_absolute() else base_dir / p).resolve()
 
+                        serve_api_data = data.get("serveApi") if isinstance(data.get("serveApi"), dict) else {}
+                        serve_api_enabled = serve_api_data.get("enabled", True)
+                        if not isinstance(serve_api_enabled, bool):
+                            serve_api_enabled = True
+                        serve_api_path = serve_api_data.get("path", "/api/sparql")
+
                         return cls(
                             input_dirs=[resolve(d) for d in input_data],
                             asset_dirs=[resolve(d) for d in asset_data],
@@ -206,6 +216,8 @@ class WikiConfig:
                             exclude=[str(p) for p in exclude_data],
                             config_root=base_dir,
                             html_template=html_template_path,
+                            serve_api_enabled=serve_api_enabled,
+                            serve_api_path=serve_api_path,
                         )
                 except Exception as e:
                     logger.warning("Failed to load config file %s: %s", config_path.name, e)
@@ -229,4 +241,12 @@ def normalize_url_style(value: str | None) -> str:
     if normalized not in VALID_URL_STYLES:
         raise ValueError(f"Invalid urlStyle: {value}")
     return normalized
+
+
+def normalize_api_path(value: str | None) -> str:
+    raw = str(value or "/api/sparql").strip()
+    if not raw.startswith("/"):
+        raise ValueError(f"Invalid serveApi.path: {value}")
+    normalized = raw.rstrip("/")
+    return normalized or "/"
 

--- a/src/wiki/format.py
+++ b/src/wiki/format.py
@@ -144,14 +144,20 @@ def run_query(graph: Any, query: str, output_format: str = "table", wiki_base: s
 
 
 _SPARQL_FORM_RE = re.compile(r"\b(SELECT|ASK|CONSTRUCT|DESCRIBE)\b", re.IGNORECASE)
-_SPARQL_UPDATE_RE = re.compile(r"\b(INSERT|DELETE|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD|WITH)\b", re.IGNORECASE)
+_SPARQL_UPDATE_RE = re.compile(r"^(INSERT|DELETE|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD|WITH)\b", re.IGNORECASE)
+
+
+def _strip_sparql_prelude(query: str) -> str:
+    """Remove comments and PREFIX/BASE declarations before query-form detection."""
+    text = re.sub(r"^[ \t]*(?:#.*)?$", "", query, flags=re.MULTILINE)
+    text = re.sub(r"\bPREFIX\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\bBASE\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    return text.lstrip()
 
 
 def detect_query_form(query: str) -> str:
     """Return the SPARQL query form keyword from *query*."""
-    text = re.sub(r"^[ \t]*(?:#.*)?$", "", query, flags=re.MULTILINE)
-    text = re.sub(r"\bPREFIX\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
-    text = re.sub(r"\bBASE\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    text = _strip_sparql_prelude(query)
     match = _SPARQL_FORM_RE.search(text)
     if not match:
         raise ValueError("Could not determine SPARQL query form.")
@@ -160,9 +166,7 @@ def detect_query_form(query: str) -> str:
 
 def is_sparql_update(query: str) -> bool:
     """Return True when *query* looks like a SPARQL Update operation."""
-    text = re.sub(r"^[ \t]*(?:#.*)?$", "", query, flags=re.MULTILINE)
-    text = re.sub(r"\bPREFIX\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
-    text = re.sub(r"\bBASE\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    text = _strip_sparql_prelude(query)
     return _SPARQL_UPDATE_RE.search(text) is not None
 
 

--- a/src/wiki/format.py
+++ b/src/wiki/format.py
@@ -144,6 +144,7 @@ def run_query(graph: Any, query: str, output_format: str = "table", wiki_base: s
 
 
 _SPARQL_FORM_RE = re.compile(r"\b(SELECT|ASK|CONSTRUCT|DESCRIBE)\b", re.IGNORECASE)
+_SPARQL_UPDATE_RE = re.compile(r"\b(INSERT|DELETE|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD|WITH)\b", re.IGNORECASE)
 
 
 def detect_query_form(query: str) -> str:
@@ -155,6 +156,14 @@ def detect_query_form(query: str) -> str:
     if not match:
         raise ValueError("Could not determine SPARQL query form.")
     return match.group(1).upper()
+
+
+def is_sparql_update(query: str) -> bool:
+    """Return True when *query* looks like a SPARQL Update operation."""
+    text = re.sub(r"^[ \t]*(?:#.*)?$", "", query, flags=re.MULTILINE)
+    text = re.sub(r"\bPREFIX\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\bBASE\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    return _SPARQL_UPDATE_RE.search(text) is not None
 
 
 def process_rdf_format(data: dict[str, Any], file_stem: str, context: Any, output_format: str) -> Any:

--- a/src/wiki/format.py
+++ b/src/wiki/format.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 
@@ -111,8 +112,8 @@ def markdown_format(result: Any, wiki_base: str | None = None, known_slugs: set[
 
 def run_query(graph: Any, query: str, output_format: str = "table", wiki_base: str | None = None, known_slugs: set[str] | None = None) -> str:
     """Run a SPARQL SELECT or CONSTRUCT query against the graph, returning formatted output."""
-    q = query.strip().upper()
-    is_construct = q.startswith("CONSTRUCT") or q.startswith("DESCRIBE")
+    query_form = detect_query_form(query)
+    is_construct = query_form in {"CONSTRUCT", "DESCRIBE"}
 
     if is_construct:
         result = graph.query(query)
@@ -140,6 +141,20 @@ def run_query(graph: Any, query: str, output_format: str = "table", wiki_base: s
         return markdown_format(result, wiki_base=wiki_base, known_slugs=known_slugs)
     else:
         return table_format(result)
+
+
+_SPARQL_FORM_RE = re.compile(r"\b(SELECT|ASK|CONSTRUCT|DESCRIBE)\b", re.IGNORECASE)
+
+
+def detect_query_form(query: str) -> str:
+    """Return the SPARQL query form keyword from *query*."""
+    text = re.sub(r"^[ \t]*(?:#.*)?$", "", query, flags=re.MULTILINE)
+    text = re.sub(r"\bPREFIX\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\bBASE\b\s+[^\n\r]+", "", text, flags=re.IGNORECASE)
+    match = _SPARQL_FORM_RE.search(text)
+    if not match:
+        raise ValueError("Could not determine SPARQL query form.")
+    return match.group(1).upper()
 
 
 def process_rdf_format(data: dict[str, Any], file_stem: str, context: Any, output_format: str) -> Any:

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -246,6 +246,7 @@ def create_server(
     """Build the site and return a configured HTTPServer (not yet started)."""
     resolved_base_url = config.base_url if base_url is None else base_url
     resolved_url_style = config.url_style if url_style is None else url_style
+    _validate_serve_api_path(config, resolved_base_url)
     site = build_site(config, base_url=resolved_base_url, url_style=resolved_url_style)
     WikiHandler.site = site
     WikiHandler.config = config
@@ -276,6 +277,25 @@ class _BadSparqlRequest(Exception):
         super().__init__(message)
         self.status_code = status_code
         self.message = message
+
+
+def _validate_serve_api_path(config: WikiConfig, base_url: str) -> None:
+    """Validate that the configured SPARQL route does not shadow page routes."""
+    if not config.serve_api_enabled:
+        return
+
+    api_path = config.serve_api_path.rstrip("/") or "/"
+    resolved_base = base_url.rstrip("/") if base_url else ""
+    watch_path = f"{resolved_base}/__watch" if resolved_base else "/__watch"
+
+    if api_path == "/":
+        raise ValueError("Invalid serveApi.path: '/' would shadow the entire server.")
+    if api_path == watch_path:
+        raise ValueError(f"Invalid serveApi.path: '{config.serve_api_path}' collides with the watch endpoint.")
+    if resolved_base and (api_path == resolved_base or api_path.startswith(f"{resolved_base}/")):
+        raise ValueError(
+            f"Invalid serveApi.path: '{config.serve_api_path}' collides with page routes under baseUrl '{resolved_base}'."
+        )
 
 
 def _parse_bool_flag(values: dict[str, list[str]], key: str, default: bool) -> bool:

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -15,8 +15,8 @@ from urllib.parse import parse_qs, urlsplit
 from typing import Any, Optional
 
 from .config import WikiConfig
-from .format import detect_query_form, run_query
-from .graph import load_graph, graph_stats
+from .format import detect_query_form, is_sparql_update, run_query
+from .graph import load_graph
 from .site import (
     WikiSite,
     VirtualPage,
@@ -354,6 +354,9 @@ def _parse_sparql_http_request(method: str, raw_query_string: str, headers: Any,
 
     if not query_text or not query_text.strip():
         raise _BadSparqlRequest(400, "Missing SPARQL query.")
+
+    if is_sparql_update(query_text):
+        raise _BadSparqlRequest(405, "SPARQL Update is not supported by this endpoint.")
 
     query_form = detect_query_form(query_text)
     if query_form in {"CONSTRUCT", "DESCRIBE"}:

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -11,9 +11,12 @@ import threading
 import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 from typing import Any, Optional
 
 from .config import WikiConfig
+from .format import detect_query_form, run_query
+from .graph import load_graph, graph_stats
 from .site import (
     WikiSite,
     VirtualPage,
@@ -33,10 +36,16 @@ class WikiHandler(BaseHTTPRequestHandler):
     watch_enabled: bool = False
     build_id: int = 0
     html_template: str | None = None
+    serve_api_enabled: bool = True
+    serve_api_path: str = "/api/sparql"
 
     def do_GET(self) -> None:
         base = self.base_url
-        parsed = re.sub(r"\?.*$", "", self.path)
+        parsed_url = urlsplit(self.path)
+        parsed = parsed_url.path
+        if parsed.rstrip("/") == self.serve_api_path.rstrip("/"):
+            self._handle_sparql_request("GET", parsed_url.query)
+            return
         if parsed.rstrip("/") == f"{base}/__watch":
             self._send_json({"build": self.build_id})
             return
@@ -61,6 +70,13 @@ class WikiHandler(BaseHTTPRequestHandler):
             return
         else:
             self._send_error(404, f"Not found: {self.path}")
+
+    def do_POST(self) -> None:
+        parsed_url = urlsplit(self.path)
+        if parsed_url.path.rstrip("/") == self.serve_api_path.rstrip("/"):
+            self._handle_sparql_request("POST", parsed_url.query)
+            return
+        self._send_error(404, f"Not found: {self.path}")
 
     def _serve_asset(self, rel_path: str) -> bool:
         """Try to serve a static asset from configured assetDirs. Returns True if served."""
@@ -133,6 +149,13 @@ class WikiHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_bytes(self, code: int, body: bytes, content_type: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def _send_error(self, code: int, message: str) -> None:
         body = f"""<!DOCTYPE html>
 <html lang="en">
@@ -153,6 +176,33 @@ class WikiHandler(BaseHTTPRequestHandler):
 
     def log_message(self, fmt: str, *args: Any) -> None:
         sys.stderr.write(f"[{self.log_date_time_string()}] {fmt % args}\n")
+
+    def _handle_sparql_request(self, method: str, raw_query_string: str) -> None:
+        if not self.serve_api_enabled:
+            self._send_error(404, "SPARQL endpoint is disabled.")
+            return
+
+        try:
+            sparql_query, output_format, infer, reload_graph = _parse_sparql_http_request(
+                method=method,
+                raw_query_string=raw_query_string,
+                headers=self.headers,
+                rfile=self.rfile,
+            )
+            query_form = detect_query_form(sparql_query)
+            if query_form not in {"SELECT", "ASK", "CONSTRUCT", "DESCRIBE"}:
+                self._send_error(405, f"Unsupported SPARQL query form: {query_form}")
+                return
+            graph = load_graph(self.config, infer=infer, reload=reload_graph)
+            result = run_query(graph, sparql_query, output_format=output_format, wiki_base=self.config.wiki_base)
+            body = result.encode("utf-8") if isinstance(result, str) else result
+            self._send_bytes(200, body, _response_content_type(query_form, output_format))
+        except _BadSparqlRequest as exc:
+            self._send_error(exc.status_code, exc.message)
+        except ValueError as exc:
+            self._send_error(400, str(exc))
+        except Exception as exc:
+            self._send_error(422, f"Query Execution Error: {exc}")
 
 
 def refresh_vault(
@@ -203,6 +253,8 @@ def create_server(
     WikiHandler.url_style = resolved_url_style
     WikiHandler.watch_enabled = watch
     WikiHandler.build_id = 0
+    WikiHandler.serve_api_enabled = config.serve_api_enabled
+    WikiHandler.serve_api_path = config.serve_api_path
 
     # Load custom HTML template if configured; silently fall back to default if file missing
     if config.html_template is not None and config.html_template.is_file():
@@ -217,6 +269,117 @@ def create_server(
     if not site.pages:
         print("Warning: no pages found. Ensure your wiki directory has .md, .yaml, .yml, or .json files.")
     return server
+
+
+class _BadSparqlRequest(Exception):
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+def _parse_bool_flag(values: dict[str, list[str]], key: str, default: bool) -> bool:
+    raw = values.get(key, [str(default).lower()])[-1].strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _best_accept_media(accept_header: str, supported: list[str]) -> str | None:
+    if not accept_header.strip():
+        return supported[0]
+    entries: list[tuple[float, str]] = []
+    for part in accept_header.split(","):
+        item = part.strip()
+        if not item:
+            continue
+        media = item
+        q = 1.0
+        if ";" in item:
+            media, *params = [p.strip() for p in item.split(";")]
+            for param in params:
+                if param.startswith("q="):
+                    try:
+                        q = float(param[2:])
+                    except ValueError:
+                        q = 0.0
+        entries.append((q, media.lower()))
+    entries.sort(key=lambda item: item[0], reverse=True)
+    supported_lower = {media.lower(): media for media in supported}
+    for _, media in entries:
+        if media in supported_lower:
+            return supported_lower[media]
+        if media == "*/*":
+            return supported[0]
+    return None
+
+
+def _response_content_type(query_form: str, output_format: str) -> str:
+    if query_form in {"CONSTRUCT", "DESCRIBE"}:
+        return {
+            "turtle": "text/turtle; charset=utf-8",
+            "n3": "text/n3; charset=utf-8",
+            "nt": "application/n-triples; charset=utf-8",
+        }.get(output_format, "text/turtle; charset=utf-8")
+    return {
+        "json": "application/sparql-results+json; charset=utf-8",
+        "csv": "text/csv; charset=utf-8",
+        "tsv": "text/tab-separated-values; charset=utf-8",
+    }.get(output_format, "application/sparql-results+json; charset=utf-8")
+
+
+def _parse_sparql_http_request(method: str, raw_query_string: str, headers: Any, rfile: Any) -> tuple[str, str, bool, bool]:
+    params = parse_qs(raw_query_string, keep_blank_values=True)
+    infer = _parse_bool_flag(params, "inference", True)
+    reload_graph = _parse_bool_flag(params, "reload", False)
+    query_text: str | None = None
+
+    if method == "GET":
+        query_text = params.get("query", [""])[-1]
+    elif method == "POST":
+        content_length = int(headers.get("Content-Length", "0") or "0")
+        raw_body = rfile.read(content_length).decode("utf-8") if content_length else ""
+        content_type = headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        if content_type == "application/sparql-query":
+            query_text = raw_body
+        elif content_type == "application/x-www-form-urlencoded":
+            body_params = parse_qs(raw_body, keep_blank_values=True)
+            query_text = body_params.get("query", [""])[-1]
+            if "inference" in body_params:
+                infer = _parse_bool_flag(body_params, "inference", infer)
+            if "reload" in body_params:
+                reload_graph = _parse_bool_flag(body_params, "reload", reload_graph)
+        else:
+            raise _BadSparqlRequest(400, f"Unsupported Content-Type: {content_type or 'missing'}")
+    else:
+        raise _BadSparqlRequest(405, f"Unsupported method: {method}")
+
+    if not query_text or not query_text.strip():
+        raise _BadSparqlRequest(400, "Missing SPARQL query.")
+
+    query_form = detect_query_form(query_text)
+    if query_form in {"CONSTRUCT", "DESCRIBE"}:
+        supported = ["text/turtle", "application/n-triples", "text/n3"]
+        default_format = "turtle"
+        format_map = {
+            "text/turtle": "turtle",
+            "application/n-triples": "nt",
+            "text/n3": "n3",
+        }
+    else:
+        supported = ["application/sparql-results+json", "text/csv", "text/tab-separated-values"]
+        default_format = "json"
+        format_map = {
+            "application/sparql-results+json": "json",
+            "text/csv": "csv",
+            "text/tab-separated-values": "tsv",
+        }
+
+    accept = headers.get("Accept", "")
+    media = _best_accept_media(accept, supported)
+    if media is None:
+        raise _BadSparqlRequest(406, f"Unsupported Accept header: {accept}")
+    output_format = format_map.get(media, default_format)
+
+    return query_text, output_format, infer, reload_graph
 
 
 def _snapshot_watch_dirs(watch_dirs: list[Path]) -> dict[str, float]:

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -219,6 +219,63 @@ def create_server(
     return server
 
 
+def _snapshot_watch_dirs(watch_dirs: list[Path]) -> dict[str, float]:
+    """Capture mtimes for watchable files under the provided roots."""
+    mtimes: dict[str, float] = {}
+    for root in watch_dirs:
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            if not p.is_file():
+                continue
+            if p.suffix.lower() not in {".md", ".yaml", ".yml", ".json", ".ttl", ".trig", ".nt", ".nq", ".rdf", ".xml", ".jsonld", ".html", ".htm", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".css", ".js", ".woff2", ".woff", ".ttf"}:
+                continue
+            try:
+                mtimes[str(p)] = p.stat().st_mtime
+            except OSError:
+                continue
+    return mtimes
+
+
+def _watch_for_changes(
+    config: WikiConfig,
+    *,
+    watch_dirs: list[Path],
+    base_url: str,
+    url_style: str,
+    mtimes: dict[str, float],
+    stop_event: threading.Event,
+    poll_interval: float = 0.5,
+    snapshot_func: Any | None = None,
+) -> None:
+    """Poll watched directories and refresh the in-memory site on changes."""
+    snapshot = _snapshot_watch_dirs if snapshot_func is None else snapshot_func
+    current_mtimes = mtimes
+
+    while not stop_event.is_set():
+        time.sleep(poll_interval)
+        try:
+            new = snapshot(watch_dirs)
+            if new != current_mtimes:
+                changed = {
+                    Path(k)
+                    for k in set(current_mtimes) | set(new)
+                    if current_mtimes.get(k) != new.get(k)
+                }
+                current_mtimes = new
+                WikiHandler.site = refresh_vault(
+                    config,
+                    changed_paths=changed,
+                    base_url=base_url,
+                    url_style=url_style,
+                )
+                WikiHandler.build_id += 1
+        except Exception:
+            if stop_event.is_set():
+                return
+            continue
+
+
 def run_server(
     config: WikiConfig,
     host: str = "127.0.0.1",
@@ -241,49 +298,22 @@ def run_server(
 
     if watch:
         watch_dirs = list(config.input_dirs) + [d for d in config.asset_dirs if d.exists()]
-
-        def snapshot() -> dict[str, float]:
-            mtimes: dict[str, float] = {}
-            for root in watch_dirs:
-                if not root.exists():
-                    continue
-                for p in root.rglob("*"):
-                    if not p.is_file():
-                        continue
-                    if p.suffix.lower() not in {".md", ".yaml", ".yml", ".json", ".ttl", ".trig", ".nt", ".nq", ".rdf", ".xml", ".jsonld", ".html", ".htm", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".css", ".js", ".woff2", ".woff", ".ttf"}:
-                        continue
-                    try:
-                        mtimes[str(p)] = p.stat().st_mtime
-                    except OSError:
-                        continue
-            return mtimes
-
-        mtimes = snapshot()
-
-        def watch_loop() -> None:
-            nonlocal mtimes
-            while True:
-                time.sleep(0.5)
-                try:
-                    new = snapshot()
-                    if new != mtimes:
-                        changed = {
-                            Path(k)
-                            for k in set(mtimes) | set(new)
-                            if mtimes.get(k) != new.get(k)
-                        }
-                        mtimes = new
-                        WikiHandler.site = refresh_vault(
-                            config,
-                            changed_paths=changed,
-                            base_url=resolved_base_url,
-                            url_style=resolved_url_style,
-                        )
-                        WikiHandler.build_id += 1
-                except Exception:
-                    continue
-
-        threading.Thread(target=watch_loop, daemon=True).start()
+        stop_event = threading.Event()
+        mtimes = _snapshot_watch_dirs(watch_dirs)
+        threading.Thread(
+            target=_watch_for_changes,
+            kwargs={
+                "config": config,
+                "watch_dirs": watch_dirs,
+                "base_url": resolved_base_url,
+                "url_style": resolved_url_style,
+                "mtimes": mtimes,
+                "stop_event": stop_event,
+            },
+            daemon=True,
+        ).start()
+    else:
+        stop_event = None
 
     print("Press Ctrl+C to stop.")
     try:
@@ -291,3 +321,7 @@ def run_server(
     except KeyboardInterrupt:
         print("\nShutting down server...")
         server.shutdown()
+    finally:
+        if stop_event is not None:
+            stop_event.set()
+        server.server_close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import time
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 from urllib.request import urlopen
 from urllib.error import URLError
 
@@ -348,6 +349,30 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
                 result3 = runner.invoke(main, ["init", "--force"],
                     input="https://wiki.example.org/\n", catch_exceptions=False)
                 self.assertEqual(result3.exit_code, 0)
+
+                self.assertFalse((Path(".git")).exists())
+
+    def test_cli_init_git_opt_in_runs_git_init(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            with runner.isolated_filesystem(temp_dir=tmpdir):
+                with patch("shutil.which", return_value="git"), patch("subprocess.run") as run_mock:
+                    result = runner.invoke(
+                        main,
+                        ["init", "--force", "--git"],
+                        input="https://wiki.example.org/\n",
+                        catch_exceptions=False,
+                    )
+
+                self.assertEqual(result.exit_code, 0)
+                run_mock.assert_called_once_with(
+                    ["git", "init"],
+                    cwd=Path.cwd(),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertIn("Ran git init", result.output)
 
     def test_cli_render_single_file_scope(self) -> None:
         runner = CliRunner()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,8 @@ class TestWikiConfig(unittest.TestCase):
         self.assertEqual(config.check.get("brokenLinks"), "warning")
         self.assertEqual(config.check.get("headings"), "off")
         self.assertIsNotNone(config.context)
+        self.assertTrue(config.serve_api_enabled)
+        self.assertEqual(config.serve_api_path, "/api/sparql")
 
     def test_wikiconfig_load_no_files(self) -> None:
         """Test WikiConfig.load falls back to defaults when no files exist."""
@@ -74,6 +76,7 @@ class TestWikiConfig(unittest.TestCase):
                 "filenamePattern": "[A-Za-z0-9_()-]+",
                 "baseUrl": "/docs",
                 "urlStyle": "file",
+                "serveApi": {"enabled": False, "path": "/sparql"},
                 "context": {
                     "custom_pref": "http://custom-pref.org/"
                 }
@@ -88,6 +91,8 @@ class TestWikiConfig(unittest.TestCase):
             self.assertEqual(config.filename_pattern, "[A-Za-z0-9_()-]+")
             self.assertEqual(config.base_url, "/docs")
             self.assertEqual(config.url_style, "file")
+            self.assertFalse(config.serve_api_enabled)
+            self.assertEqual(config.serve_api_path, "/sparql")
             self.assertIn("custom_pref", config.namespaces)
 
     def test_wikiconfig_load_json(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,7 +53,7 @@ class TestWikiConfig(unittest.TestCase):
         self.assertEqual(config.check.get("brokenLinks"), "warning")
         self.assertEqual(config.check.get("headings"), "off")
         self.assertIsNotNone(config.context)
-        self.assertTrue(config.serve_api_enabled)
+        self.assertFalse(config.serve_api_enabled)
         self.assertEqual(config.serve_api_path, "/api/sparql")
 
     def test_wikiconfig_load_no_files(self) -> None:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -10,12 +10,13 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from time import sleep
 from typing import Generator
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from wiki.cli import main
 from wiki.config import WikiConfig
-from wiki.serve import build_site, create_server, refresh_vault
+from wiki.serve import build_site, create_server, refresh_vault, run_server, _watch_for_changes, WikiHandler
 
 
 def _free_port() -> int:
@@ -325,6 +326,64 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
 
         self.assertRegex(page.read_text(encoding="utf-8"), r"\| Name\s+\|")
         self.assertGreater(len(site.pages), 0)
+
+    def test_watch_loop_repeated_refreshes_increment_build_id(self) -> None:
+        page = self._write("alpha.md", "# Alpha\n")
+        watch_dirs = [self.wiki_dir]
+        initial = {str(page): 1.0}
+        second = {str(page): 2.0}
+        third = {str(page): 3.0}
+        snapshots = iter([second, third, third])
+        stop_event = threading.Event()
+        WikiHandler.build_id = 0
+        WikiHandler.site = None
+
+        def fake_snapshot(_: list[Path]) -> dict[str, float]:
+            state = next(snapshots)
+            if state == third:
+                stop_event.set()
+            return state
+
+        refreshed_sites = [object(), object()]
+        with patch("wiki.serve.refresh_vault", side_effect=refreshed_sites) as refresh_mock, patch("wiki.serve.time.sleep", return_value=None):
+            _watch_for_changes(
+                WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir),
+                watch_dirs=watch_dirs,
+                base_url="/wiki",
+                url_style="dir",
+                mtimes=initial,
+                stop_event=stop_event,
+                poll_interval=0,
+                snapshot_func=fake_snapshot,
+            )
+
+        self.assertEqual(refresh_mock.call_count, 2)
+        self.assertEqual(WikiHandler.build_id, 2)
+        self.assertIs(WikiHandler.site, refreshed_sites[-1])
+
+    def test_run_server_shutdowns_on_keyboard_interrupt(self) -> None:
+        class FakeServer:
+            def __init__(self) -> None:
+                self.shutdown_called = False
+                self.server_close_called = False
+
+            def serve_forever(self) -> None:
+                raise KeyboardInterrupt
+
+            def shutdown(self) -> None:
+                self.shutdown_called = True
+
+            def server_close(self) -> None:
+                self.server_close_called = True
+
+        fake_server = FakeServer()
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir)
+
+        with patch("wiki.serve.create_server", return_value=fake_server):
+            run_server(config)
+
+        self.assertTrue(fake_server.shutdown_called)
+        self.assertTrue(fake_server.server_close_called)
 
 
 if __name__ == "__main__":

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -329,32 +329,62 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
 
     def test_sparql_endpoint_get_select_json(self) -> None:
         self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
-        for port in _serve_in_thread(self.wiki_dir):
-            conn = HTTPConnection("127.0.0.1", port, timeout=5)
-            conn.request("GET", "/api/sparql?query=SELECT%20%3Fname%20WHERE%20%7B%20%3Fs%20%3Chttps%3A//schema.org/name%3E%20%3Fname%20%7D", headers={"Accept": "application/sparql-results+json"})
-            resp = conn.getresponse()
-            body = resp.read().decode("utf-8")
-            conn.close()
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True)
+        port = _free_port()
+        server = create_server(config, host="127.0.0.1", port=port)
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        for _ in range(100):
+            try:
+                conn = HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except ConnectionRefusedError:
+                sleep(0.05)
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/sparql?query=SELECT%20%3Fname%20WHERE%20%7B%20%3Fs%20%3Chttps%3A//schema.org/name%3E%20%3Fname%20%7D", headers={"Accept": "application/sparql-results+json"})
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8")
+        conn.close()
+        server.shutdown()
+        server.server_close()
         self.assertEqual(resp.status, 200)
         self.assertEqual(resp.getheader("Content-Type"), "application/sparql-results+json; charset=utf-8")
         self.assertIn("Alice", body)
 
     def test_sparql_endpoint_post_construct_turtle(self) -> None:
         self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
-        for port in _serve_in_thread(self.wiki_dir):
-            conn = HTTPConnection("127.0.0.1", port, timeout=5)
-            conn.request(
-                "POST",
-                "/api/sparql",
-                body="CONSTRUCT { ?s <https://schema.org/name> ?name } WHERE { ?s <https://schema.org/name> ?name }",
-                headers={
-                    "Content-Type": "application/sparql-query",
-                    "Accept": "text/turtle",
-                },
-            )
-            resp = conn.getresponse()
-            body = resp.read().decode("utf-8")
-            conn.close()
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True)
+        port = _free_port()
+        server = create_server(config, host="127.0.0.1", port=port)
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        for _ in range(100):
+            try:
+                conn = HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except ConnectionRefusedError:
+                sleep(0.05)
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/sparql",
+            body="CONSTRUCT { ?s <https://schema.org/name> ?name } WHERE { ?s <https://schema.org/name> ?name }",
+            headers={
+                "Content-Type": "application/sparql-query",
+                "Accept": "text/turtle",
+            },
+        )
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8")
+        conn.close()
+        server.shutdown()
+        server.server_close()
         self.assertEqual(resp.status, 200)
         self.assertEqual(resp.getheader("Content-Type"), "text/turtle; charset=utf-8")
         self.assertIn("schema:name", body)
@@ -389,7 +419,7 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
     def test_sparql_endpoint_custom_path(self) -> None:
         self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
         port = _free_port()
-        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_path="/sparql")
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True, serve_api_path="/sparql")
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
         t.start()
@@ -414,37 +444,91 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
 
     def test_sparql_endpoint_rejects_update_queries(self) -> None:
         self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
-        for port in _serve_in_thread(self.wiki_dir):
-            conn = HTTPConnection("127.0.0.1", port, timeout=5)
-            conn.request(
-                "POST",
-                "/api/sparql",
-                body="INSERT DATA { <https://example.org/a> <https://schema.org/name> \"Alice\" }",
-                headers={
-                    "Content-Type": "application/sparql-query",
-                    "Accept": "application/sparql-results+json",
-                },
-            )
-            resp = conn.getresponse()
-            body = resp.read().decode("utf-8")
-            conn.close()
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True)
+        port = _free_port()
+        server = create_server(config, host="127.0.0.1", port=port)
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        for _ in range(100):
+            try:
+                conn = HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except ConnectionRefusedError:
+                sleep(0.05)
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/sparql",
+            body="INSERT DATA { <https://example.org/a> <https://schema.org/name> \"Alice\" }",
+            headers={
+                "Content-Type": "application/sparql-query",
+                "Accept": "application/sparql-results+json",
+            },
+        )
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8")
+        conn.close()
+        server.shutdown()
+        server.server_close()
         self.assertEqual(resp.status, 405)
         self.assertIn("SPARQL Update is not supported", body)
 
     def test_sparql_endpoint_allows_literals_with_update_keywords(self) -> None:
         self._write("person.md", "---\ntype: Person\nname: Delete\n---\n")
-        for port in _serve_in_thread(self.wiki_dir):
-            conn = HTTPConnection("127.0.0.1", port, timeout=5)
-            conn.request(
-                "GET",
-                "/api/sparql?query=SELECT%20%3Fname%20WHERE%20%7B%20%3Fs%20%3Chttps%3A//schema.org/name%3E%20%3Fname%20.%20FILTER(%3Fname%20%3D%20%22Delete%22)%20%7D",
-                headers={"Accept": "application/sparql-results+json"},
-            )
-            resp = conn.getresponse()
-            body = resp.read().decode("utf-8")
-            conn.close()
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True)
+        port = _free_port()
+        server = create_server(config, host="127.0.0.1", port=port)
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        for _ in range(100):
+            try:
+                conn = HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except ConnectionRefusedError:
+                sleep(0.05)
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "GET",
+            "/api/sparql?query=SELECT%20%3Fname%20WHERE%20%7B%20%3Fs%20%3Chttps%3A//schema.org/name%3E%20%3Fname%20.%20FILTER(%3Fname%20%3D%20%22Delete%22)%20%7D",
+            headers={"Accept": "application/sparql-results+json"},
+        )
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8")
+        conn.close()
+        server.shutdown()
+        server.server_close()
         self.assertEqual(resp.status, 200)
         self.assertIn("Delete", body)
+
+    def test_sparql_endpoint_invalid_root_path_rejected(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True, serve_api_path="/")
+        with self.assertRaisesRegex(ValueError, "shadow the entire server"):
+            create_server(config, host="127.0.0.1", port=_free_port())
+
+    def test_sparql_endpoint_invalid_base_url_path_rejected(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True, serve_api_path="/wiki")
+        with self.assertRaisesRegex(ValueError, "collides with page routes"):
+            create_server(config, host="127.0.0.1", port=_free_port())
+
+    def test_sparql_endpoint_invalid_page_subpath_rejected(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True, serve_api_path="/wiki/foo")
+        with self.assertRaisesRegex(ValueError, "collides with page routes"):
+            create_server(config, host="127.0.0.1", port=_free_port())
+
+    def test_sparql_endpoint_invalid_watch_path_rejected(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=True, serve_api_path="/wiki/__watch")
+        with self.assertRaisesRegex(ValueError, "collides with the watch endpoint"):
+            create_server(config, host="127.0.0.1", port=_free_port())
 
     def test_watch_loop_repeated_refreshes_increment_build_id(self) -> None:
         page = self._write("alpha.md", "# Alpha\n")

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -327,6 +327,91 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
         self.assertRegex(page.read_text(encoding="utf-8"), r"\| Name\s+\|")
         self.assertGreater(len(site.pages), 0)
 
+    def test_sparql_endpoint_get_select_json(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        for port in _serve_in_thread(self.wiki_dir):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("GET", "/api/sparql?query=SELECT%20%3Fname%20WHERE%20%7B%20%3Fs%20%3Chttps%3A//schema.org/name%3E%20%3Fname%20%7D", headers={"Accept": "application/sparql-results+json"})
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8")
+            conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.getheader("Content-Type"), "application/sparql-results+json; charset=utf-8")
+        self.assertIn("Alice", body)
+
+    def test_sparql_endpoint_post_construct_turtle(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        for port in _serve_in_thread(self.wiki_dir):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request(
+                "POST",
+                "/api/sparql",
+                body="CONSTRUCT { ?s <https://schema.org/name> ?name } WHERE { ?s <https://schema.org/name> ?name }",
+                headers={
+                    "Content-Type": "application/sparql-query",
+                    "Accept": "text/turtle",
+                },
+            )
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8")
+            conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.getheader("Content-Type"), "text/turtle; charset=utf-8")
+        self.assertIn("schema:name", body)
+        self.assertIn("Alice", body)
+
+    def test_sparql_endpoint_can_be_disabled(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        port = _free_port()
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_enabled=False)
+        server = create_server(config, host="127.0.0.1", port=port)
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        for _ in range(100):
+            try:
+                conn = HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except ConnectionRefusedError:
+                sleep(0.05)
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/sparql?query=SELECT%20*%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D")
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8")
+        conn.close()
+        server.shutdown()
+        server.server_close()
+        self.assertEqual(resp.status, 404)
+        self.assertIn("SPARQL endpoint is disabled", body)
+
+    def test_sparql_endpoint_custom_path(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        port = _free_port()
+        config = WikiConfig(input_dirs=[self.wiki_dir], config_root=self.wiki_dir, serve_api_path="/sparql")
+        server = create_server(config, host="127.0.0.1", port=port)
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        for _ in range(100):
+            try:
+                conn = HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/")
+                conn.getresponse()
+                conn.close()
+                break
+            except ConnectionRefusedError:
+                sleep(0.05)
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/sparql?query=SELECT%20%3Fname%20WHERE%20%7B%20%3Fs%20%3Chttps%3A//schema.org/name%3E%20%3Fname%20%7D", headers={"Accept": "application/sparql-results+json"})
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8")
+        conn.close()
+        server.shutdown()
+        server.server_close()
+        self.assertEqual(resp.status, 200)
+        self.assertIn("Alice", body)
+
     def test_watch_loop_repeated_refreshes_increment_build_id(self) -> None:
         page = self._write("alpha.md", "# Alpha\n")
         watch_dirs = [self.wiki_dir]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -412,6 +412,25 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
         self.assertEqual(resp.status, 200)
         self.assertIn("Alice", body)
 
+    def test_sparql_endpoint_rejects_update_queries(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Alice\n---\n")
+        for port in _serve_in_thread(self.wiki_dir):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request(
+                "POST",
+                "/api/sparql",
+                body="INSERT DATA { <https://example.org/a> <https://schema.org/name> \"Alice\" }",
+                headers={
+                    "Content-Type": "application/sparql-query",
+                    "Accept": "application/sparql-results+json",
+                },
+            )
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8")
+            conn.close()
+        self.assertEqual(resp.status, 405)
+        self.assertIn("SPARQL Update is not supported", body)
+
     def test_watch_loop_repeated_refreshes_increment_build_id(self) -> None:
         page = self._write("alpha.md", "# Alpha\n")
         watch_dirs = [self.wiki_dir]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -431,6 +431,21 @@ SELECT ?name WHERE { ?s <https://schema.org/name> ?name }
         self.assertEqual(resp.status, 405)
         self.assertIn("SPARQL Update is not supported", body)
 
+    def test_sparql_endpoint_allows_literals_with_update_keywords(self) -> None:
+        self._write("person.md", "---\ntype: Person\nname: Delete\n---\n")
+        for port in _serve_in_thread(self.wiki_dir):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request(
+                "GET",
+                "/api/sparql?query=SELECT%20%3Fname%20WHERE%20%7B%20%3Fs%20%3Chttps%3A//schema.org/name%3E%20%3Fname%20.%20FILTER(%3Fname%20%3D%20%22Delete%22)%20%7D",
+                headers={"Accept": "application/sparql-results+json"},
+            )
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8")
+            conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertIn("Delete", body)
+
     def test_watch_loop_repeated_refreshes_increment_build_id(self) -> None:
         page = self._write("alpha.md", "# Alpha\n")
         watch_dirs = [self.wiki_dir]


### PR DESCRIPTION
## Summary
- add a read-only SPARQL endpoint to wiki serve at a configurable path
- reuse the existing SPARQL engine and graph loading path used by wiki query
- add serveApi config for enabling/disabling the endpoint and customizing its route
- document the serve API, graph cache behavior, local dev workflow, and init/git behavior
- add RDF/XML and XML reference pages and consolidate HTML template docs under Wiki_Configuration

## What changed
- support GET ?query=..., POST application/sparql-query, and POST application/x-www-form-urlencoded
- negotiate protocol-appropriate response types for result and graph queries
- reject SPARQL Update operations explicitly
- add serve/config tests for the endpoint and route configuration
- sync wiki docs with current command behavior

## Validation
- python -m pytest
- wiki check

## Notes
- branch includes the recent roadmap-driven documentation and CLI improvements that were built up before the SPARQL endpoint work
- intended merge mode: squash and merge