### PR TITLE
Add RDF metadata mode toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,8 +452,11 @@ wiki export
 # Export a single file
 wiki export wiki/Gregory_House.md
 
-# Export as expanded JSON-LD
+# Export as JSON-LD
 wiki export wiki/rdf.md -f json-ld
+
+# Export as compacted JSON-LD
+wiki export wiki/rdf.md -f json-ld --mode compacted
 
 # Export in other RDF formats (turtle, xml, n3, nt, trig, nquads)
 wiki export wiki/rdf.md -f turtle

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -144,7 +144,7 @@ Replace `{key}` tokens in your HTML shell:
 | `{sidebar_contents_html}` | raw HTML     | Extra sidebar links from typed properties.                                                                 |
 | `{source_markdown}`       | escaped text | Raw markdown source for the "view source" tab.                                                             |
 | `{metadata_tool_html}`    | raw HTML     | Sidebar "View metadata" link `<li>` (empty if no frontmatter).                                             |
-| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON-LD)" `<li>` (empty if no frontmatter).                                              |
+| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON-LD)" `<li>` (empty if no frontmatter).                                             |
 | `{metadata_pane_html}`    | raw HTML     | Full metadata display pane `<div>` (empty if no frontmatter).                                              |
 
 Unknown `{placeholders}` are left untouched in the output. This lets you use literal braces in JavaScript or CSS without escaping.

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -149,6 +149,8 @@ Replace `{key}` tokens in your HTML shell:
 
 Unknown `{placeholders}` are left untouched in the output. This lets you use literal braces in JavaScript or CSS without escaping.
 
+The metadata pane is rendered from the same JSON-LD serialization path used by `wiki export`. In `wiki serve`, the initial view can be selected with `?metadata_mode=expanded|compacted`. In `wiki build`, both modes are embedded in the page HTML so the toggle works without JavaScript.
+
 ### Built-in CSS classes and IDs
 
 The wiki builder generates these selectors in the rendered page content:

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -144,7 +144,7 @@ Replace `{key}` tokens in your HTML shell:
 | `{sidebar_contents_html}` | raw HTML     | Extra sidebar links from typed properties.                                                                 |
 | `{source_markdown}`       | escaped text | Raw markdown source for the "view source" tab.                                                             |
 | `{metadata_tool_html}`    | raw HTML     | Sidebar "View metadata" link `<li>` (empty if no frontmatter).                                             |
-| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON)" `<li>` (empty if no frontmatter).                                                |
+| `{metadata_tab_html}`     | raw HTML     | Tab bar "Metadata (JSON-LD)" `<li>` (empty if no frontmatter).                                              |
 | `{metadata_pane_html}`    | raw HTML     | Full metadata display pane `<div>` (empty if no frontmatter).                                              |
 
 Unknown `{placeholders}` are left untouched in the output. This lets you use literal braces in JavaScript or CSS without escaping.

--- a/docs/wiki/Wiki_Subcommand_build.md
+++ b/docs/wiki/Wiki_Subcommand_build.md
@@ -7,6 +7,7 @@ description: Generate a static HTML site from the vault.
 # `wiki build`
 
 Compile markdown and data files into static HTML with wikilinks, backlinks, table of contents, and typed templates/infoboxes.
+The generated pages now embed both expanded and compacted metadata views so the toggle works without JavaScript.
 
 ## Usage
 
@@ -42,6 +43,10 @@ _site/wiki/Alice/index.html  →  /wiki/Alice/
 ```
 
 Assets from `asset_dirs` copy under the same prefix. See [Wiki_Configuration](Wiki_Configuration.md).
+
+## Metadata view
+
+Each built page includes both expanded and compacted metadata blocks. The page defaults to expanded, and the switch stays usable without JavaScript.
 
 ## Custom HTML shell
 

--- a/docs/wiki/Wiki_Subcommand_export.md
+++ b/docs/wiki/Wiki_Subcommand_export.md
@@ -15,6 +15,7 @@ wiki export
 wiki export wiki/Page.md
 wiki export wiki/Page.md -f turtle
 wiki export -f json-ld -o vault.json
+wiki export wiki/Page.md --mode compacted -f json-ld
 ```
 
 ## Options
