### PR TITLE
Fix init flags (#72) and rename link.style to markdown/obsidian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 ### Changed
 
 - `wiki upgrade` on standalone binaries prints GitHub Releases re-download instructions instead of calling pip
+- `link.style` value `wikilink` renamed to `obsidian` (standard Markdown vs Obsidian wikilinks); `wiki init --link-style` and docs use the new names
 
 ### Changed (breaking)
 
@@ -73,6 +74,7 @@
 4. In `site:` move branding into `manifest:`:
    - `title` → `manifest.name`
    - `theme_color` → `manifest.theme_color`
+5. In `link:` rename `style: wikilink` → `style: obsidian` (default remains `markdown`)
 
 ## 0.1.9 — 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Standalone `wiki` executables for Linux, macOS, and Windows via PyInstaller — published to GitHub Releases with `SHA256SUMS` on each `v*` tag ([#77](https://github.com/wazootech/wiki/issues/77))
 - Unified [`.github/workflows/release.yml`](.github/workflows/release.yml): PyPI, npm, and GitHub Release binaries in one workflow (replaces separate `release.yaml`)
 
+### Fixed
+
+- `wiki init --graph-implicit-types-policy` accepts `fallback` or `append` (was incorrectly `override`) ([#72](https://github.com/wazootech/wiki/issues/72))
+
 ### Changed
 
 - `wiki upgrade` on standalone binaries prints GitHub Releases re-download instructions instead of calling pip

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ wiki link --apply
 wiki link --fix-broken
 ```
 
-`wiki lint` reports broken links (`lint.broken_links`). `wiki link` enriches prose with new internal links (`--apply`) or fixes typos and renames when the target is unique (`--fix-broken`). `--apply` uses `link.style` in `wiki.yaml` (`markdown` inserts `[text](Page.md)`; `wikilink` inserts `[[Page|text]]`). `lint.link_style` flags wikilinks in body prose when `link.style` is `markdown`. Optional `link.renames` maps old slugs to new routes for renames.
+`wiki lint` reports broken links (`lint.broken_links`). `wiki link` enriches prose with new internal links (`--apply`) or fixes typos and renames when the target is unique (`--fix-broken`). `--apply` uses `link.style` in `wiki.yaml` (`markdown` inserts `[text](Page.md)`; `obsidian` inserts `[[Page|text]]`). `lint.link_style` flags Obsidian wikilinks in body prose when `link.style` is `markdown`. Optional `link.renames` maps old slugs to new routes for renames.
 
 ### `query`
 Execute any SPARQL SELECT or CONSTRUCT query against the loaded and reasoning-expanded RDF graph. The graph is built once per process and reused across queries in the same run (see **Graph cache** under `render`). Use `--cache` to persist a warm graph under `.wiki/cache/` for reuse across new CLI processes.

--- a/docs/wiki.yaml
+++ b/docs/wiki.yaml
@@ -54,7 +54,7 @@ site:
 
 # wiki link command output format and rename repair map.
 link:
-  # wikilink or markdown (wiki link --apply).
+  # standard Markdown or Obsidian (wiki link --apply).
   style: markdown
   # renames:
   #   Old_Page_Name: New_Page_Name

--- a/docs/wiki/Style_Guide.md
+++ b/docs/wiki/Style_Guide.md
@@ -113,7 +113,7 @@ All internal links must resolve to existing documents in the wiki.
 
 Use Markdown links for all internal and external URLs. Do not mix wikilinks (`[[Page]]`) with Markdown links in wiki prose.
 
-Markdown links are the default (`link.style: markdown` in [wiki.yaml](Wiki_Configuration.md)). `wiki link --apply` inserts `[display](Page_Name.md)` links. `wiki lint` reports wikilinks in body prose via `lint.link_style` (warning by default).
+Standard Markdown links are the default (`link.style: markdown` in [wiki.yaml](Wiki_Configuration.md)). `wiki link --apply` inserts `[display](Page_Name.md)` links. Set `link.style: obsidian` to insert `[[Page|display]]` instead. `wiki lint` reports Obsidian wikilinks in body prose via `lint.link_style` (warning by default).
 
 ## References (external standards)
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -138,10 +138,10 @@ Branding and PWA metadata use the [Web App Manifest](https://www.w3.org/TR/appma
 
 Settings for the `wiki link` command family (separate from `lint.link_style` severity):
 
-| Key            | Default    | Purpose                                                       |
-| -------------- | ---------- | ------------------------------------------------------------- |
+| Key            | Default    | Purpose                                                                                               |
+| -------------- | ---------- | ----------------------------------------------------------------------------------------------------- |
 | `link.style`   | `markdown` | Format `wiki link --apply` inserts: standard Markdown (`markdown`) or Obsidian wikilinks (`obsidian`) |
-| `link.renames` | `{}`       | Old slug → new route map for `wiki link --fix-broken`         |
+| `link.renames` | `{}`       | Old slug → new route map for `wiki link --fix-broken`                                                 |
 
 ## Serve API
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -140,7 +140,7 @@ Settings for the `wiki link` command family (separate from `lint.link_style` sev
 
 | Key            | Default    | Purpose                                                       |
 | -------------- | ---------- | ------------------------------------------------------------- |
-| `link.style`   | `markdown` | Format `wiki link --apply` inserts (`markdown` or `wikilink`) |
+| `link.style`   | `markdown` | Format `wiki link --apply` inserts: standard Markdown (`markdown`) or Obsidian wikilinks (`obsidian`) |
 | `link.renames` | `{}`       | Old slug → new route map for `wiki link --fix-broken`         |
 
 ## Serve API
@@ -353,7 +353,7 @@ Page routes keep the casing from the filename; GitHub Pages URLs are case-sensit
 
 `wiki link --fix-broken` preserves the existing link kind in each file; only `--apply` uses `link.style`.
 
-When `link.style` is `markdown`, `lint.link_style` (default `warning`) flags Obsidian wikilinks in body prose. Set `lint.link_style: off` to allow wikilinks while keeping markdown as the apply format, or set `link.style: wikilink` for an Obsidian-style wiki.
+When `link.style` is `markdown`, `lint.link_style` (default `warning`) flags Obsidian wikilinks (`[[Page]]`) in body prose. Set `lint.link_style: off` to allow wikilinks while keeping Markdown as the apply format, or set `link.style: obsidian` for an Obsidian-style wiki.
 
 ## Formatting (`fmt`)
 
@@ -390,7 +390,7 @@ Under `lint`, each rule is `error`, `warning`, or `off`:
 | `filename_pattern` | `warning` | Full filename vs `wiki.filename_pattern` regex                                                                 |
 | `headings`         | `off`     | ATX `#` headings only (no Setext underlines), sentence-case H2+, H1 title case conventional, numbered headings |
 | `thematic_breaks`  | `off`     | Horizontal rules (`---`, `***`, `___`) in body prose                                                           |
-| `link_style`       | `warning` | Wikilinks in body prose when `link.style` is `markdown`                                                        |
+| `link_style`       | `warning` | Obsidian wikilinks (`[[Page]]`) in body prose when `link.style` is `markdown`                                  |
 
 ## This repository
 

--- a/docs/wiki/Wiki_Subcommand_init.md
+++ b/docs/wiki/Wiki_Subcommand_init.md
@@ -31,7 +31,7 @@ wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywi
 | `--site-base-url`                | Override `site.base_url` (default `/wiki` or inferred from `--repo`)                           |
 | `--site-url-style`               | Override `site.url_style`: `dir` or `file` (default `dir`)                                     |
 | `--graph-content-predicate`      | Override `graph.content_predicate` CURIE (e.g. `schema:articleBody`)                           |
-| `--link-style`                   | Override `link.style`: `markdown` or `wikilink`                                                |
+| `--link-style`                   | Override `link.style`: standard Markdown (`markdown`) or Obsidian wikilinks (`obsidian`)       |
 | `--site-manifest-name`           | Override `site.manifest.name` (default `Wiki CLI`)                                             |
 | `--wiki-inputs`                  | Override `wiki.inputs` list (can be specified multiple times, default `[wiki]`)                |
 | `--graph-base-iri`               | Override `graph.base_iri` URI                                                                  |

--- a/docs/wiki/Wiki_Subcommand_init.md
+++ b/docs/wiki/Wiki_Subcommand_init.md
@@ -37,7 +37,7 @@ wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywi
 | `--graph-base-iri`               | Override `graph.base_iri` URI                                                                  |
 | `--site-manifest-theme-color`    | Override `site.manifest.theme_color` (e.g. `#3b82f6`)                                          |
 | `--graph-implicit-types`         | Override `graph.implicit_types` (can be specified multiple times)                              |
-| `--graph-implicit-types-policy`  | Override `graph.implicit_types_policy`: `fallback` or `override`                               |
+| `--graph-implicit-types-policy`  | Override `graph.implicit_types_policy`: `fallback` or `append`                                 |
 | `--graph-include-file-extension` | Override `graph.include_file_extension` flag (defaults to `--no-graph-include-file-extension`) |
 
 ## URL resolution

--- a/docs/wiki/Wiki_Subcommand_link.md
+++ b/docs/wiki/Wiki_Subcommand_link.md
@@ -27,7 +27,7 @@ wiki link --fix-broken --dry-run
 | Flag              | Description                                                                                                                                                         |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `FILE...`         | Optional markdown paths; otherwise entire wiki                                                                                                                      |
-| `--apply`         | Insert internal links for each suggestion (body only, never frontmatter); format from `link.style` in [wiki.yaml](Wiki_Configuration.md) (`wikilink` or `markdown`) |
+| `--apply`         | Insert internal links for each suggestion (body only, never frontmatter); format from `link.style` in [wiki.yaml](Wiki_Configuration.md) (`markdown` or `obsidian`) |
 | `--fix-broken`    | Repair unambiguous broken wikilinks and internal markdown page links                                                                                                |
 | `-n`, `--dry-run` | Preview `--apply` or `--fix-broken` without writing files                                                                                                           |
 | `-c`, `--check`   | Exit 1 if opportunities or broken links remain (CI gate)                                                                                                            |

--- a/docs/wiki/Wiki_Subcommand_lint.md
+++ b/docs/wiki/Wiki_Subcommand_lint.md
@@ -40,7 +40,7 @@ wiki lint --strict
 | `heading_levels`     | Heading depth must increase by one level at a time (MD001-inspired)                              |
 | `duplicate_headings` | Duplicate H2+ heading text in the same document (MD024-inspired)                                 |
 | `thematic_breaks`    | Horizontal rules (`---`, `***`, `___`) in body prose                                             |
-| `link_style`         | Wikilinks in body prose when `link.style` is `markdown`                                          |
+| `link_style`         | Obsidian wikilinks (`[[Page]]`) in body prose when `link.style` is `markdown`                  |
 
 Each rule is `error`, `warning`, or `off`. Defaults: `broken_links`, `filename_pattern`, and `link_style` are `warning`; `headings`, `heading_levels`, `duplicate_headings`, and `thematic_breaks` are `off`.
 

--- a/docs/wiki/Wiki_Subcommand_lint.md
+++ b/docs/wiki/Wiki_Subcommand_lint.md
@@ -40,7 +40,7 @@ wiki lint --strict
 | `heading_levels`     | Heading depth must increase by one level at a time (MD001-inspired)                              |
 | `duplicate_headings` | Duplicate H2+ heading text in the same document (MD024-inspired)                                 |
 | `thematic_breaks`    | Horizontal rules (`---`, `***`, `___`) in body prose                                             |
-| `link_style`         | Obsidian wikilinks (`[[Page]]`) in body prose when `link.style` is `markdown`                  |
+| `link_style`         | Obsidian wikilinks (`[[Page]]`) in body prose when `link.style` is `markdown`                    |
 
 Each rule is `error`, `warning`, or `off`. Defaults: `broken_links`, `filename_pattern`, and `link_style` are `warning`; `headings`, `heading_levels`, `duplicate_headings`, and `thematic_breaks` are `off`.
 

--- a/skills/wiki-best-practices/SKILL.md
+++ b/skills/wiki-best-practices/SKILL.md
@@ -75,7 +75,7 @@ When `lint.*` rules are `off`, still note violations. Use the spot-check table b
 | ---- | ------------- |
 | Filenames | Wikipedia-style (`Page_Name.md`); `index.md` only for folder routes |
 | Headings | Title-case H1; sentence-case H2+; ATX `#` only |
-| Links | Markdown `[text](Page.md)` when `link.style: markdown` |
+| Links | Standard Markdown `[text](Page.md)` when `link.style: markdown`; Obsidian `[[Page]]` when `obsidian` |
 | Frontmatter | `type` / shapes aligned; CURIEs use `graph.context` |
 | SPARQL | People → `givenName`/`familyName`; TechArticle → `headline`/`description` |
 | Prose | No `---` thematic breaks in body; `## References` on standard pages |

--- a/skills/wiki-create/SKILL.md
+++ b/skills/wiki-create/SKILL.md
@@ -68,6 +68,12 @@ Ask **one decision at a time** with a short explainer. Prefer **flags** over int
 | Site display name | Custom display title | `--site-manifest-name "My Title"` |
 | Inputs directory | Custom markdown folder | `--wiki-inputs myfolder` |
 | Theme color | Manifest theme color | `--site-manifest-theme-color "#3b82f6"` |
+| URL style | File vs directory routes | `--site-url-style dir` or `file` |
+| Content predicate | Body text RDF predicate | `--graph-content-predicate schema:articleBody` |
+| Document IRIs | IRIs differ from `wiki:` namespace | `--graph-base-iri https://…/` |
+| Implicit types | Wiki-wide default `rdf:type` CURIEs | `--graph-implicit-types schema:TechArticle` (repeatable) |
+| Implicit types policy | Merge vs fallback for types | `--graph-implicit-types-policy append` or `fallback` |
+| File extension in IRIs | Include `.md` in document URIs | `--graph-include-file-extension` |
 
 If the user has no preference for namespace and no `--repo`, pass:
 

--- a/skills/wiki-create/SKILL.md
+++ b/skills/wiki-create/SKILL.md
@@ -64,7 +64,7 @@ Ask **one decision at a time** with a short explainer. Prefer **flags** over int
 | GitHub Pages | User publishes to `{owner}.github.io/{repo}` | `--repo owner/repo` |
 | Custom namespace | No GitHub / custom site | `--graph-context-wiki https://…/` and optional `--site-base-url` |
 | Git repository | User wants `git init` now | `--git` (requires `git` on PATH) |
-| Link style | Obsidian-style wikilinks vs markdown | `--link-style wikilink` (default: omit → markdown) |
+| Link style | Obsidian wikilinks vs standard Markdown | `--link-style obsidian` (default: omit → `markdown`) |
 | Site display name | Custom display title | `--site-manifest-name "My Title"` |
 | Inputs directory | Custom markdown folder | `--wiki-inputs myfolder` |
 | Theme color | Manifest theme color | `--site-manifest-theme-color "#3b82f6"` |

--- a/skills/wiki-create/references/init-options.md
+++ b/skills/wiki-create/references/init-options.md
@@ -24,6 +24,13 @@ wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywi
 | `--site-url-style` | `dir` or `file` (default `dir`) |
 | `--graph-content-predicate` | Override `graph.content_predicate` CURIE (e.g. `schema:articleBody`) |
 | `--link-style` | `markdown` or `wikilink` |
+| `--site-manifest-name` | Override `site.manifest.name` (default `Wiki CLI`) |
+| `--wiki-inputs` | Default markdown directories relative to config root (repeatable; default `wiki`) |
+| `--graph-base-iri` | Override `graph.base_iri` when document IRIs differ from `graph.context.wiki` |
+| `--site-manifest-theme-color` | Override `site.manifest.theme_color` (e.g. `#3b82f6`) |
+| `--graph-implicit-types` | Default `rdf:type` CURIEs for untyped documents (repeatable) |
+| `--graph-implicit-types-policy` | `fallback` or `append` when applying `graph.implicit_types` |
+| `--graph-include-file-extension` / `--no-graph-include-file-extension` | Include file extension in inferred document URIs |
 
 ## URL resolution order
 

--- a/skills/wiki-create/references/init-options.md
+++ b/skills/wiki-create/references/init-options.md
@@ -23,7 +23,7 @@ wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywi
 | `--site-base-url` | Override `site.base_url` (default `/wiki` or inferred from `--repo`) |
 | `--site-url-style` | `dir` or `file` (default `dir`) |
 | `--graph-content-predicate` | Override `graph.content_predicate` CURIE (e.g. `schema:articleBody`) |
-| `--link-style` | `markdown` or `wikilink` |
+| `--link-style` | Standard Markdown (`markdown`, default) or Obsidian wikilinks (`obsidian`) |
 | `--site-manifest-name` | Override `site.manifest.name` (default `Wiki CLI`) |
 | `--wiki-inputs` | Default markdown directories relative to config root (repeatable; default `wiki`) |
 | `--graph-base-iri` | Override `graph.base_iri` when document IRIs differ from `graph.context.wiki` |

--- a/skills/wiki-create/references/wiki-yaml-preferences.md
+++ b/skills/wiki-create/references/wiki-yaml-preferences.md
@@ -19,7 +19,7 @@ Maps to layout chrome and `manifest.webmanifest`.
 | `lint.headings` | `off`, `warning`, `error` | Sentence-case H2+ and numbered headings |
 | `lint.filename_pattern` | severity | Wikipedia-style filenames |
 | `lint.broken_links` | severity | Unresolved internal links |
-| `lint.link_style` | severity | Wikilinks in body when `link.style: markdown` |
+| `lint.link_style` | severity | Obsidian wikilinks in body when `link.style: markdown` |
 
 Severity is `off`, `warning`, or `error`. Unknown top-level keys fail at config load.
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -609,7 +609,7 @@ def serve(config: Config, host: str, port: int, site_base_url: str | None, site_
 @click.option("--graph-base-iri", "graph_base_iri", default=None, help="Override graph.base_iri.")
 @click.option("--site-manifest-theme-color", "site_manifest_theme_color", default=None, help="Theme color for web manifest.")
 @click.option("--graph-implicit-types", "graph_implicit_types", type=str, multiple=True, help="Default types applied to untyped documents.")
-@click.option("--graph-implicit-types-policy", "graph_implicit_types_policy", type=click.Choice(["override", "fallback"]), default=None, help="Strategy when applying graph.implicit_types.")
+@click.option("--graph-implicit-types-policy", "graph_implicit_types_policy", type=click.Choice(["fallback", "append"]), default=None, help="Strategy when applying graph.implicit_types.")
 @click.option("--graph-include-file-extension/--no-graph-include-file-extension", "graph_include_file_extension", default=None, help="Include file extension in inferred document URIs.")
 def init(
     force: bool,

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -603,7 +603,7 @@ def serve(config: Config, host: str, port: int, site_base_url: str | None, site_
 @click.option("--site-base-url", "site_base_url", default=None, help="Override site.base_url (default /wiki or inferred from --repo).")
 @click.option("--site-url-style", "site_url_style", default=None, type=click.Choice(["file", "dir"]), help="Override site.url_style: dir or file.")
 @click.option("--graph-content-predicate", "graph_content_predicate", default=None, help="Override graph.content_predicate CURIE (e.g. schema:articleBody).")
-@click.option("--link-style", "link_style", default=None, type=click.Choice(["markdown", "wikilink"]), help="Override link.style: markdown or wikilink.")
+@click.option("--link-style", "link_style", default=None, type=click.Choice(["markdown", "obsidian"]), help="Override link.style: standard Markdown links or Obsidian wikilinks.")
 @click.option("--site-manifest-name", "site_manifest_name", default="Wiki CLI", help="Override site.manifest.name (default 'Wiki CLI').")
 @click.option("--wiki-inputs", "wiki_inputs", type=str, multiple=True, help="Default directories to index relative to config root.")
 @click.option("--graph-base-iri", "graph_base_iri", default=None, help="Override graph.base_iri.")

--- a/src/wiki/links.py
+++ b/src/wiki/links.py
@@ -80,4 +80,6 @@ def format_internal_link(target_route: str, display: str, style: str = "markdown
     """Format an internal wiki link for insertion or CLI suggestions."""
     if style == "markdown":
         return f"[{display}]({markdown_link_target(target_route)})"
-    return f"[[{target_route}|{display}]]"
+    if style == "obsidian":
+        return f"[[{target_route}|{display}]]"
+    raise ValueError(f"expected markdown or obsidian, got {style!r}")

--- a/src/wiki/schemas/init.py
+++ b/src/wiki/schemas/init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-_LINK_STYLES = frozenset({"wikilink", "markdown"})
+_LINK_STYLES = frozenset({"markdown", "obsidian"})
 _VALID_URL_STYLES = frozenset({"dir", "file"})
 
 
@@ -38,8 +38,8 @@ class InitOptions(BaseModel):
         if value is None:
             return None
         if not isinstance(value, str):
-            raise ValueError(f"expected wikilink or markdown, got {value!r}")
+            raise ValueError(f"expected markdown or obsidian, got {value!r}")
         normalized = value.strip().lower()
         if normalized not in _LINK_STYLES:
-            raise ValueError(f"expected wikilink or markdown, got {value!r}")
+            raise ValueError(f"expected markdown or obsidian, got {value!r}")
         return normalized

--- a/src/wiki/schemas/wiki_config.py
+++ b/src/wiki/schemas/wiki_config.py
@@ -27,7 +27,7 @@ from .rules import CheckConfig, LintConfig
 
 logger = logging.getLogger(__name__)
 
-_LINK_STYLES = frozenset({"wikilink", "markdown"})
+_LINK_STYLES = frozenset({"markdown", "obsidian"})
 DEFAULT_LINK_STYLE = "markdown"
 DEFAULT_BASE_URL = "/wiki"
 DEFAULT_URL_STYLE = "dir"
@@ -137,7 +137,7 @@ def format_config_validation_error(config_name: str, exc: ValidationError) -> Va
             if block == "link" and field == "style":
                 bad = error.get("input")
                 return ValueError(
-                    f"Invalid config file {config_name}: Invalid link_style: {bad!r} (expected wikilink or markdown)"
+                    f"Invalid config file {config_name}: Invalid link_style: {bad!r} (expected markdown or obsidian)"
                 )
         if len(loc) >= 2 and loc[0] == "lint":
             field = str(loc[1])
@@ -399,10 +399,10 @@ class LinkConfig(BaseModel):
         if value is None:
             return DEFAULT_LINK_STYLE
         if not isinstance(value, str):
-            raise ValueError(f"expected wikilink or markdown, got {value!r}")
+            raise ValueError(f"expected markdown or obsidian, got {value!r}")
         normalized = value.strip().lower()
         if normalized not in _LINK_STYLES:
-            raise ValueError(f"expected wikilink or markdown, got {value!r}")
+            raise ValueError(f"expected markdown or obsidian, got {value!r}")
         return normalized
 
 

--- a/src/wiki/templates/wiki.yaml.j2
+++ b/src/wiki/templates/wiki.yaml.j2
@@ -89,10 +89,10 @@ site:
 # wiki link command output format and rename repair map.
 link:
 {% if link_style %}
-  # wikilink or markdown (wiki link --apply).
+  # standard Markdown or Obsidian (wiki link --apply).
   style: {{ link_style }}
 {% else %}
-  # wikilink or markdown (wiki link --apply).
+  # standard Markdown or Obsidian (wiki link --apply).
   style: markdown
 {% endif %}
   # renames:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -474,7 +474,7 @@ type: schema:WebPage
             wikilink_config = Config(
                 wiki={"inputs": [wiki]},
                 config_root=Path(tmpdir),
-                link={"style": "wikilink"},
+                link={"style": "obsidian"},
             )
             (wiki / "Guide.md").write_text(
                 "# Guide\n\nSee [[Target]] for details.\n",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -512,6 +512,49 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
                 self.assertIn("base_url: /wiki", config_content)
                 self.assertIn("wazoo: https://schema.wazoo.dev/", config_content)
 
+    def test_cli_init_implicit_types_policy_append(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            with runner.isolated_filesystem(temp_dir=tmpdir):
+                result = runner.invoke(
+                    main,
+                    [
+                        "init",
+                        "--force",
+                        "--graph-context-wiki",
+                        "https://wiki.example.org/",
+                        "--graph-implicit-types",
+                        "schema:TechArticle",
+                        "--graph-implicit-types-policy",
+                        "append",
+                    ],
+                    catch_exceptions=False,
+                )
+                self.assertEqual(result.exit_code, 0)
+                config_content = Path("wiki.yaml").read_text(encoding="utf-8")
+                self.assertIn("implicit_types:", config_content)
+                self.assertIn("- schema:TechArticle", config_content)
+                self.assertIn("implicit_types_policy: append", config_content)
+
+    def test_cli_init_rejects_invalid_implicit_types_policy(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            with runner.isolated_filesystem(temp_dir=tmpdir):
+                result = runner.invoke(
+                    main,
+                    [
+                        "init",
+                        "--force",
+                        "--graph-context-wiki",
+                        "https://wiki.example.org/",
+                        "--graph-implicit-types-policy",
+                        "override",
+                    ],
+                    catch_exceptions=False,
+                )
+                self.assertNotEqual(result.exit_code, 0)
+                self.assertIn("append", result.output)
+
     def test_cli_init_context_wiki_overrides_repo(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,11 +210,15 @@ class TestConfig(unittest.TestCase):
             config = Config.load(base_path)
             self.assertEqual(config.link.style, "markdown")
 
+    def test_Config_load_obsidian_link_style(self) -> None:
+        config = Config(link={"style": "obsidian"})
+        self.assertEqual(config.link.style, "obsidian")
+
     def test_Config_rejects_invalid_link_style(self) -> None:
         from pydantic import ValidationError
 
         with self.assertRaises(ValidationError):
-            Config(link={"style": "obsidian"})
+            Config(link={"style": "wikilink"})
 
     def test_Config_implicit_types_defaults(self) -> None:
         config = Config()

--- a/tests/test_link_suggest.py
+++ b/tests/test_link_suggest.py
@@ -119,7 +119,7 @@ class TestLinkSuggest(unittest.TestCase):
             self.assertTrue(content.startswith("---\ntype: TechArticle\n---\n\n"))
             self.assertIn("[Wiki CLI](Wiki_CLI.md)", content)
 
-    def test_apply_uses_wikilinks_when_link_style_configured(self) -> None:
+    def test_apply_uses_obsidian_links_when_link_style_configured(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             wiki = root / "wiki"
@@ -130,7 +130,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "# Getting started\n\nRead the Wiki CLI guide before you begin.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, link={"style": "wikilink"}, config_root=root)
+            config = Config(wiki={"inputs": [wiki]}, link={"style": "obsidian"}, config_root=root)
 
             opportunities = find_link_opportunities(config)
             apply_link_opportunities(config, opportunities, dry_run=False)


### PR DESCRIPTION
## Summary
- Fix `wiki init --graph-implicit-types-policy` to accept `fallback` or `append` (was `override`)
- Sync init docs and `wiki-create` skill with the full `wiki init` flag surface
- Rename `link.style` value `wikilink` → `obsidian`; default remains `markdown` (standard Markdown links)
- Clarify docs/skills: standard Markdown vs Obsidian wikilinks

Closes #72.

## Breaking

In `wiki.yaml`, set `link.style: obsidian` instead of `wikilink`. See CHANGELOG Migration step 5.

## Test plan
- [x] `pytest tests/test_cli.py -k implicit_types`n- [x] `pytest tests/test_init_scaffold.py`n- [x] `pytest tests/test_config.py -k link_style`n- [x] `pytest tests/test_link_suggest.py`n- [x] `pytest tests/test_audit.py -k link_style`