### PR TITLE
Add npm delivery layer for wazootech-wiki

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,54 @@ jobs:
 
     - name: Verify Docs Wiki SPARQL Blocks are Up to Date
       run: uv run wiki -c docs/wiki.yaml render --check
+
+  npm-checks:
+    name: NPM Package Checks
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Check npm/PyPI version consistency
+      run: |
+        PY_VER=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml').read())['project']['version'])")
+        NPM_VER=$(node -e "console.log(require('./package.json').version)")
+        test "$PY_VER" = "$NPM_VER" || { echo "::error::Version mismatch: pyproject=$PY_VER package.json=$NPM_VER"; exit 1; }
+
+    - name: Syntax check JS files
+      run: |
+        node -e "require('./npm/python')"
+        node -e "require('./npm/setup')"
+
+    - name: Verify npm can pack
+      run: npm pack --dry-run
+
+    - name: Build Python package for integration test
+      run: uv build
+
+    - name: Integration test (pack and run wiki --help)
+      run: |
+        TARBALL=$(npm pack --silent)
+        TMPDIR=$(mktemp -d)
+        cd "$TMPDIR"
+        tar xzf "${GITHUB_WORKSPACE}/${TARBALL}"
+        cd package
+        WHEEL=$(ls "${GITHUB_WORKSPACE}/dist/wazootech_wiki-"*.whl | head -1)
+        echo "Installing from wheel: $WHEEL"
+        WIKI_PIP_SPEC="$WHEEL" node npm/bin/wiki.js --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release (PyPI)
+name: Release (PyPI + npm)
 
 on:
   push:
@@ -28,19 +28,25 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install dependencies
         run: uv sync
 
       - name: Install build tooling
         run: python -m pip install -U build twine
 
-      - name: Verify tag matches pyproject version
+      - name: Verify tag matches pyproject and package.json versions
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          python -c "import tomllib, pathlib; v=tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8')).get('project',{}).get('version'); print(v); assert v, 'missing version'"
           TAG="${GITHUB_REF_NAME#v}"
-          PYPROJECT="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])")"
-          test "$TAG" = "$PYPROJECT"
+          PY_VER=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml').read())['project']['version'])")
+          NPM_VER=$(node -e "console.log(require('./package.json').version)")
+          test "$TAG" = "$PY_VER" || { echo "::error::tag $TAG != pyproject $PY_VER"; exit 1; }
+          test "$TAG" = "$NPM_VER" || { echo "::error::tag $TAG != package.json $NPM_VER"; exit 1; }
 
       - name: Build
         run: python -m build