@@ -23,6 +24,7 @@ wiki export -f json-ld -o vault.json
 | ---------------- | -------------- | ---------------------------------------------------------------- |
 | `FILE`           | all vault docs | Single file or entire vault                                      |
 | `-f`, `--format` | `dict`         | `dict`, `json-ld`, `turtle`, `xml`, `n3`, `nt`, `trig`, `nquads` |
+| `--mode`         | `expanded`     | `expanded` or `compacted` serialization mode                     |
 | `-o`, `--output` | stdout         | Output file                                                      |
 
 ## Output shape
@@ -30,6 +32,8 @@ wiki export -f json-ld -o vault.json
 For `dict` and `json-ld`, each entry is `{"name": "<filename>", "rdf": ...}`.
 
 Raw RDF formats (`turtle`, etc.) on a **single** file write plain serialization without a JSON wrapper. Bulk export with raw formats still wraps entries in JSON for structure.
+
+`--mode compacted` is most visible for JSON-LD, where it emits `@context` and compacted terms when the vault context provides them.
 
 ## Related
 

--- a/docs/wiki/Wiki_Subcommand_serve.md
+++ b/docs/wiki/Wiki_Subcommand_serve.md
@@ -6,7 +6,7 @@ description: Local HTTP server for live HTML preview.
 
 # `wiki serve`
 
-Start a development server that renders vault pages on demand (same engine as [Wiki_Subcommand_build](Wiki_Subcommand_build.md), without writing files).
+Start a development server that renders vault pages on demand.
 
 ## Usage
 
@@ -68,6 +68,10 @@ For safety, the endpoint is **disabled by default**. Its path is also validated 
 ## Custom HTML shell
 
 The same `html_template` from [Wiki_Configuration](Wiki_Configuration.md#html-template) applies to the dev server.
+
+## Metadata view
+
+The live page metadata panel supports `expanded` and `compacted` modes without JavaScript. The request can set the initial selection with `?metadata_mode=expanded|compacted`.
 
 ## Related
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -398,8 +398,9 @@ def build(
 @click.argument("file", required=False, type=click.Path(exists=True, path_type=Path))
 @click.option("-o", "--output", type=click.Path(path_type=Path), help="File to write serialized RDF output.")
 @click.option("-f", "--format", "rdf_format", type=FormatChoice(["dict", "json-ld", "turtle", "xml", "n3", "nt", "trig", "nquads"], case_sensitive=False), default="dict", show_default=True, help="Output format for RDF export.")
+@click.option("--mode", type=click.Choice(["expanded", "compacted"], case_sensitive=False), default="expanded", show_default=True, help="Serialization mode for formats that support compaction.")
 @click.pass_obj
-def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_format: str) -> None:
+def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_format: str, mode: str) -> None:
     """Compile and export wiki documents in a supported RDF format."""
     result_payload: Any = None
 
@@ -409,7 +410,7 @@ def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_f
             click.echo(f"No valid document metadata found in {file.name}", err=True)
             sys.exit(1)
 
