### PR TITLE
Add best-practices Agent Skill for vault hygiene audits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ _site-test/
 
 # Wiki CLI graph and render caches (legacy on-disk layout)
 .wiki/
+
+# Agent skill eval workspaces (skill-creator iteration output; not shipped)
+skills/*-workspace/

--- a/skills/best-practices/.gitattributes
+++ b/skills/best-practices/.gitattributes
@@ -1,0 +1,1 @@
+scripts/*.sh text eol=lf

--- a/skills/best-practices/SKILL.md
+++ b/skills/best-practices/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: best-practices
+description: >-
+  Audit a Wiki CLI vault and wiki.yaml for CI-ready hygiene — run fmt, lint, check,
+  and render validators, interpret config semantics, and spot-check Style_Guide
+  conventions. Use whenever the user asks for a vault audit, wiki best practices,
+  pre-commit or CI validation, check/lint failures, broken links, wiki.yaml review,
+  or preparing vault changes before a PR — even if they do not say "skill".
+---
+
+# Wiki CLI best practices
+
+Audit a [Wiki CLI](https://github.com/wazootech/wiki) vault. Run tools and cite output; do not guess.
+
+Skills live outside `vault.inputs` — they are agent procedural knowledge, not published wiki pages.
+
+## Quick start
+
+From the repo root (directory containing `wiki.yaml`):
+
+```bash
+bash skills/best-practices/scripts/audit.sh -c path/to/wiki.yaml
+```
+
+The script prefers `wiki` on PATH when it supports `fmt`; otherwise falls back to `uv run wiki` or `python -m wiki` (use the latter in this repo if a global PyPI install is stale).
+
+In **this repo**: `-c docs/wiki.yaml`. For a single changed page, append file paths after the config flag.
+
+Manual equivalent (strict CI order):
+
+```bash
+wiki -c path/to/wiki.yaml fmt --check
+wiki -c path/to/wiki.yaml lint --strict -v
+wiki -c path/to/wiki.yaml check --strict -v
+wiki -c path/to/wiki.yaml render --check
+# wiki link --check  — only when CI wires it (see below)
+```
+
+## Audit workflow
+
+### 1. Locate scope
+
+- Find `wiki.yaml` and read `vault.inputs`, `lint:`, `check:`, `link.style`, `vault.filename_pattern`.
+- Skills under `skills/` are not vault documents — do not index or build them.
+
+### 2. Run the audit script
+
+Use [`scripts/audit.sh`](scripts/audit.sh). It runs fmt → lint → check → render with `--strict` / `--check`, then scans `.github/workflows/` for `wiki link --check` and runs it only when wired.
+
+Stop on first failure; report which stage failed and paste relevant CLI output.
+
+### 3. Config semantics
+
+| Block | Command | Purpose |
+| ----- | ------- | ------- |
+| `fmt:` | `wiki fmt` | Mechanical markdown (mdformat) |
+| `lint:` | `wiki lint` | Conventions — links, filenames, headings |
+| `check:` | `wiki check` | Integrity — SHACL, routes, layouts |
+
+Regex belongs in `vault.filename_pattern`, not under `check:`. Unknown keys should fail at load — do not suggest runtime migration shims.
+
+### 4. Deploy alignment (custom wikis)
+
+When auditing deploy-related pages or CI, cross-check workflow paths against [Deploying_to_GitHub_Pages.md](docs/wiki/Deploying_to_GitHub_Pages.md):
+
+- `-c` points at the correct `wiki.yaml`
+- `--site-base-url` matches the Pages path (`/wiki`, `/my-wiki`, or `''` for root)
+- `upload-pages-artifact` `path` contains the built `index.html` tree
+
+### 5. Manual spot-check
+
+When `lint.*` rules are `off`, still note violations. Canonical rules: vault `Style_Guide.md`; CLI mapping: repo `AGENTS.md`.
+
+| Area | Best practice |
+| ---- | ------------- |
+| Filenames | Wikipedia-style (`Page_Name.md`); `index.md` only for folder routes |
+| Headings | Title-case H1; sentence-case H2+; ATX `#` only |
+| Links | Markdown `[text](Page.md)` when `link.style: markdown` |
+| Frontmatter | `type` / shapes aligned; CURIEs use `graph.context` |
+| SPARQL | People → `givenName`/`familyName`; TechArticle → `headline`/`description` |
+| Prose | No `---` thematic breaks in body; `## References` on standard pages |
+
+### 6. Fixes (explicit mutation only)
+
+Never edit vault files unless the user asks. Suggest:
+
+- `wiki fmt` — apply formatting
+- `wiki link --fix-broken` — repair unambiguous broken internal links (separate from lint reporting)
+- `wiki link --apply` — insert suggested markdown links
+
+`wiki link` enrichment is not a lint violation — keep it distinct from `lint.broken_links`.
+
+## Report template
+
+```markdown
+## Wiki vault audit — <vault or path>
+
+**Config:** <wiki.yaml path>
+**Date:** <ISO date>
+
+### Automated checks
+| Check | Result | Notes |
+| fmt --check | pass/fail | |
+| lint --strict | pass/fail | |
+| check --strict | pass/fail | |
+| render --check | pass/fail | |
+| link --check | skipped/pass/fail | only if CI wired |
+
+### Config review
+- <wiki.yaml observations>
+
+### Manual findings
+- [severity] <file>: <issue> — <fix>
+
+### Recommended next steps
+1. ...
+```
+
+Prioritize check failures and strict lint errors before style nits.
+
+## Related docs
+
+- `docs/wiki/Style_Guide.md` — canonical authoring rules
+- `docs/wiki/Wiki_Configuration.md` — `check` vs `lint` vs `fmt`
+- `docs/wiki/Design_Philosophies.md` — why link repair is separate from lint

--- a/skills/best-practices/evals/evals.json
+++ b/skills/best-practices/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "best-practices",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit the docs vault before I open a PR",
+      "expected_output": "Runs strict pipeline on docs/wiki.yaml via audit.sh or equivalent commands; produces scorecard with pass/fail per stage (fmt, lint, check, render).",
+      "files": [],
+      "expectations": [
+        "Output mentions fmt, lint, check, and render",
+        "Uses -c docs/wiki.yaml or equivalent config path",
+        "Produces a structured pass/fail report",
+        "Does not modify vault files"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I changed docs/wiki/Deploying_to_GitHub_Pages.md — anything I should verify?",
+      "expected_output": "Scoped audit on the changed file plus deploy alignment notes (-c, --site-base-url, upload-pages-artifact path).",
+      "files": [],
+      "expectations": [
+        "Runs lint or check scoped to the changed file or full vault",
+        "Mentions deploy alignment (site-base-url or artifact path)",
+        "Uses -c with discovered wiki.yaml",
+        "Does not modify vault files without explicit request"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "My wiki lint is failing on broken links in wiki/Foo.md",
+      "expected_output": "Single-file lint --strict with broken link output cited; distinguishes lint reporting from wiki link --fix-broken repair.",
+      "files": [],
+      "expectations": [
+        "Runs wiki lint --strict on the target file",
+        "Cites or summarizes lint output for broken links",
+        "Mentions wiki link --fix-broken as optional repair, separate from lint",
+        "Does not auto-edit files"
+      ]
+    }
+  ]
+}

--- a/skills/best-practices/scripts/audit.sh
+++ b/skills/best-practices/scripts/audit.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Wiki CLI vault audit — strict CI pipeline (fmt → lint → check → render).
+# Optionally runs wiki link --check when wired in .github/workflows/.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: audit.sh -c <wiki.yaml> [FILE...]
+
+Run strict vault validators in CI order:
+  fmt --check → lint --strict → check --strict → render --check
+  (+ wiki link --check when present in .github/workflows/)
+
+Options:
+  -c PATH   Path to wiki.yaml (required)
+  -h        Show this help
+
+Remaining arguments are optional vault file paths passed to fmt, lint, and check.
+EOF
+}
+
+CONFIG=""
+FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -c)
+      CONFIG="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      FILES+=("$@")
+      break
+      ;;
+    -*)
+      echo "audit.sh: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      FILES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$CONFIG" ]]; then
+  echo "audit.sh: -c wiki.yaml is required" >&2
+  usage >&2
+  exit 2
+fi
+
+wiki_supports_fmt() {
+  command -v wiki >/dev/null 2>&1 && wiki --help 2>&1 | grep -q 'fmt'
+}
+
+if [[ -f pyproject.toml ]] && command -v uv >/dev/null 2>&1; then
+  WIKI=(uv run wiki -c "$CONFIG")
+elif [[ -f pyproject.toml ]] && command -v python >/dev/null 2>&1; then
+  WIKI=(python -m wiki -c "$CONFIG")
+elif wiki_supports_fmt; then
+  WIKI=(wiki -c "$CONFIG")
+elif command -v uv >/dev/null 2>&1; then
+  WIKI=(uv run wiki -c "$CONFIG")
+elif command -v python >/dev/null 2>&1; then
+  WIKI=(python -m wiki -c "$CONFIG")
+else
+  echo "audit.sh: need uv, python -m wiki, or a current wiki on PATH" >&2
+  exit 127
+fi
+
+if ((${#FILES[@]} > 0)); then
+  FILE_ARGS=("${FILES[@]}")
+else
+  FILE_ARGS=()
+fi
+
+run_stage() {
+  local label="$1"
+  shift
+  echo "==> $label"
+  if "$@"; then
+    echo "    OK"
+  else
+    echo "audit.sh: FAILED at stage: $label" >&2
+    exit 1
+  fi
+}
+
+run_stage "fmt --check" "${WIKI[@]}" fmt --check "${FILE_ARGS[@]+"${FILE_ARGS[@]}"}"
+run_stage "lint --strict" "${WIKI[@]}" lint --strict -v "${FILE_ARGS[@]+"${FILE_ARGS[@]}"}"
+run_stage "check --strict" "${WIKI[@]}" check --strict -v "${FILE_ARGS[@]+"${FILE_ARGS[@]}"}"
+run_stage "render --check" "${WIKI[@]}" render --check
+
+if [[ -d .github/workflows ]] && grep -rqE 'wiki[[:space:]].*link.*--check|wiki[[:space:]]+link[[:space:]]+--check' .github/workflows 2>/dev/null; then
+  run_stage "link --check" "${WIKI[@]}" link --check "${FILE_ARGS[@]+"${FILE_ARGS[@]}"}"
+else
+  echo "==> link --check (skipped — not wired in .github/workflows/)"
+fi
+
+echo "audit.sh: all stages passed"


### PR DESCRIPTION
## AI transcript

https://gist.github.com/EthanThatOneKid/3d963e54d0053d8851fbb5594c7ec41e

## Summary

- Add `skills/best-practices/` — an [Agent Skills](https://agentskills.io/home)-compatible skill for auditing Wiki CLI vaults
- `SKILL.md` orchestrates strict `fmt` → `lint` → `check` → `render` validation, config semantics, Style_Guide spot-checks, and deploy alignment notes
- `scripts/audit.sh` runs the CI pipeline deterministically; `wiki link --check` runs only when wired in `.github/workflows/`
- `evals/evals.json` holds skill-creator test prompts for future iteration

Closes #17 (repo-only for now; `wiki init` scaffold deferred).

## Test plan

- [ ] `bash skills/best-practices/scripts/audit.sh -c docs/wiki.yaml` passes on a clean vault
- [ ] `uv run wiki -c docs/wiki.yaml lint --strict` still passes after merge
- [ ] Agent loads skill from `skills/best-practices/SKILL.md` when asked to audit vault hygiene