@@ -52,3 +58,13 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+
+      - name: Verify npm can pack
+        run: npm pack --dry-run
+
+      - name: Publish to npm (trusted publishing / OIDC)
+        run: npm publish --provenance
+
+      - name: Verify npm publish
+        run: |
+          npm view wazootech-wiki@$(node -e "console.log(require('./package.json').version)") version

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 ﻿# Wiki CLI (`wazootech-wiki`)
 
 [![PyPI version](https://badge.fury.io/py/wazootech-wiki.svg)](https://pypi.org/project/wazootech-wiki/)
+[![npm version](https://img.shields.io/npm/v/wazootech-wiki)](https://www.npmjs.com/package/wazootech-wiki)
 [![CI Status](https://github.com/wazootech/wiki/actions/workflows/ci.yml/badge.svg)](https://github.com/wazootech/wiki/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 An elegant, pure, and idiomatic Python command-line interface for managing a semantic knowledge base of markdown documents with SHACL validation and SPARQL reasoning.
 
-Repository: [github.com/wazootech/wiki](https://github.com/wazootech/wiki). PyPI package: `wazootech-wiki`. CLI command: `wiki`.
+Repository: [github.com/wazootech/wiki](https://github.com/wazootech/wiki). CLI command: `wiki`. Install via [pip](https://pypi.org/project/wazootech-wiki/) or [npm](https://www.npmjs.com/package/wazootech-wiki).
 
 Starter template repo: [github.com/wazootech/wiki-example](https://github.com/wazootech/wiki-example) (use GitHub’s “Use this template” button).
 
@@ -44,6 +45,21 @@ python -m wiki --help
 ```
 
 Multiple `wiki.exe` shims can coexist across Python installs. If PATH is preferring a stale launcher, run `python -m wiki upgrade -y` with the intended Python environment and remove or refresh the older `wiki.exe`.
+
+### From npm
+
+```bash
+npm install -g wazootech-wiki
+```
+
+This installs the `wiki` command globally via npm. The npm package automatically creates a private Python virtual environment and installs the matching PyPI version of `wazootech-wiki` as the engine. Python 3.12 or newer is required.
+
+Zero-install (no install required):
+
+```bash
+npx wazootech-wiki --help
+uvx wazootech-wiki --help
+```
 
 ### From within this repo (editable)
 

--- a/npm/bin/wiki.js
+++ b/npm/bin/wiki.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+const { spawnSync, spawn } = require('child_process');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..', '..');
+const VENV_DIR = path.join(PACKAGE_ROOT, '.venv');
+
+function getVenvPython() {
+  const isWin = process.platform === 'win32';
+  const exeName = isWin ? 'python.exe' : 'python';
+  const scriptsDir = isWin ? 'Scripts' : 'bin';
+  return path.join(VENV_DIR, scriptsDir, exeName);
+}
+
+function venvIsReady() {
+  const pythonExe = getVenvPython();
+  if (!fs.existsSync(pythonExe)) return false;
+  try {
+    const result = spawnSync(pythonExe, ['-c', 'import wiki; print("ok")'], { encoding: 'utf-8', timeout: 10000 });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function autoRepair() {
+  console.error('wazootech-wiki Python environment missing; repairing...');
+  try {
+    const setup = require('../setup');
+    setup();
+  } catch (err) {
+    console.error('Auto-repair failed:', err.message);
+    console.error('  Run: npm rebuild -g wazootech-wiki');
+    return false;
+  }
+  return venvIsReady();
+}
+
+function runWiki() {
+  const pythonExe = getVenvPython();
+  const args = ['-m', 'wiki', ...process.argv.slice(2)];
+  const child = spawn(pythonExe, args, { stdio: 'inherit' });
+
+  ['SIGINT', 'SIGTERM'].forEach((signal) => {
+    process.on(signal, () => child.kill(signal));
+  });
+
+  child.on('exit', (code) => process.exit(code));
+}
+
+if (!venvIsReady()) {
+  if (!autoRepair()) {
+    process.exit(1);
+  }
+}
+
+runWiki();

--- a/npm/python.js
+++ b/npm/python.js
@@ -1,0 +1,56 @@
+const { spawnSync } = require('child_process');
+const os = require('os');
+
+function tryCandidate(cmd, args) {
+  try {
+    const result = spawnSync(cmd, args, { encoding: 'utf-8', timeout: 10000 });
+    if (result.status === 0) {
+      return result.stdout.trim();
+    }
+  } catch {}
+  return null;
+}
+
+function parseVersion(versionStr) {
+  const parts = versionStr.split('.').map(Number);
+  return { major: parts[0] || 0, minor: parts[1] || 0, patch: parts[2] || 0 };
+}
+
+function meetsRequirement(version) {
+  return version.major > 3 || (version.major === 3 && version.minor >= 12);
+}
+
+function getPythonCandidates() {
+  const platform = os.platform();
+  if (platform === 'win32') {
+    return [
+      { cmd: 'py', args: ['-3.12', '-c', 'import sys; print(".".join(str(v) for v in sys.version_info[:3]))'] },
+      { cmd: 'py', args: ['-3', '-c', 'import sys; print(".".join(str(v) for v in sys.version_info[:3]))'] },
+      { cmd: 'python', args: ['-c', 'import sys; print(".".join(str(v) for v in sys.version_info[:3]))'] },
+    ];
+  }
+  return [
+    { cmd: 'python3.12', args: ['-c', 'import sys; print(".".join(str(v) for v in sys.version_info[:3]))'] },
+    { cmd: 'python3', args: ['-c', 'import sys; print(".".join(str(v) for v in sys.version_info[:3]))'] },
+    { cmd: 'python', args: ['-c', 'import sys; print(".".join(str(v) for v in sys.version_info[:3]))'] },
+  ];
+}
+
+function findPython() {
+  const candidates = getPythonCandidates();
+  for (const { cmd, args } of candidates) {
+    const versionStr = tryCandidate(cmd, args);
+    if (versionStr) {
+      const version = parseVersion(versionStr);
+      if (meetsRequirement(version)) {
+        const fullPath = tryCandidate(cmd, ['-c', 'import sys; print(sys.executable)']);
+        if (fullPath) {
+          return { path: fullPath, version };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+module.exports = { findPython };

--- a/npm/setup.js
+++ b/npm/setup.js
@@ -1,0 +1,86 @@
+const { execSync, spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { findPython } = require('./python');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const VENV_DIR = path.join(PACKAGE_ROOT, '.venv');
+
+function getVenvPython() {
+  const isWin = process.platform === 'win32';
+  const exeName = isWin ? 'python.exe' : 'python';
+  const scriptsDir = isWin ? 'Scripts' : 'bin';
+  return path.join(VENV_DIR, scriptsDir, exeName);
+}
+
+function getPackageVersion() {
+  return require(path.join(PACKAGE_ROOT, 'package.json')).version;
+}
+
+function venvIsUsable() {
+  const venvPython = getVenvPython();
+  if (!fs.existsSync(venvPython)) return false;
+  try {
+    const result = spawnSync(venvPython, ['-c', 'import wiki; print("ok")'], { encoding: 'utf-8', timeout: 10000 });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function run(cmd, description) {
+  console.error(`  ${description}...`);
+  try {
+    execSync(cmd, { stdio: 'inherit', timeout: 300000 });
+  } catch (err) {
+    const msg = err.status
+      ? `  ${description} exited with code ${err.status}`
+      : `  Failed to run ${description.toLowerCase()}: ${err.message}`;
+    throw new Error(msg);
+  }
+}
+
+function setup() {
+  if (venvIsUsable()) {
+    console.error('wazootech-wiki Python environment already exists. Skipping setup.');
+    return;
+  }
+
+  if (fs.existsSync(getVenvPython())) {
+    console.error('wazootech-wiki Python environment incomplete; rebuilding...');
+  }
+
+  const pythonInfo = findPython();
+  if (!pythonInfo) {
+    die(`wazootech-wiki requires Python 3.12 or newer.
+
+Install Python:
+  macOS:    brew install python@3.12
+  Windows:  winget install Python.Python.3.12
+  Linux:    use your distro package manager or https://www.python.org/downloads/
+
+Then rerun: npm install -g wazootech-wiki`);
+  }
+
+  const version = getPackageVersion();
+  const pythonPath = pythonInfo.path;
+  const venvPython = getVenvPython();
+
+  run(`"${pythonPath}" -m venv "${VENV_DIR}"`, 'Creating Python virtual environment');
+  run(`"${venvPython}" -m pip install --upgrade pip`, 'Upgrading pip');
+
+  const pkgSpec = process.env.WIKI_PIP_SPEC || `wazootech-wiki==${version}`;
+  run(`"${venvPython}" -m pip install ${pkgSpec}`, 'Installing wazootech-wiki');
+  console.error(`wazootech-wiki ${version} Python environment ready.`);
+}
+
+if (require.main === module) {
+  setup();
+}
+
+module.exports = setup;

--- a/npm/uninstall.js
+++ b/npm/uninstall.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const VENV_DIR = path.join(PACKAGE_ROOT, '.venv');
+
+if (fs.existsSync(VENV_DIR)) {
+  console.error('Removing wazootech-wiki Python environment...');
+  fs.rmSync(VENV_DIR, { recursive: true, force: true });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "wazootech-wiki",
+  "version": "0.1.11",
+  "description": "Clean, pure, idiomatic CLI for managing a semantic LLM wiki",
+  "homepage": "https://github.com/wazootech/wiki",
+  "bugs": "https://github.com/wazootech/wiki/issues",
+  "license": "MIT",
+  "bin": {
+    "wiki": "npm/bin/wiki.js"
+  },
+  "scripts": {
+    "postinstall": "node npm/setup.js",
+    "preuninstall": "node npm/uninstall.js",
+    "setup": "node npm/setup.js"
+  },
+  "files": [
+    "npm/",
+    "package.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazootech-wiki",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Clean, pure, idiomatic CLI for managing a semantic LLM wiki",
   "homepage": "https://github.com/wazootech/wiki",
   "bugs": "https://github.com/wazootech/wiki/issues",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wazootech-wiki"
-version = "0.1.11"
+version = "0.1.12"
 description = "Clean, pure, idiomatic Python CLI for managing a semantic LLM wiki"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Add npm delivery layer for wazootech-wiki

Implements the design from the grilling session: an npm wrapper that installs a private Python venv and delegates to \python -m wiki\.

See issue #44 for the strategy.

### What ships
- \package.json\, \
pm/\ � npm package exposing \wiki\ bin
- CI: new \
pm-checks\ job with version lock, syntax check, pack, and integration test
- Release: publish npm via OIDC after PyPI in lockstep

### You need to do after merge
1. Configure npm trusted publishing on npmjs.com for wazootech-wiki:
   - Provider: GitHub Actions
   - Repository: wazootech/wiki
   - Workflow: release.yml
2. Push tag v0.1.12 (already bumped)