-        processed_rdf = process_rdf_format(data, file.stem, context, rdf_format)
+        processed_rdf = process_rdf_format(data, file.stem, context, rdf_format, mode=mode)
         result_payload = {
             "name": file.name,
             "rdf": processed_rdf,
@@ -422,7 +423,7 @@ def export(context: Context, file: Optional[Path], output: Optional[Path], rdf_f
             data = document_data_from_path(file_path, content_predicate=context.content_predicate)
             if data:
                 processed_rdf = process_rdf_format(
-                    data, route_for_document_file(context, file_path), context, rdf_format
+                    data, route_for_document_file(context, file_path), context, rdf_format, mode=mode
                 )
                 converted_list.append({
                     "name": file_path.name,

--- a/src/wiki/format.py
+++ b/src/wiki/format.py
@@ -6,6 +6,8 @@ import json
 import re
 from typing import Any
 
+from rdflib import Graph
+
 
 def _wiki_link(s: str, wiki_base: str, known_slugs: set[str] | None = None) -> str:
     """Convert a wiki URI to a standard markdown link if applicable."""
@@ -170,7 +172,49 @@ def is_sparql_update(query: str) -> bool:
     return _SPARQL_UPDATE_RE.search(text) is not None
 
 
-def process_rdf_format(data: dict[str, Any], file_stem: str, context: Any, output_format: str) -> Any:
+def normalize_metadata_mode(mode: str | None) -> str:
+    """Normalize the metadata/RDF display mode to a known value."""
+    return "compacted" if str(mode).strip().lower() == "compacted" else "expanded"
+
+
+def serialize_rdf_graph(graph: Graph, output_format: str, mode: str = "expanded", context: Any = None) -> Any:
+    """Serialize an RDF graph in the requested format and display mode."""
+    normalized_mode = normalize_metadata_mode(mode)
+
+    if output_format in ("json-ld", "jsonld"):
+        kwargs: dict[str, Any] = {"indent": 2}
+        if normalized_mode == "compacted":
+            context_data = None
+            if context is not None:
+                if hasattr(context, "namespaces"):
+                    context_data = {prefix: str(namespace) for prefix, namespace in context.namespaces.items()}
+                elif isinstance(context, dict):
+                    context_data = context
+            if context_data:
+                kwargs["context"] = context_data
+                kwargs["auto_compact"] = True
+        serialized = graph.serialize(format="json-ld", **kwargs)
+        return json.loads(serialized)
+
+    if output_format == "nquads":
+        from rdflib import Dataset
+
+        dataset = Dataset()
+        default = dataset.default_graph
+        for s, p, o in graph:
+            default.add((s, p, o))
+        return dataset.serialize(format="nquads")
+
+    return graph.serialize(format=output_format, indent=2)
+
+
+def process_rdf_format(
+    data: dict[str, Any],
+    file_stem: str,
+    context: Any,
+    output_format: str,
+    mode: str = "expanded",
+) -> Any:
     """Convert frontmatter dict to the requested RDF serialization format.
 
     Used by the export command to convert frontmatter dicts into various RDF formats.
@@ -181,18 +225,4 @@ def process_rdf_format(data: dict[str, Any], file_stem: str, context: Any, outpu
     from .graph import frontmatter_to_graph
 
     graph = frontmatter_to_graph(data, context, file_id=file_stem)
-
-    if output_format in ("json-ld", "jsonld"):
-        serialized = graph.serialize(format="json-ld", indent=2)
-        return json.loads(serialized)
-
-    if output_format == "nquads":
-        from rdflib import Dataset
-        dataset = Dataset()
-        default = dataset.default_graph
-        for s, p, o in graph:
-            default.add((s, p, o))
-        return dataset.serialize(format="nquads")
-
-    rdf_format = output_format
-    return graph.serialize(format=rdf_format, indent=2)
+    return serialize_rdf_graph(graph, output_format, mode=mode, context=context)

--- a/src/wiki/format.py
+++ b/src/wiki/format.py
@@ -197,15 +197,17 @@ def serialize_rdf_graph(graph: Graph, output_format: str, mode: str = "expanded"
         return json.loads(serialized)
 
     if output_format == "nquads":
-        from rdflib import Dataset
-
-        dataset = Dataset()
-        default = dataset.default_graph
-        for s, p, o in graph:
-            default.add((s, p, o))
-        return dataset.serialize(format="nquads")
+        return _serialize_nquads_graph(graph)
 
     return graph.serialize(format=output_format, indent=2)
+
+
+def _serialize_nquads_graph(graph: Graph) -> str:
+    """Serialize a single RDF graph as N-Quads without deprecated rdflib APIs."""
+    lines = []
+    for subject, predicate, obj in graph:
+        lines.append(f"{subject.n3()} {predicate.n3()} {obj.n3()} .")
+    return "\n".join(lines) + ("\n" if lines else "")
 
 
 def process_rdf_format(

--- a/src/wiki/graph.py
+++ b/src/wiki/graph.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import re
+import warnings
 from pathlib import Path
 from typing import Any, Optional
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup, Tag, XMLParsedAsHTMLWarning
 from rdflib import Graph, Literal, URIRef, RDF, BNode
 from rdflib.namespace import XSD
 from rdflib.parser import InputSource, Parser, StringInputSource
@@ -182,7 +183,9 @@ class MicrodataParser(Parser):
             content = content.decode("utf-8", errors="ignore")
             
         try:
-            soup = BeautifulSoup(content, "html.parser")
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+                soup = BeautifulSoup(content, "html.parser")
         except Exception as e:
             logger.warning("Failed to parse HTML: %s", e)
             return

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qs, urlsplit
 from typing import Any, Optional
 
 from .config import WikiConfig
-from .format import detect_query_form, is_sparql_update, run_query
+from .format import detect_query_form, is_sparql_update, normalize_metadata_mode, run_query
 from .graph import load_graph
 from .site import (
     WikiSite,
@@ -43,6 +43,7 @@ class WikiHandler(BaseHTTPRequestHandler):
         base = self.base_url
         parsed_url = urlsplit(self.path)
         parsed = parsed_url.path
+        query_params = parse_qs(parsed_url.query, keep_blank_values=True)
         if parsed.rstrip("/") == self.serve_api_path.rstrip("/"):
             self._handle_sparql_request("GET", parsed_url.query)
             return
@@ -61,7 +62,17 @@ class WikiHandler(BaseHTTPRequestHandler):
             slug = parsed[len(base) + 1:]
             target = self._find_page(slug)
             if target:
-                self._send_html(build_page_html(target, self.site, base_url=base, url_style=self.url_style, html_template=self.html_template))
+                metadata_mode = normalize_metadata_mode(query_params.get("metadata_mode", ["expanded"])[-1])
+                self._send_html(
+                    build_page_html(
+                        target,
+                        self.site,
+                        base_url=base,
+                        url_style=self.url_style,
+                        html_template=self.html_template,
+                        metadata_mode=metadata_mode,
+                    )
+                )
             elif self._serve_asset(parsed[len(base) + 1:]):
                 return
             else:

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -712,6 +712,10 @@ textarea.wiki-textarea:focus {
   display: block;
 }
 
+#view-metadata-content:target {
+  display: block !important;
+}
+
 /* Template Label badge */
 .template-label {
   display: inline-block;
@@ -1200,8 +1204,8 @@ def build_page_html(
 
     metadata_mode_html = _build_metadata_panel_html(page, site, selected_mode)
     if page.has_frontmatter:
-        metadata_tool_html = '<li><a href="javascript:void(0)" onclick="switchTab(\'metadata\')">View metadata</a></li>'
-        metadata_tab_html = '<li id="ca-metadata"><a href="javascript:void(0)" onclick="switchTab(\'metadata\')">Metadata (JSON-LD)</a></li>'
+        metadata_tool_html = '<li><a href="#view-metadata-content" onclick="switchTab(\'metadata\'); return false;">View metadata</a></li>'
+        metadata_tab_html = '<li id="ca-metadata"><a href="#view-metadata-content" onclick="switchTab(\'metadata\'); return false;">Metadata (JSON-LD)</a></li>'
         metadata_pane_html = f"""<!-- METADATA VIEW (JSON-LD frontmatter) -->
     <div id="view-metadata-content" class="wiki-view-pane" style="display: none;">
       <h1 class="firstHeading">Metadata: {html_module.escape(page.title)}</h1>

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -18,6 +18,7 @@ from pygments.util import ClassNotFound
 from wiki.mdit_py_plugins.wikilink import wikilink_plugin
 
 from .config import DEFAULT_URL_STYLE, WikiConfig
+from .format import normalize_metadata_mode, process_rdf_format
 from .headings import GitHubHeadingSlugger, heading_slug
 from .links import is_external_link, markdown_link_is_page, resolve_page_href, resolve_page_route
 from .paths import iter_document_files, page_url, route_for_document_file
@@ -654,6 +655,56 @@ textarea.wiki-textarea:focus {
   color: #54595d;
 }
 
+.metadata-mode-switch {
+  position: relative;
+}
+
+.metadata-mode-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.metadata-mode-label {
+  display: inline-block;
+  margin: 0 8px 12px 0;
+  padding: 6px 10px;
+  border: 1px solid #a2a9b1;
+  border-radius: 999px;
+  background: #fff;
+  color: #202122;
+  font-size: 0.85em;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.metadata-mode-label:hover {
+  background: #eaecf0;
+}
+
+.metadata-mode-input[value="expanded"]:checked + .metadata-mode-label,
+.metadata-mode-input[value="compacted"]:checked + .metadata-mode-label {
+  background: #36c;
+  color: #fff;
+  border-color: #36c;
+}
+
+.metadata-mode-panels {
+  margin-top: 8px;
+}
+
+.metadata-mode-panel {
+  display: none;
+}
+
+.metadata-mode-input[value="expanded"]:checked ~ .metadata-mode-panels .metadata-mode-panel-expanded {
+  display: block;
+}
+
+.metadata-mode-input[value="compacted"]:checked ~ .metadata-mode-panels .metadata-mode-panel-compacted {
+  display: block;
+}
+
 /* Template Label badge */
 .template-label {
   display: inline-block;
@@ -863,6 +914,7 @@ class VirtualPage:
 @dataclass
 class WikiSite:
     pages: list[VirtualPage]
+    config: WikiConfig | None = None
     pages_by_route: dict[str, VirtualPage] = field(default_factory=dict)
     routes_by_wiki_id: dict[str, str] = field(default_factory=dict)
 
@@ -989,7 +1041,7 @@ def build_site(
         for wiki_id in page.wiki_ids:
             routes_by_wiki_id[wiki_id] = page.file_slug
 
-    return WikiSite(pages=pages, pages_by_route=pages_by_route, routes_by_wiki_id=routes_by_wiki_id)
+    return WikiSite(pages=pages, config=config, pages_by_route=pages_by_route, routes_by_wiki_id=routes_by_wiki_id)
 
 
 def _render_html(shell: str, context: dict[str, str]) -> str:
@@ -1077,8 +1129,16 @@ def build_index_html(
     return _render_html(shell, context)
 
 
-def build_page_html(page: VirtualPage, site: WikiSite, base_url: str = "/wiki", url_style: str = DEFAULT_URL_STYLE, html_template: str | None = None) -> str:
+def build_page_html(
+    page: VirtualPage,
+    site: WikiSite,
+    base_url: str = "/wiki",
+    url_style: str = DEFAULT_URL_STYLE,
+    html_template: str | None = None,
+    metadata_mode: str = "expanded",
+) -> str:
     """Compile individual page HTML."""
+    selected_mode = normalize_metadata_mode(metadata_mode)
     toc_html = _build_toc_html(page)
     sidebar_contents_html = _build_sidebar_contents_html(page)
     bl_html = _build_backlinks_html(page, site, base_url, url_style)
@@ -1131,17 +1191,16 @@ def build_page_html(page: VirtualPage, site: WikiSite, base_url: str = "/wiki", 
   <text x="100" y="112" font-family="'Inter', sans-serif" font-size="36" font-weight="900" fill="#ffffff" text-anchor="middle" style="letter-spacing: -2px;">W</text>
 </svg>"""
 
-    metadata_formatted = json.dumps(_metadata_view_frontmatter(page), indent=2, default=str)
+    metadata_mode_html = _build_metadata_panel_html(page, site, selected_mode)
     if page.has_frontmatter:
-        metadata_highlighted = _highlight_json(metadata_formatted)
         metadata_tool_html = '<li><a href="javascript:void(0)" onclick="switchTab(\'metadata\')">View metadata</a></li>'
-        metadata_tab_html = '<li id="ca-metadata"><a href="javascript:void(0)" onclick="switchTab(\'metadata\')">Metadata (JSON)</a></li>'
+        metadata_tab_html = '<li id="ca-metadata"><a href="javascript:void(0)" onclick="switchTab(\'metadata\')">Metadata (JSON-LD)</a></li>'
         metadata_pane_html = f"""<!-- METADATA VIEW (JSON-LD frontmatter) -->
     <div id="view-metadata-content" class="wiki-view-pane" style="display: none;">
       <h1 class="firstHeading">Metadata: {html_module.escape(page.title)}</h1>
-      <div id="siteSub">JSON representation compiled from frontmatter</div>
+      <div id="siteSub">JSON-LD representation compiled from frontmatter</div>
       
-      <pre class="highlight"><code class="language-json">{metadata_highlighted}</code></pre>
+      {metadata_mode_html}
     </div>"""
     else:
         metadata_tool_html = ""
@@ -1295,14 +1354,45 @@ def _build_backlinks_html(page: VirtualPage, site: WikiSite, base_url: str, url_
 </section>"""
 
 
-def _build_metadata_json_html(page: VirtualPage) -> str:
+def _build_metadata_panel_html(page: VirtualPage, site: WikiSite, selected_mode: str) -> str:
     if not page.frontmatter:
         return ""
-    highlighted_json = _highlight_json(json.dumps(_metadata_view_frontmatter(page), indent=2, default=str))
-    return f"""<section class="page-meta">
+
+    page_config = site.config or WikiConfig(input_dirs=[])
+    mode_id = _metadata_mode_dom_id(page)
+    expanded_checked = ' checked="checked"' if selected_mode == "expanded" else ""
+    compacted_checked = ' checked="checked"' if selected_mode == "compacted" else ""
+
+    expanded_json = _metadata_json_for_page(page, page_config, "expanded")
+    compacted_json = _metadata_json_for_page(page, page_config, "compacted")
+
+    return f"""<section class="page-meta metadata-panel">
 <h2>Metadata</h2>
-<pre class="highlight"><code class="language-json">{highlighted_json}</code></pre>
+<div class="metadata-mode-switch" role="group" aria-label="Metadata display mode">
+  <input class="metadata-mode-input" type="radio" name="{mode_id}" id="{mode_id}-expanded" value="expanded"{expanded_checked}>
+  <label class="metadata-mode-label" for="{mode_id}-expanded">Expanded</label>
+  <input class="metadata-mode-input" type="radio" name="{mode_id}" id="{mode_id}-compacted" value="compacted"{compacted_checked}>
+  <label class="metadata-mode-label" for="{mode_id}-compacted">Compacted</label>
+  <div class="metadata-mode-panels">
+    <div class="metadata-mode-panel metadata-mode-panel-expanded">
+      <pre class="highlight"><code class="language-json">{expanded_json}</code></pre>
+    </div>
+    <div class="metadata-mode-panel metadata-mode-panel-compacted">
+      <pre class="highlight"><code class="language-json">{compacted_json}</code></pre>
+    </div>
+  </div>
+</div>
 </section>"""
+
+
+def _metadata_json_for_page(page: VirtualPage, config: WikiConfig, mode: str) -> str:
+    rdf = process_rdf_format(page.frontmatter, page.full_slug, config.context, "json-ld", mode=mode)
+    return _highlight_json(json.dumps(rdf, indent=2, default=str))
+
+
+def _metadata_mode_dom_id(page: VirtualPage) -> str:
+    safe_slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", page.full_slug or "index").strip("-") or "index"
+    return f"metadata-mode-{safe_slug.lower()}"
 
 
 def _highlight_json(value: str) -> str:
@@ -1311,30 +1401,6 @@ def _highlight_json(value: str) -> str:
     except ClassNotFound:
         return html_module.escape(value)
     return highlight(value, lexer, PYGMENTS_FORMATTER)
-
-
-def _metadata_view_frontmatter(page: VirtualPage) -> dict[str, Any]:
-    frontmatter = page.frontmatter
-    normalized: dict[str, Any] = {}
-
-    metadata_id = frontmatter.get("@id") or frontmatter.get("id") or (page.wiki_ids[0] if page.wiki_ids else None)
-    if metadata_id is not None:
-        normalized["@id"] = metadata_id
-
-    if "@type" in frontmatter:
-        normalized["@type"] = frontmatter["@type"]
-    elif "type" in frontmatter:
-        normalized["@type"] = frontmatter["type"]
-
-    for key, value in frontmatter.items():
-        if key in {"@id", "id", "@type", "type"}:
-            continue
-        normalized[key] = value
-
-    if normalized:
-        return normalized
-
-    return frontmatter
 
 
 def _build_infobox_html(page: VirtualPage, site: WikiSite, base_url: str, url_style: str) -> str:

--- a/src/wiki/site.py
+++ b/src/wiki/site.py
@@ -659,6 +659,13 @@ textarea.wiki-textarea:focus {
   position: relative;
 }
 
+.metadata-mode-heading {
+  margin: 0 0 8px;
+  font-size: 0.85em;
+  font-weight: 600;
+  color: #54595d;
+}
+
 .metadata-mode-input {
   position: absolute;
   opacity: 0;
@@ -1369,6 +1376,7 @@ def _build_metadata_panel_html(page: VirtualPage, site: WikiSite, selected_mode:
     return f"""<section class="page-meta metadata-panel">
 <h2>Metadata</h2>
 <div class="metadata-mode-switch" role="group" aria-label="Metadata display mode">
+  <div class="metadata-mode-heading">View as format</div>
   <input class="metadata-mode-input" type="radio" name="{mode_id}" id="{mode_id}-expanded" value="expanded"{expanded_checked}>
   <label class="metadata-mode-label" for="{mode_id}-expanded">Expanded</label>
   <input class="metadata-mode-input" type="radio" name="{mode_id}" id="{mode_id}-compacted" value="compacted"{compacted_checked}>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -156,6 +156,49 @@ name: Bella Davidson
             self.assertIn('href="/wiki/Bella_Davidson/"', html)
             self.assertIn('href="https://example.com/gregory-davidson"', html)
 
+    def test_build_embeds_both_metadata_modes(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            output_dir = root / "_site"
+            wiki.mkdir()
+            template = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"UTF-8\">
+<meta name=\"viewport\" content=\"width=device-width,initial-scale=1.0\">
+<title>{page_title}</title>
+</head>
+<body>
+<h1>{page_title}</h1>
+{page_content}
+{metadata_pane_html}
+</body>
+</html>"""
+            (root / "wiki.yaml").write_text("input_dirs: wiki\nhtml_template: test_shell.html\n", encoding="utf-8")
+            (root / "test_shell.html").write_text(template, encoding="utf-8")
+            (wiki / "Page.md").write_text(
+                """---
+type: Person
+name: Alice
+about: wiki:Alice_Theory
+---
+# Alice
+""",
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(main, ["--config", str(root), "build", "--output-dir", str(output_dir)])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            html = (output_dir / "wiki" / "Page" / "index.html").read_text(encoding="utf-8")
+            self.assertIn("View as format", html)
+            self.assertIn('metadata-mode-panel-expanded', html)
+            self.assertIn('metadata-mode-panel-compacted', html)
+            self.assertIn('value="expanded" checked="checked"', html)
+            self.assertIn('value="compacted"', html)
+
     def test_missing_configured_template_falls_back_silently(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -619,6 +619,7 @@ name: Gregory
             page.write_text("""---
 type: Person
 name: Alice
+about: wiki:Alice_Theory
 ---
 """, encoding="utf-8")
             
@@ -628,9 +629,19 @@ name: Alice
             data = json.loads(result.output)
             self.assertIsInstance(data["rdf"], list)
             self.assertIn("@id", data["rdf"][0])
+            self.assertIn("https://schema.org/name", data["rdf"][0])
+
+            # compacted JSON-LD includes @context and compacted predicates
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "export", str(page), "--format", "json-ld", "--mode", "compacted"])
+            self.assertEqual(result.exit_code, 0)
+            compacted = json.loads(result.output)
+            self.assertIn("@context", compacted["rdf"])
+            self.assertEqual(compacted["rdf"]["@type"], "schema:Person")
+            self.assertEqual(compacted["rdf"]["schema:name"], "Alice")
+            self.assertEqual(compacted["rdf"]["schema:about"]["@id"], "wiki:Alice_Theory")
             
             # turtle format returns raw serialized turtle (no JSON wrapper)
-            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "export", str(page), "--format", "turtle"])
+            result = runner.invoke(main, ["--input-dir", str(wiki_dir), "export", str(page), "--format", "turtle", "--mode", "compacted"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("schema:name", result.output)  # turtle has prefix:name
             self.assertIn("Alice", result.output)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -45,6 +45,23 @@ _RICH_TEMPLATE = """<!DOCTYPE html>
 </html>"""
 
 
+_METADATA_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>{page_title}</title>
+</head>
+<body>
+<h1>{page_title}</h1>
+{metadata_tool_html}
+{metadata_tab_html}
+{metadata_pane_html}
+{page_content}
+</body>
+</html>"""
+
+
 def _serve_in_thread(wiki_dir: Path) -> Generator[int, None, None]:
     port = _free_port()
     config = WikiConfig(input_dirs=[wiki_dir], config_root=wiki_dir)
@@ -213,6 +230,20 @@ class TestServe(unittest.TestCase):
         self.assertIn("My Page", body)
         self.assertIn("My Page", body)
         self.assertIn("Article", body)
+
+    def test_metadata_mode_query_switches_initial_selection(self) -> None:
+        self._write("page.md", "---\ntype: Article\nname: My Page\nabout: wiki:My_Page\n---\n\n# My Page\n")
+        for port in _serve_with_template(self.wiki_dir, template=_METADATA_TEMPLATE):
+            status, expanded = self._get(port, "/wiki/page?metadata_mode=expanded")
+            compact_status, compacted = self._get(port, "/wiki/page?metadata_mode=compacted")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(compact_status, 200)
+        self.assertIn('value="expanded" checked="checked"', expanded)
+        self.assertIn('value="compacted" checked="checked"', compacted)
+        self.assertIn('&quot;@id&quot;', expanded)
+        self.assertIn('&quot;@context&quot;', compacted)
+        self.assertIn('schema:about', compacted)
 
     def test_404(self) -> None:
         self._write("exists.md", "# Exists")

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -244,6 +244,7 @@ specialty: Diagnostics
             html = build_page_html(page, site, base_url="/wiki", url_style="dir", html_template=html_template)
 
             self.assertIn("Metadata (JSON-LD)", html)
+            self.assertIn('href="#view-metadata-content"', html)
             self.assertIn('metadata-mode-panel-expanded', html)
             self.assertIn('metadata-mode-panel-compacted', html)
             self.assertIn('value="expanded" checked="checked"', html)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -243,7 +243,10 @@ specialty: Diagnostics
             html_template = pkg_files("wiki").joinpath("templates/index.html").read_text(encoding="utf-8")
             html = build_page_html(page, site, base_url="/wiki", url_style="dir", html_template=html_template)
 
-            self.assertIn("Metadata (JSON)", html)
+            self.assertIn("Metadata (JSON-LD)", html)
+            self.assertIn('metadata-mode-panel-expanded', html)
+            self.assertIn('metadata-mode-panel-compacted', html)
+            self.assertIn('value="expanded" checked="checked"', html)
             self.assertIn('class="language-json"', html)
             self.assertIn('class="highlight"', html)
             self.assertIn("<span", html)
@@ -251,7 +254,10 @@ specialty: Diagnostics
             self.assertIn('&quot;@type&quot;', html)
             self.assertNotIn('&quot;type&quot;', html)
             self.assertLess(html.index('&quot;@id&quot;'), html.index('&quot;@type&quot;'))
-            self.assertLess(html.index('&quot;@type&quot;'), html.index('&quot;name&quot;'))
+            self.assertLess(html.index('&quot;@type&quot;'), html.index('&quot;https://schema.org/name&quot;'))
+            self.assertIn('&quot;@context&quot;', html)
+            self.assertIn('schema:Person', html)
+            self.assertIn('schema:name', html)
 
     def test_obsidian_wikilinks_resolve_relative_to_current_file(self) -> None:
         html = render_wiki_markdown(


### PR DESCRIPTION
Summary:\n- Add shared RDF serialization with expanded/compacted modes\n- Wire wiki export --mode through CLI\n- Update live metadata panel and static build to use the same JSON-LD serialization\n- Remove rdflib N-Quads warning\n\nVerification:\n- python -m pytest\n- 231 passed