### PR TITLE
Use Node 24 for npm OIDC release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: uv sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ wiki = "wiki.__main__:main"
 wikilink = "wiki.mdformat_wikilink"
 
 [tool.setuptools]
-packages = ["wiki"]
 package-dir = {"" = "src"}
+packages = {find = {where = ["src"], include = ["wiki*"]}}
 package-data = {"wiki" = ["templates/*"]}
 
 [tool.uv]


### PR DESCRIPTION
## Summary

- Bump Node to 24 in \elease.yml\ so npm trusted publishing (OIDC) works in CI (requires npm CLI 11.5.1+).
- Includes setuptools packaging fix for \wiki.schemas\, \wiki.site\, and \wiki.mdit_py_plugins\ subpackages.

npm trusted publishing is configured on \wazootech-wiki\ for \wazootech/wiki\ / \elease.yml\.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, tag release validates PyPI + npm OIDC publish