### PR TITLE
Add install-wiki and create-wiki onboarding skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,25 @@
+# Wiki CLI agent skills
+
+Agent skills for [Wiki CLI](https://github.com/wazootech/wiki). They live under `skills/` and are **not** vault content — do not add this folder to `vault.inputs`.
+
+## Onboarding (independent modules)
+
+| Skill | Purpose |
+| ----- | ------- |
+| [install-wiki](install-wiki/SKILL.md) | Install and verify the CLI (`wazootech-wiki`). Exits with “installed and ready to go.” |
+| [create-wiki](create-wiki/SKILL.md) | `wiki init` plus a preferences wizard (site name, first page). Requires CLI on PATH. |
+
+No orchestrator and **no required order**. Each skill completes its own job and stops. Neither skill tells the user to invoke the other.
+
+- Missing CLI while creating a wiki → `create-wiki` states the blocker and stops; the user chooses how to install.
+- After install → `install-wiki` confirms ready; it does not suggest scaffolding.
+
+## Vault hygiene
+
+| Skill | Purpose |
+| ----- | ------- |
+| [best-practices](best-practices/SKILL.md) | Audit a vault: fmt, lint, check, render |
+
+## Docs
+
+Canonical user docs: [docs/wiki/Getting_Started.md](../docs/wiki/Getting_Started.md)

--- a/skills/create-wiki/SKILL.md
+++ b/skills/create-wiki/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: create-wiki
+description: >-
+  Scaffold a Wiki CLI workspace with wiki init, then walk through site name, first
+  page, and light preferences. Use when the user wants a new wiki, wiki init,
+  bootstrap semantic markdown, get started with a new vault, or customize an
+  existing scaffold — even if they do not say "skill". Requires the wiki command
+  on PATH.
+---
+
+# Create Wiki
+
+Scaffold a new [Wiki CLI](https://github.com/wazootech/wiki) workspace: `wiki init` plus a short preferences wizard. Requires **`wiki` on PATH** (PyPI package `wazootech-wiki`).
+
+Skills under `skills/` are agent procedural knowledge — not vault pages and not indexed by `wiki`.
+
+## Modularity
+
+This skill **only** scaffolds or customizes a workspace. When done, summarize and **stop**. Do not suggest installing the CLI or name other skills. If the CLI is missing, state the blocker and stop — the user chooses how to follow up.
+
+## Resolve wiki command
+
+Prefer `wiki` on PATH. In the **wiki-cli repository checkout** only, if global `wiki` is missing or stale:
+
+```bash
+uv run wiki --help
+python -m wiki --help
+```
+
+Use the command that works for all steps below (`wiki`, `uv run wiki`, or `python -m wiki`).
+
+## Prerequisite gate
+
+Before init or file edits, verify the CLI:
+
+```bash
+wiki --help
+```
+
+If it fails:
+
+1. Say that **creating a wiki requires the Wiki CLI on PATH**.
+2. Optional one-liner: PyPI package name is **`wazootech-wiki`** (not a full install tutorial).
+3. **Do not** run `wiki init`, write scaffold files, or paste a step-by-step pip guide.
+4. **Do not** say “use install-wiki” or reference any skill path.
+5. **Stop.**
+
+## Workflow (CLI present)
+
+Ask **one decision at a time** with a short explainer. Prefer **flags** over interactive `wiki init` prompts (stdin blocks agents).
+
+### Choose mode
+
+- **`wiki.yaml` absent** → Phase A (init) then Phase B (wizard).
+- **`wiki.yaml` present** → **Wizard-only** (Phase B). Do not re-init unless the user explicitly wants `--force`.
+
+### Phase A — Init
+
+1. **Directory** — Confirm workspace root. `wiki init` writes to the **current directory** (`wiki.yaml`, `README.md`, `wiki/`, `layouts/`).
+2. **Init options** — Gather flags before running (see [references/init-options.md](references/init-options.md)):
+
+| Topic | When to ask | Flag |
+| ----- | ----------- | ---- |
+| GitHub Pages | User publishes to `{owner}.github.io/{repo}` | `--repo owner/repo` |
+| Custom namespace | No GitHub / custom site | `--graph-context-wiki https://…/` and optional `--site-base-url` |
+| Git repository | User wants `git init` now | `--git` (requires `git` on PATH) |
+| Link style | Obsidian-style wikilinks vs markdown | `--link-style wikilink` (default: omit → markdown) |
+
+If the user has no preference for namespace and no `--repo`, pass:
+
+`--graph-context-wiki https://wiki.example.org/`
+
+3. **Preflight** — Without `--force`, init fails if any exist:
+
+- `wiki.yaml`
+- `README.md`
+- non-empty `wiki/`
+
+If blocked, ask: different directory, or `wiki init --force` (overwrites scaffold files).
+
+4. **Run** — Example:
+
+```bash
+wiki init --repo owner/repo --git
+```
+
+Capture stdout/stderr.
+
+### Phase B — Preferences wizard
+
+Gather **before init** when it affects flags (`--repo`, `--link-style`). **After init** for file edits:
+
+| Topic | Action |
+| ----- | ------ |
+| Site display name | Edit `site.manifest.name` in `wiki.yaml` |
+| First page | Replace or rename `wiki/Ethan_Davidson.md`, or add the user’s page |
+| Lint strictness | Only if user asks — explain `lint.headings` etc. in `wiki.yaml` |
+
+**Only edit files with explicit user approval.** After markdown or config edits, run `wiki fmt` on changed paths when a config exists.
+
+### What init creates
+
+- `wiki.yaml` — vault, graph, site, lint, fmt defaults
+- `layouts/default.html`
+- `wiki/Person_Shape.md`, `wiki/Ethan_Davidson.md`
+- `README.md`
+
+See [Wiki_Subcommand_init.md](../../docs/wiki/Wiki_Subcommand_init.md) for full detail.
+
+## Clean exit
+
+Summarize: workspace path, init flags used, wizard edits (if any). You may mention [Getting_Started.md](../../docs/wiki/Getting_Started.md) for daily commands (`check`, `lint`, `serve`) — not as a required next step.
+
+**Do not** run `wiki check`, `wiki lint`, or `wiki serve` unless the user asks.
+
+## Troubleshooting
+
+| Issue | Response |
+| ----- | -------- |
+| `wiki.yaml already exists` | Wizard-only, new directory, or `--force` with user consent |
+| Invalid `--repo` | Fix `owner/repo` or use `--graph-context-wiki` |
+| `--git` fails | Report error; init may have completed without git |
+| Interactive prompt during init | Re-run with explicit flags — avoid bare `wiki init` in agent sessions |
+
+## Related docs
+
+- [references/init-options.md](references/init-options.md) — `wiki init` flags
+- [Wiki_Configuration.md](../../docs/wiki/Wiki_Configuration.md) — `wiki.yaml` semantics
+- [Getting_Started.md](../../docs/wiki/Getting_Started.md) — install and daily workflow

--- a/skills/create-wiki/evals/evals.json
+++ b/skills/create-wiki/evals/evals.json
@@ -1,0 +1,51 @@
+{
+  "skill_name": "create-wiki",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I want a new wiki in ~/projects/my-notes for GitHub Pages at me/my-notes",
+      "expected_output": "wiki init with --repo me/my-notes; preferences wizard for site name and first page; no check/lint/serve unless asked.",
+      "files": [],
+      "expectations": [
+        "Uses wiki init with --repo or equivalent non-interactive flags",
+        "Asks about or applies site manifest name or first page in wizard",
+        "Does not run wiki check, wiki lint, or wiki serve unsolicited",
+        "Does not include a full pip install tutorial"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Scaffold a wiki in an empty directory",
+      "expected_output": "Init with explicit flags; at least one wizard question; fmt only if edits approved.",
+      "files": [],
+      "expectations": [
+        "Runs or plans wiki init with non-interactive flags",
+        "Includes preferences wizard after init",
+        "Does not run check/lint/serve pipeline unsolicited"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Create a wiki for me",
+      "expected_output": "When CLI missing: states CLI requirement, optional wazootech-wiki one-liner, stops without naming install-wiki or running init.",
+      "files": [],
+      "expectations": [
+        "States that Wiki CLI on PATH is required when CLI is missing",
+        "Does not run wiki init when CLI is missing",
+        "Does not say install-wiki or reference skills/install-wiki path",
+        "Does not paste a full step-by-step pip install guide"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Customize my wiki — wiki.yaml already exists",
+      "expected_output": "Wizard-only mode; no force re-init; edits only with approval.",
+      "files": [],
+      "expectations": [
+        "Skips wiki init or does not use --force without explicit user request",
+        "Focuses on site name, first page, or preferences wizard",
+        "Does not run check/lint/serve unsolicited"
+      ]
+    }
+  ]
+}

--- a/skills/create-wiki/references/init-options.md
+++ b/skills/create-wiki/references/init-options.md
@@ -1,0 +1,48 @@
+# `wiki init` options
+
+Condensed from [Wiki_Subcommand_init.md](../../../docs/wiki/Wiki_Subcommand_init.md). Use non-interactive flags in agent sessions so `wiki init` does not block on stdin.
+
+## Usage
+
+```bash
+wiki init
+wiki init --force
+wiki init --git
+wiki init --repo wazootech/wiki
+wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywiki
+```
+
+## Flags
+
+| Flag | Description |
+| ---- | ----------- |
+| `--force` | Overwrite existing `wiki.yaml`, `README.md`, starter `wiki/` files, and `layouts/default.html` |
+| `--git` | Run `git init` after scaffolding |
+| `--repo` | GitHub `owner/repo`; infer `graph.context.wiki` and `site.base_url` for GitHub Pages |
+| `--graph-context-wiki` | Override `graph.context.wiki` (wins over `--repo`) |
+| `--site-base-url` | Override `site.base_url` (default `/wiki` or inferred from `--repo`) |
+| `--site-url-style` | `dir` or `file` (default `dir`) |
+| `--graph-content-predicate` | Override `graph.content_predicate` CURIE (e.g. `schema:articleBody`) |
+| `--link-style` | `markdown` or `wikilink` |
+
+## URL resolution order
+
+When `--graph-context-wiki` is not passed:
+
+1. **`--repo`** — `https://{owner}.github.io/{repo}/` and `site.base_url: /{repo}`
+2. **Git remote** — If `.git` exists or `--git` was passed, parse `origin` when GitHub
+3. **Interactive prompt** — default IRI `https://wiki.example.org/` (avoid in agent runs — pass a flag)
+
+`--graph-context-wiki` always wins over `--repo`. `--site-base-url` overrides inferred path from `--repo`.
+
+## Generated layout
+
+| Path | Purpose |
+| ---- | ------- |
+| `wiki.yaml` | Config: vault, graph, site, lint, fmt |
+| `layouts/default.html` | Default page layout |
+| `wiki/Person_Shape.md` | Starter SHACL shape |
+| `wiki/Ethan_Davidson.md` | Starter Person example |
+| `README.md` | Workspace overview |
+
+Default: no Git repo. Use `--git` to run `git init`.

--- a/skills/install-wiki/SKILL.md
+++ b/skills/install-wiki/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: install-wiki
+description: >-
+  Install and verify the Wiki CLI (wazootech-wiki on PyPI). Use when the user needs
+  to install wiki, wiki is not found on PATH, pip or PyPI setup, or the CLI is
+  missing — even if they do not say "skill".
+---
+
+# Install Wiki CLI
+
+Install and verify the [Wiki CLI](https://github.com/wazootech/wiki) (`wiki` command, PyPI package **`wazootech-wiki`**).
+
+Skills under `skills/` are agent procedural knowledge — not vault pages and not indexed by `wiki`.
+
+## Modularity
+
+This skill **only** installs and verifies the CLI. When done, say the CLI is ready and **stop**. Do not suggest creating a wiki, scaffolding a vault, or any follow-on task. Do not name other skills or skills paths.
+
+## Workflow
+
+### 1. Detect
+
+Run:
+
+```bash
+wiki --help
+```
+
+If that succeeds, the CLI is already installed. Confirm briefly (help output or version if available), then tell the user:
+
+**Wiki CLI is installed and ready to go.**
+
+Exit.
+
+### 2. Install (CLI missing)
+
+Tell the user the CLI was not found. Give the standard install block:
+
+```bash
+pip install wazootech-wiki
+wiki --help
+```
+
+You may offer to run `pip install wazootech-wiki` **only if the user explicitly approves** (network and environment vary).
+
+**Contributors in the wiki-cli repository** may instead use:
+
+```bash
+uv pip install -e .
+uv run wiki --help
+```
+
+Use `uv run wiki` only when the current working directory is this checkout and the user is developing the CLI — not as the default for end users.
+
+### 3. Verify
+
+After install (user-run or agent-run with approval), run `wiki --help` again.
+
+- **Success** → **Wiki CLI is installed and ready to go.** Exit.
+- **Failure** → Report the error output. Exit. The user chooses whether to retry, fix their environment, or ask again.
+
+## Do not
+
+- Suggest `wiki init`, creating a workspace, or daily workflow commands as a required next step.
+- Auto-run `pip install` without user approval.
+- Duplicate full vault or configuration documentation.
+
+## Related docs
+
+- [Getting_Started.md](../../docs/wiki/Getting_Started.md) — install and daily commands (for the user’s reference, not as a “next step” from this skill)

--- a/skills/install-wiki/evals/evals.json
+++ b/skills/install-wiki/evals/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "install-wiki",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I want to use wiki but don't have it installed",
+      "expected_output": "Install instructions for wazootech-wiki; optional pip with user approval; verify wiki --help; ready message without suggesting create-wiki or scaffolding.",
+      "files": [],
+      "expectations": [
+        "Mentions pip install wazootech-wiki or equivalent install path",
+        "Runs or instructs verification with wiki --help",
+        "Ends with installed and ready to go or equivalent success message when CLI works",
+        "Does not mention create-wiki or wiki init as a next step",
+        "Does not run wiki init"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Check if wiki CLI is installed",
+      "expected_output": "Runs wiki --help; if success, confirms installed and ready only — no follow-on suggestions.",
+      "files": [],
+      "expectations": [
+        "Runs wiki --help or wiki --version",
+        "If CLI works, message is ready-to-go style without next-step suggestions",
+        "Does not mention create-wiki",
+        "Does not suggest scaffolding a vault"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add **install-wiki** and **create-wiki** agent skills for onboarding new wikis (independent modules; no orchestrator).
- **install-wiki**: detect CLI, install with approval, verify, exit with "installed and ready to go" (no cross-skill suggestions).
- **create-wiki**: prerequisite gate, `wiki init` walkthrough, preferences wizard, wizard-only when `wiki.yaml` exists; references `init-options.md`.
- Suite map in `skills/README.md`; eval definitions in each skill's `evals/evals.json`.

## Eval results (iteration 1)

Full eval artifacts (review HTML, grading, responses, benchmarks) are on a public gist:

https://gist.github.com/EthanThatOneKid/f318d9281810acbb539ca077be7cac32

Open **install-wiki-review.html** and **create-wiki-review.html** in the gist for side-by-side review.

## Test plan

- [ ] Read `skills/install-wiki/SKILL.md` and `skills/create-wiki/SKILL.md` for modularity (no required ordering, no install-wiki named from create-wiki).
- [ ] Spot-check `skills/create-wiki/references/init-options.md` against `wiki init` docs.
- [ ] Optional: run skill-creator eval loop locally against iteration-1 prompts.
