### PR TITLE
Add JSON Schema frontmatter validation for wiki check (#71)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ wiki -c docs/wiki.yaml fmt --check
 # 2. Conventions: broken links, filename pattern, headings, link style
 wiki -c docs/wiki.yaml lint --strict
 
-# 3. Integrity: SHACL, route safety, layout frontmatter
+# 3. Integrity: SHACL, JSON Schema frontmatter, route safety, layout frontmatter
 wiki -c docs/wiki.yaml check --strict
 
 # 4. Stale inline SPARQL result blocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 
 ### Added
 
+- JSON Schema frontmatter validation in `wiki check` — bind schemas on SHACL shape documents with `wazoo:jsonSchema` + `sh:targetClass`, or append per-page schemas; configurable via `check.frontmatter_schema` and `check.missing_schema_ref` ([#71](https://github.com/wazootech/wiki/issues/71))
+- `wiki init` scaffolds `schemas/person.json` and binds it from `Person_Shape.md`
+- Dogfood schema at `docs/schemas/tech-article.json` bound from [Tech Article Shape](docs/wiki/Tech_Article_Shape.md)
 - Standalone `wiki` executables for Linux, macOS, and Windows via PyInstaller — published to GitHub Releases with `SHA256SUMS` on each `v*` tag ([#77](https://github.com/wazootech/wiki/issues/77))
 - Unified [`.github/workflows/release.yml`](.github/workflows/release.yml): PyPI, npm, and GitHub Release binaries in one workflow (replaces separate `release.yaml`)
 - `wiki-deploy` agent skill — GitHub Pages setup aligned with [`.github/workflows/deploy-pages.yml`](.github/workflows/deploy-pages.yml); pip and uv workflow templates, deploy anti-patterns, and Pages `build_type` verification

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Wiki CLI (`wazootech-wiki`)
 
-Semantic knowledge **toolchain** for Markdown wikis: compile frontmatter and body into RDF, validate with SHACL, infer with OWL-RL, query with SPARQL, and publish static HTML or serializations. Wiki CLI is the compiler and query engine — not the primary editor or note app. See [docs/wiki/Wiki_CLI.md](docs/wiki/Wiki_CLI.md) for scope, boundaries, and command reference.
+Semantic knowledge **toolchain** for Markdown wikis: compile frontmatter and body into RDF, validate with SHACL and JSON Schema, infer with OWL-RL, query with SPARQL, and publish static HTML or serializations. Wiki CLI is the compiler and query engine — not the primary editor or note app. See [docs/wiki/Wiki_CLI.md](docs/wiki/Wiki_CLI.md) for scope, boundaries, and command reference.
 
 ## Architecture decision: Python core
 
@@ -32,7 +32,7 @@ Issue [#44](https://github.com/wazootech/wiki/issues/44): keep the **Python CLI 
 
 **Axiom**: Ontological rules and schema definitions loaded from Turtle files to guide the inference process. _Avoid_: Rule, schema rule.
 
-**Validation**: The process of checking the frontmatter of Documents against SHACL Shapes to ensure structure and value compliance. _Avoid_: Formatting check, manual review.
+**Validation**: The process of checking Document frontmatter against SHACL shapes and optional JSON Schema bindings (`wazoo:jsonSchema`) to ensure structure and value compliance. _Avoid_: Formatting check, manual review.
 
 **Shape**: A SHACL constraint definition loaded from Turtle files to validate the structure of Documents. _Avoid_: Rule, template.
 
@@ -42,7 +42,7 @@ Issue [#44](https://github.com/wazootech/wiki/issues/44): keep the **Python CLI 
 
 **Graph cache**: The in-process RDF graph held for the lifetime of a CLI run so multiple SPARQL queries and renders share one **Wiki** build. _Avoid_: Disk cache, pickle store.
 
-**Checking**: Integrity validation on the **Wiki** via `wiki check` — SHACL, route safety, collisions, and layout frontmatter.
+**Checking**: Integrity validation on the **Wiki** via `wiki check` — SHACL, JSON Schema frontmatter, route safety, collisions, and layout frontmatter.
 
 **Linting**: Conventions and broken links via `wiki lint` (`lint.broken_links`, filename pattern, headings, link style).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![skills.sh](https://skills.sh/b/wazootech/wiki)](https://skills.sh/wazootech/wiki)
 
-**Wiki CLI** is a command-line toolchain and compiler for Markdown wikis. It compiles a directory of Markdown documents with structured metadata (YAML or JSON frontmatter) into a queryable semantic graph, validating data integrity with SHACL, executing queries with SPARQL, and building static websites. It operates as an independent semantic layer underneath your markdown files, meaning you can keep writing in Obsidian, VS Code, or any other editor without changing your tools.
+**Wiki CLI** is a command-line toolchain and compiler for Markdown wikis. It compiles a directory of Markdown documents with structured metadata (YAML or JSON frontmatter) into a queryable semantic graph, validating data integrity with SHACL and JSON Schema, executing queries with SPARQL, and building static websites. It operates as an independent semantic layer underneath your markdown files, meaning you can keep writing in Obsidian, VS Code, or any other editor without changing your tools.
 
 Repository: [github.com/wazootech/wiki](https://github.com/wazootech/wiki). CLI command: `wiki`. Install via [pip](https://pypi.org/project/wazootech-wiki/) or [npm](https://www.npmjs.com/package/wazootech-wiki).
 
@@ -26,7 +26,7 @@ Wiki CLI is **interop-first**: a general-purpose semantic layer that runs beside
 
 While inspired by personal digital gardens like **Farzapedia** (a subjective, first-person memory wiki optimized for a single agent), **Wiki CLI** is a general-purpose, multi-player toolchain:
 - **Farzapedia** is a specific *content wiki* containing diary entries, notes, and messages.
-- **Wiki CLI** is a *utility* for *any* wiki. It compiles Markdown files, enforces structure (SHACL), queries data (SPARQL), and builds static websites.
+- **Wiki CLI** is a *utility* for *any* wiki. It compiles Markdown files, enforces structure (SHACL and JSON Schema), queries data (SPARQL), and builds static websites.
 
 Adoption path: [Wiki CLI](docs/wiki/Wiki_CLI.md) in the docs wiki.
 
@@ -36,7 +36,7 @@ Three beats, one toolchain:
 
 | Beat | Commands | What you get |
 |------|----------|--------------|
-| **Trust** | [`check`](#check), [`lint`](#lint), [`fmt`](#fmt) | SHACL integrity, wiki conventions, mechanical Markdown layout |
+| **Trust** | [`check`](#check), [`lint`](#lint), [`fmt`](#fmt) | SHACL and JSON Schema integrity, wiki conventions, mechanical Markdown layout |
 | **Intelligence** | [`query`](#query), [`render`](#render), [`export`](#export) | OWL-RL inference, inline SPARQL tables, JSON-LD and RDF serializations |
 | **Publish** | [`build`](#build), [`serve`](#serve), [`link`](#link) | Static HTML with infoboxes and metadata pane, local preview, optional read-only SPARQL endpoint, wikilink hygiene |
 
@@ -184,7 +184,7 @@ wiki serve
 
 
 ### `check`
-Run **integrity** validations: strict SHACL schema validation, route safety, output collisions, and layout frontmatter. Under the "silence is golden" philosophy, `check` exits silently with code 0 on success.
+Run **integrity** validations: strict SHACL validation, JSON Schema frontmatter validation, route safety, output collisions, and layout frontmatter. Under the "silence is golden" philosophy, `check` exits silently with code 0 on success.
 
 ```bash
 wiki check
@@ -193,7 +193,7 @@ wiki check -v
 wiki check --strict
 ```
 
-Single-file mode runs SHACL validation for that document only. Broken links and other conventions are **`wiki lint`**.
+Single-file mode runs SHACL and JSON Schema validation for that document only. Broken links and other conventions are **`wiki lint`**.
 
 ### `lint`
 Run **convention** audits: broken links, filename pattern, heading style (ATX `#` only, sentence-case H2+), and link style.
@@ -614,7 +614,7 @@ Following the Unix philosophy of pipes and filters, `wiki` works seamlessly with
 While the Wiki CLI operates as a standalone tool, it pairs naturally with Obsidian. You can seamlessly trigger operations directly from within your wiki using the **Shell Commands** community plugin.
 
 Recommended workflows:
-* **Check on save**: Bind `wiki check` to execute whenever a file is modified to receive instant feedback on SHACL validations and formatting.
+* **Check on save**: Bind `wiki check` to execute whenever a file is modified to receive instant feedback on SHACL, JSON Schema, and layout validation.
 * **Trigger re-rendering**: Map a hotkey or command palette item to `wiki render` to automatically update all dynamic SPARQL blocks in the wiki.
 
 ### Declarative modeling & full-text SPARQL

--- a/docs/schemas/tech-article.json
+++ b/docs/schemas/tech-article.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["headline", "description"],
+  "properties": {
+    "headline": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/wiki.yaml
+++ b/docs/wiki.yaml
@@ -59,10 +59,14 @@ link:
   # renames:
   #   Old_Page_Name: New_Page_Name
 
-# Integrity severities (wiki check): SHACL, routes, layout files.
+# Integrity severities (wiki check): SHACL, JSON Schema, routes, layout files.
 check:
   # Error when wazoo:layout points at a missing .html.j2 file.
   missing_layout_file: error
+  # Error when frontmatter fails JSON Schema validation.
+  frontmatter_schema: error
+  # Error when wazoo:jsonSchema cannot be loaded (local or remote).
+  missing_schema_ref: error
 
 # Convention severities (wiki lint): links, filenames, headings.
 lint:

--- a/docs/wiki/Agent_Memory_Filesystems.md
+++ b/docs/wiki/Agent_Memory_Filesystems.md
@@ -16,16 +16,16 @@ Traditional chat UIs are largely stateless. These systems let an agent (and ofte
 
 ### Feature matrix
 
-|                          | [Wiki CLI](Wiki_CLI.md)                         | [Supermemory SMFS](Supermemory_SMFS.md)      | [Letta MemFS](Letta_MemFS.md)               |
-| ------------------------ | ----------------------------------------------- | -------------------------------------------- | ------------------------------------------- |
-| **Metaphor**             | Semantic markdown **wiki** / codebase           | Cloud container as **mount** or virtual bash | **Git repo** of memory markdown             |
-| **Authority**            | Your wiki on disk                               | Supermemory API                              | Local Git (+ Letta Cloud for API agents)    |
-| **Structured semantics** | YAML-LD, [SHACL](SHACL.md), [SPARQL](SPARQL.md) | Memory paths + cloud graph                   | `description` frontmatter; optional folders |
-| **Hot context**          | Agent chooses pages to open                     | `profile.md` + semantic grep                 | `system/` loaded every turn                 |
-| **Search**               | SPARQL, link graph, `wiki query`                | Semantic `grep` (literal with flags)         | Tree + on-demand file read                  |
-| **Validation**           | `wiki check` (SHACL + hygiene)                  | Supermemory indexing rules                   | Git + agent discipline                      |
-| **Publishing**           | Static site, RDF export                         | N/A (runtime memory)                         | N/A (agent memory)                          |
-| **Typical user**         | Wiki authors, PKM + semantics                   | Multi-modal, multi-source agents             | Letta Code coding agents                    |
+|                          | [Wiki CLI](Wiki_CLI.md)                                      | [Supermemory SMFS](Supermemory_SMFS.md)      | [Letta MemFS](Letta_MemFS.md)               |
+| ------------------------ | ------------------------------------------------------------ | -------------------------------------------- | ------------------------------------------- |
+| **Metaphor**             | Semantic markdown **wiki** / codebase                        | Cloud container as **mount** or virtual bash | **Git repo** of memory markdown             |
+| **Authority**            | Your wiki on disk                                            | Supermemory API                              | Local Git (+ Letta Cloud for API agents)    |
+| **Structured semantics** | YAML-LD, [SHACL](SHACL.md), JSON Schema, [SPARQL](SPARQL.md) | Memory paths + cloud graph                   | `description` frontmatter; optional folders |
+| **Hot context**          | Agent chooses pages to open                                  | `profile.md` + semantic grep                 | `system/` loaded every turn                 |
+| **Search**               | SPARQL, link graph, `wiki query`                             | Semantic `grep` (literal with flags)         | Tree + on-demand file read                  |
+| **Validation**           | `wiki check` (SHACL, JSON Schema, layout)                    | Supermemory indexing rules                   | Git + agent discipline                      |
+| **Publishing**           | Static site, RDF export                                      | N/A (runtime memory)                         | N/A (agent memory)                          |
+| **Typical user**         | Wiki authors, PKM + semantics                                | Multi-modal, multi-source agents             | Letta Code coding agents                    |
 
 ### When to use which
 

--- a/docs/wiki/Dataview_Integration.md
+++ b/docs/wiki/Dataview_Integration.md
@@ -13,17 +13,17 @@ The [Wiki CLI](Wiki_CLI.md) and Obsidian's community **Dataview** plugin can be 
 While both tools allow you to query your wiki metadata, they optimize for different workflows:
 
 - **Dataview** is designed for **interactive, in-editor presentation** inside the Obsidian GUI. It is perfect for dynamic dashboards, daily note tracking, and local navigation.
-- **Wiki CLI** is a **verifiable semantic compiler and toolchain** designed to run anywhere (local terminal, CI/CD pipelines, or static web servers). It enforces data structures via [SHACL](SHACL.md), executes query-based rendering via [SPARQL](SPARQL.md), and builds standalone static HTML sites.
+- **Wiki CLI** is a **verifiable semantic compiler and toolchain** designed to run anywhere (local terminal, CI/CD pipelines, or static web servers). It enforces data structures via [SHACL](SHACL.md) and JSON Schema, executes query-based rendering via [SPARQL](SPARQL.md), and builds standalone static HTML sites.
 
 ### Comparison
 
-| Feature               | Obsidian Dataview                        | Wiki CLI                                      |
-| --------------------- | ---------------------------------------- | --------------------------------------------- |
-| **Execution Context** | Inside the Obsidian application (GUI)    | Terminal, scripts, and CI/CD pipelines        |
-| **Query Language**    | DQL (custom SQL-like) or JavaScript      | SPARQL (W3C standard)                         |
-| **Validation**        | Presentation only (no constraints check) | `wiki check` (SHACL constraints validation)   |
-| **Logical Inference** | None (direct field matching)             | OWL-RL reasoning (implicit class hierarchies) |
-| **Output Formats**    | Dynamic markdown views in Obsidian       | Static HTML, Turtle, JSON-LD, RDF/XML         |
+| Feature               | Obsidian Dataview                        | Wiki CLI                                        |
+| --------------------- | ---------------------------------------- | ----------------------------------------------- |
+| **Execution Context** | Inside the Obsidian application (GUI)    | Terminal, scripts, and CI/CD pipelines          |
+| **Query Language**    | DQL (custom SQL-like) or JavaScript      | SPARQL (W3C standard)                           |
+| **Validation**        | Presentation only (no constraints check) | `wiki check` (SHACL and JSON Schema validation) |
+| **Logical Inference** | None (direct field matching)             | OWL-RL reasoning (implicit class hierarchies)   |
+| **Output Formats**    | Dynamic markdown views in Obsidian       | Static HTML, Turtle, JSON-LD, RDF/XML           |
 
 ## Query examples
 

--- a/docs/wiki/Declarative_Knowledge.md
+++ b/docs/wiki/Declarative_Knowledge.md
@@ -8,7 +8,7 @@ description: Knowing what — facts, types, and relationships expressed as struc
 
 **Declarative knowledge** is "knowing what": facts, definitions, taxonomies, and explicit relationships. In this wiki it is represented primarily as YAML frontmatter on markdown pages, compiled into an [RDF](RDF.md) graph via the [Wiki CLI](Wiki_CLI.md).
 
-Examples include `schema:Person` fields on biography pages, `schema:TechArticle` metadata on guides, and typed links between entities. [SHACL](SHACL.md) validates that declarative statements stay complete and consistent.
+Examples include `schema:Person` fields on biography pages, `schema:TechArticle` metadata on guides, and typed links between entities. [SHACL](SHACL.md) and JSON Schema (`wazoo:jsonSchema`) validate that declarative statements stay complete and consistent.
 
 Pair declarative pages with [Procedural Knowledge](Procedural_Knowledge.md)—workflows and commands that keep the graph correct and surfaces like indexes up to date.
 

--- a/docs/wiki/Deploying_to_GitHub_Pages.md
+++ b/docs/wiki/Deploying_to_GitHub_Pages.md
@@ -11,7 +11,7 @@ This repository publishes `docs/wiki/` using `docs/wiki.yaml`. The workflow live
 ## Pipeline
 
 1. `uv sync` — install dependencies
-1. `wiki -c docs/wiki.yaml check --strict -v` — SHACL + hygiene
+1. `wiki -c docs/wiki.yaml check --strict -v` — SHACL, JSON Schema, routes, layout
 1. `wiki -c docs/wiki.yaml build --output-dir _site --site-base-url /wiki` — static HTML
 1. Upload `_site/wiki` as the Pages artifact
 1. `deploy-pages` — publish

--- a/docs/wiki/Design_Philosophies.md
+++ b/docs/wiki/Design_Philosophies.md
@@ -16,7 +16,7 @@ Four audit/format lanes (aligned with common CLI tooling):
 
 | Lane         | Command      | Config / tool                                                                                                                                                                |
 | ------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Integrity    | `wiki check` | Always-on SHACL, routes, collisions, layout frontmatter (`check.*`) — **report only**                                                                                        |
+| Integrity    | `wiki check` | Always-on SHACL, JSON Schema frontmatter, routes, collisions, layout frontmatter (`check.*`) — **report only**                                                               |
 | Convention   | `wiki lint`  | `lint.broken_links`, `lint.filename_pattern`, `lint.headings`, `lint.heading_levels`, `lint.duplicate_headings`, `lint.thematic_breaks`, `lint.link_style` — **report only** |
 | Formatting   | `wiki fmt`   | mdformat                                                                                                                                                                     |
 | Link hygiene | `wiki link`  | Optional `link.renames`; `--apply` and `--fix-broken` require explicit flags                                                                                                 |

--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -33,12 +33,12 @@ wiki init --repo wazootech/wiki
 wiki init --git
 ```
 
-`wiki init` writes `wiki.yaml`, `README.md`, `layouts/` wiki page layouts, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. See [Wiki Subcommand init](Wiki_Subcommand_init.md) for all flags and `--force` behavior.
+`wiki init` writes `wiki.yaml`, `README.md`, `layouts/`, `schemas/person.json`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. See [Wiki Subcommand init](Wiki_Subcommand_init.md) for all flags and `--force` behavior.
 
 ## Daily workflow
 
 ```bash
-# Validate integrity (SHACL, routes, layout; silent on success)
+# Validate integrity (SHACL, JSON Schema, routes, layout; silent on success)
 wiki check
 
 # Validate conventions (filename pattern, headings, link style)

--- a/docs/wiki/LLM_Wiki.md
+++ b/docs/wiki/LLM_Wiki.md
@@ -36,7 +36,7 @@ This [Wiki CLI](Wiki_CLI.md) repository is built directly on the principles of t
 
 1. **Declarative Frontmatter**: Structuring YAML-LD metadata to make pages machine-readable.
 
-1. **Procedural Automation**: Using subcommands like [Wiki Subcommand check](Wiki_Subcommand_check.md) to validate shapes, and [Wiki Subcommand render](Wiki_Subcommand_render.md) to execute [SPARQL](SPARQL.md) queries dynamically, compiling the graph's intelligence back into static Markdown.
+1. **Procedural Automation**: Using subcommands like [Wiki Subcommand check](Wiki_Subcommand_check.md) to validate SHACL shapes and JSON Schema frontmatter, and [Wiki Subcommand render](Wiki_Subcommand_render.md) to execute [SPARQL](SPARQL.md) queries dynamically, compiling the graph's intelligence back into static Markdown.
 
 ## References
 

--- a/docs/wiki/Obsidian_Integration.md
+++ b/docs/wiki/Obsidian_Integration.md
@@ -12,11 +12,11 @@ Use the community **Shell Commands** plugin to run `wiki` against your wiki root
 
 ## Suggested commands
 
-| Trigger       | Command               | Purpose                    |
-| ------------- | --------------------- | -------------------------- |
-| On save       | `wiki check`          | Fast SHACL + link feedback |
-| Hotkey        | `wiki render`         | Refresh all SPARQL tables  |
-| Before commit | `wiki check --strict` | CI-parity validation       |
+| Trigger       | Command               | Purpose                           |
+| ------------- | --------------------- | --------------------------------- |
+| On save       | `wiki check`          | Fast SHACL + JSON Schema feedback |
+| Hotkey        | `wiki render`         | Refresh all SPARQL tables         |
+| Before commit | `wiki check --strict` | CI-parity validation              |
 
 Point the plugin’s working directory at the folder containing `wiki.yaml`.
 

--- a/docs/wiki/Personal_Knowledge.md
+++ b/docs/wiki/Personal_Knowledge.md
@@ -23,9 +23,9 @@ owns: Bella
 
 This is parsed as a typed graph triple (`wiki:gregory wiki:owns wiki:bella`), allowing the graph to mathematically reason about family, colleague, or friend connections.
 
-### Built-in structural correctness (SHACL shapes)
+### Built-in structural correctness
 
-Traditional notes suffer from "schema drift" where you forget to add fields like dates or tags. The [Wiki CLI](Wiki_CLI.md) uses **SHACL shapes** to audit your notes automatically. This ensures your [second brain](Second_Brain.md) remains consistently structured and complete.
+Traditional notes suffer from "schema drift" where you forget to add fields like dates or tags. The [Wiki CLI](Wiki_CLI.md) uses **SHACL shapes** and optional **JSON Schema** bindings (`wazoo:jsonSchema`) to audit your notes automatically. This ensures your [second brain](Second_Brain.md) remains consistently structured and complete.
 
 ### Infinite dynamic synthesis (SPARQL)
 
@@ -36,4 +36,4 @@ Instead of manually maintaining index lists or tag pages, you write a simple SPA
 A modern [second brain](Second_Brain.md) must distinguish between **[declarative knowledge](Declarative_Knowledge.md)** ("knowing what") and **[procedural knowledge](Procedural_Knowledge.md)** ("knowing how"):
 
 - **[Declarative Knowledge](Declarative_Knowledge.md)**: Represented statically as semantic facts, class hierarchies, and properties within your markdown frontmatter. These are parsed into the permanent RDF graph.
-- **[Procedural Knowledge](Procedural_Knowledge.md)**: Represented dynamically as executable actions, workflows, query parameters, and validation rules (e.g., active SHACL shape rules and custom SPARQL blocks). The CLI automates this procedural layer through commands like `wiki check` and `wiki render`, transforming static notes into an active, self-correcting system.
+- **[Procedural Knowledge](Procedural_Knowledge.md)**: Represented dynamically as executable actions, workflows, query parameters, and validation rules (e.g., active SHACL shape rules, JSON Schema bindings, and custom SPARQL blocks). The CLI automates this procedural layer through commands like `wiki check` and `wiki render`, transforming static notes into an active, self-correcting system.

--- a/docs/wiki/Procedural_Knowledge.md
+++ b/docs/wiki/Procedural_Knowledge.md
@@ -11,7 +11,7 @@ description: Knowing how — workflows, rules, and executable processes rather t
 In a semantic [Personal Knowledge](Personal_Knowledge.md) wiki, procedural knowledge often lives in tooling rather than prose alone:
 
 - [Wiki Skills](Wiki_Skills.md) — agent `SKILL.md` workflows for install, scaffold, and wiki audit (repository `skills/`, not indexed as wiki pages)
-- [SHACL](SHACL.md) shapes that enforce how pages must be written
+- [SHACL](SHACL.md) shapes and JSON Schema bindings that enforce how pages must be written
 - [SPARQL](SPARQL.md) blocks and [Wiki Subcommand render](Wiki_Subcommand_render.md) that refresh tables from the graph
 - [Wiki Subcommand check](Wiki_Subcommand_check.md) and [Wiki Subcommand render](Wiki_Subcommand_render.md) pipelines that automate hygiene and synthesis
 

--- a/docs/wiki/SHACL.md
+++ b/docs/wiki/SHACL.md
@@ -46,11 +46,30 @@ sh:property:
 
 When you run `wiki check`, any page with `type: Project` is automatically validated against these constraints.
 
+### JSON Schema (optional)
+
+On the same shape document, add `wazoo:jsonSchema` beside `sh:targetClass` to validate frontmatter with [JSON Schema](https://json-schema.org/) in parallel with SHACL:
+
+```yaml
+---
+type: sh:NodeShape
+sh:targetClass: schema:Project
+wazoo:jsonSchema: schemas/project.json
+sh:property:
+  - sh:path: schema:name
+    sh:minCount: 1
+---
+```
+
+`wiki init` scaffolds `schemas/person.json` and binds it from `Person_Shape.md`. Individual pages can append schemas with their own `wazoo:jsonSchema` key (string or list). Shape binding documents are not validated as instances — only their schema refs are checked for loadability.
+
+See [Tech Article Shape](Tech_Article_Shape.md) in this wiki for a dogfooded example.
+
 Pure `.ttl` or `.trig` files in `shapes/` also load when that directory is listed in `wiki.inputs`; markdown frontmatter is the default authoring style in this wiki.
 
 ## Related
 
-- [Wiki Subcommand check](Wiki_Subcommand_check.md) — PySHACL validation
+- [Wiki Subcommand check](Wiki_Subcommand_check.md) — PySHACL and JSON Schema frontmatter validation
 - [Wiki Subcommand lint](Wiki_Subcommand_lint.md) — prose and link conventions (separate from shapes)
 - [Style Guide](Style_Guide.md) — shape authoring and filenames
 - [Software Application Shape](Software_Application_Shape.md) — example `sh:NodeShape`

--- a/docs/wiki/Style_Guide.md
+++ b/docs/wiki/Style_Guide.md
@@ -93,6 +93,8 @@ When writing `&lt;!-- sparql:start --&gt;` blocks or ad-hoc `wiki query` command
 
 Define constraints in frontmatter with `type: sh:NodeShape` (see `wiki init`'s `Person_Shape.md` or [Software Application Shape](Software_Application_Shape.md) in this wiki). Shapes in the wiki are loaded into the validation graph; [Wiki Subcommand check](Wiki_Subcommand_check.md) runs PySHACL against every document. Background: [SHACL](SHACL.md).
 
+Optionally bind a **JSON Schema** on the same shape document with `wazoo:jsonSchema` (local path under the wiki config root or remote `http(s)` URL). Type-level schemas apply to every page whose effective `type` matches `sh:targetClass`. Pages may append extra schemas with their own `wazoo:jsonSchema` key (scalar or YAML list); all bound schemas must pass.
+
 ## Internal links
 
 Link to other wiki pages with standard Markdown links. Use the page stem (filename without `.md`, case preserved), for example `Page_Name.md` or `Display text` pointing at `Page_Name.md`.

--- a/docs/wiki/Tech_Article_Shape.md
+++ b/docs/wiki/Tech_Article_Shape.md
@@ -3,6 +3,7 @@ type: sh:NodeShape
 rdfs:label: TechArticle Shape
 rdfs:comment: Basic validation rules for TechArticle documents.
 sh:targetClass: schema:TechArticle
+wazoo:jsonSchema: schemas/tech-article.json
 sh:property:
   - sh:path: schema:headline
     sh:minCount: 1
@@ -17,6 +18,6 @@ sh:property:
 
 # TechArticle validation shape
 
-This document defines the basic **SHACL validation rules** enforced upon any `type: TechArticle` documents in this wiki.
+This document defines **SHACL validation rules** and a **JSON Schema** binding (`schemas/tech-article.json`) enforced on any `type: TechArticle` document in this wiki.
 
 It ensures that all technical articles have at least a `headline` and `description` in their YAML frontmatter.

--- a/docs/wiki/WikiThon.md
+++ b/docs/wiki/WikiThon.md
@@ -23,7 +23,7 @@ It rode the same cultural moment as the [LLM Wiki](LLM_Wiki.md) pattern (Andrej 
 
 Participants were asked to build systems that reason over **long context**, **memory**, and **workflows**—not shallow prompt wrappers. The sponsored substrate was [HydraDB](https://docs.hydradb.com/get-started/introduction), a unified context layer for agents (ingest documents and memories, recall ranked context via APIs such as `full_recall`, then ground an LLM on the result).
 
-That complements file-first wikis like those described in [Personal Knowledge](Personal_Knowledge.md): HydraDB emphasizes managed recall and graph-backed context, while the [Wiki CLI](Wiki_CLI.md) supports markdown + RDF + [SHACL](SHACL.md) validation for static, inspectable wikis.
+That complements file-first wikis like those described in [Personal Knowledge](Personal_Knowledge.md): HydraDB emphasizes managed recall and graph-backed context, while the [Wiki CLI](Wiki_CLI.md) supports markdown + RDF + [SHACL](SHACL.md) and JSON Schema validation for static, inspectable wikis.
 
 ## Prizes and community
 

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -167,7 +167,7 @@ ORDER BY ?command
 | command | description |
 | --- | --- |
 | [Wiki_Subcommand_build](Wiki_Subcommand_build.md) | Generate a static HTML site from the wiki. |
-| [Wiki_Subcommand_check](Wiki_Subcommand_check.md) | Integrity checks — SHACL, JSON Schema frontmatter, route safety, and layout frontmatter. |
+| [Wiki_Subcommand_check](Wiki_Subcommand_check.md) | Integrity checks — SHACL validation, JSON Schema frontmatter, route safety, and layout frontmatter. |
 | [Wiki_Subcommand_export](Wiki_Subcommand_export.md) | Export document frontmatter as RDF or JSON-LD. |
 | [Wiki_Subcommand_fmt](Wiki_Subcommand_fmt.md) | Format markdown wiki pages using mdformat with wikilink preservation. |
 | [Wiki_Subcommand_init](Wiki_Subcommand_init.md) | Scaffold wiki.yaml and starter wiki pages interactively. |

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -7,7 +7,7 @@ description: Command-line interface for querying, validating, and publishing sem
 
 # Wiki CLI
 
-This page is the **documentation home** for **Wiki CLI** (`wiki` on PyPI as [**`wazootech-wiki`**](https://pypi.org/project/wazootech-wiki/)): the semantic knowledge **toolchain** for Markdown wikis — validate with [SHACL](SHACL.md), infer and query with [SPARQL](SPARQL.md), and publish static HTML. It compiles wikis into RDF and sits **beneath** note apps and LLM-assisted workflows — progressive enhancement, not a migration.
+This page is the **documentation home** for **Wiki CLI** (`wiki` on PyPI as [**`wazootech-wiki`**](https://pypi.org/project/wazootech-wiki/)): the semantic knowledge **toolchain** for Markdown wikis — validate with [SHACL](SHACL.md) and JSON Schema, infer and query with [SPARQL](SPARQL.md), and publish static HTML. It compiles wikis into RDF and sits **beneath** note apps and LLM-assisted workflows — progressive enhancement, not a migration.
 
 ```bash
 pip install wazootech-wiki
@@ -30,7 +30,7 @@ See [Getting Started](Getting_Started.md) for a full walkthrough.
 ## What wiki is
 
 - The **compiler / validator / query engine** for Markdown knowledge bases with semantic frontmatter
-- An **OOTB wiki builder** — links, navigation, SHACL checks, SPARQL, and static HTML from a folder of `.md` files
+- An **OOTB wiki builder** — links, navigation, SHACL and JSON Schema checks, SPARQL, and static HTML from a folder of `.md` files
 - A **memory layer** — ingest or watch an existing wiki without owning the editor
 - **Interop-first** — works alongside [Obsidian](Obsidian_Integration.md), [LLM Wiki](LLM_Wiki.md) setups, and any Markdown editor
 
@@ -43,13 +43,13 @@ Adoption path: `wiki init` → `wiki check` → `wiki serve`, then add `lint`, `
 - A **note app clone**, CMS, or authenticated multi-user web product
 - An **auth layer** — local-first CLI and static publish; see deferred scope in [ecosystem templates](#ecosystem-templates) below
 
-Humans and agents keep writing where they already write. `wiki` makes that content **trustworthy** (SHACL + conventions), **searchable** (SPARQL + OWL-RL), and **publishable** (static HTML, JSON-LD, Turtle, optional read-only SPARQL over `wiki serve`).
+Humans and agents keep writing where they already write. `wiki` makes that content **trustworthy** (SHACL, JSON Schema, and conventions), **searchable** (SPARQL + OWL-RL), and **publishable** (static HTML, JSON-LD, Turtle, optional read-only SPARQL over `wiki serve`).
 
 ## Memory layer and ingestion
 
 Rather than owning your editor or data store, the Wiki CLI functions as a **read-only memory layer** over your wiki. It parses, indexes, and queries the Markdown documents on your filesystem without mutating them or locking you into a proprietary format.
 
-- **Ingestion:** The CLI reads YAML/JSON frontmatter and HTML microdata from your files, compiling them into an in-memory RDF graph that can be queried with SPARQL or verified against SHACL shapes.
+- **Ingestion:** The CLI reads YAML/JSON frontmatter and HTML microdata from your files, compiling them into an in-memory RDF graph that can be queried with SPARQL or verified against SHACL shapes and JSON Schema bindings.
 - **Watching:** Running `wiki serve --watch` instructs the CLI to watch the wiki directory. Any edits you make in your preferred editor are immediately processed, updating the graph in the background and keeping your preview server synchronized.
 
 ## Toolchain vs authoring surface
@@ -98,7 +98,7 @@ Design rationale for silence, pipes, and flat subcommands: [Design philosophies]
 
 ## Features
 
-- **Check** — SHACL integrity, route safety, layout frontmatter ([Wiki Subcommand check](Wiki_Subcommand_check.md))
+- **Check** — SHACL and JSON Schema integrity, route safety, layout frontmatter ([Wiki Subcommand check](Wiki_Subcommand_check.md))
 - **Lint** — broken links, filename pattern, and heading conventions ([Wiki Subcommand lint](Wiki_Subcommand_lint.md))
 - **Link** — suggest missing wikilinks and repair broken internal links ([Wiki Subcommand link](Wiki_Subcommand_link.md))
 - **Fmt** — mdformat for markdown ([Wiki Subcommand fmt](Wiki_Subcommand_fmt.md))
@@ -167,7 +167,7 @@ ORDER BY ?command
 | command | description |
 | --- | --- |
 | [Wiki_Subcommand_build](Wiki_Subcommand_build.md) | Generate a static HTML site from the wiki. |
-| [Wiki_Subcommand_check](Wiki_Subcommand_check.md) | Integrity checks — SHACL validation, route safety, and layout frontmatter. |
+| [Wiki_Subcommand_check](Wiki_Subcommand_check.md) | Integrity checks — SHACL, JSON Schema frontmatter, route safety, and layout frontmatter. |
 | [Wiki_Subcommand_export](Wiki_Subcommand_export.md) | Export document frontmatter as RDF or JSON-LD. |
 | [Wiki_Subcommand_fmt](Wiki_Subcommand_fmt.md) | Format markdown wiki pages using mdformat with wikilink preservation. |
 | [Wiki_Subcommand_init](Wiki_Subcommand_init.md) | Scaffold wiki.yaml and starter wiki pages interactively. |
@@ -197,14 +197,14 @@ To prevent drift mechanically, you can wire a local Git hook or CI workflow that
 
 1. **[Wiki Subcommand fmt](Wiki_Subcommand_fmt.md)**: Auto-formats Markdown structures and standardizes YAML frontmatter layout.
 1. **[Wiki Subcommand lint](Wiki_Subcommand_lint.md) `--strict`**: Flags broken links, non-conforming filename patterns, and heading casing warnings as hard errors.
-1. **[Wiki Subcommand check](Wiki_Subcommand_check.md) `--strict`**: Ensures frontmatter properties strictly conform to defined [SHACL](SHACL.md) shapes.
+1. **[Wiki Subcommand check](Wiki_Subcommand_check.md) `--strict`**: Ensures frontmatter conforms to [SHACL](SHACL.md) shapes and bound JSON Schema documents (`wazoo:jsonSchema`).
 
 ### Resilient schema evolution
 
 Enforcing schemas on text databases can become problematic as structures evolve. The Wiki CLI avoids schema rigidity using semantic web principles:
 
 - **Additive RDF properties**: Since frontmatter is compiled into a graph, new or unconstrained keys do not cause parsing failures. They are ingested as open-world triples that can be queried or ignored.
-- **Decoupled validation**: SHACL validation is a diagnostic step, not an execution blocker. Files with invalid schemas can still be compiled, parsed, and queried.
+- **Decoupled validation**: SHACL and JSON Schema validation are diagnostic steps, not execution blockers. Files with invalid schemas can still be compiled, parsed, and queried.
 - **Class-scoped shapes**: Shapes target specific classes (e.g., `sh:targetClass schema:TechArticle`). Introducing a new document type only requires writing a new shape constraint, leaving legacy documents untouched.
 - **Namespace contexts**: Properties map to URIs via `graph.context` in [Wiki Configuration](Wiki_Configuration.md). You can rename or alias fields at the config layer without physically editing every source document.
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -14,13 +14,13 @@ Three audit lanes map to three commands:
 
 | Lane       | Command      | YAML block | Purpose                                                                                                                                                      |
 | ---------- | ------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Integrity  | `wiki check` | `check:`   | SHACL, route safety, collisions, layout frontmatter                                                                                                          |
+| Integrity  | `wiki check` | `check:`   | SHACL, JSON Schema frontmatter, route safety, collisions, layout frontmatter                                                                                 |
 | Convention | `wiki lint`  | `lint:`    | `broken_links`, `filename_pattern`, `headings`, `heading_levels`, `duplicate_headings`, `thematic_breaks`, `link_style` (plus `wiki.filename_pattern` regex) |
 | Formatting | `wiki fmt`   | `fmt:`     | Mechanical markdown (mdformat options; inline mapping or TOML path)                                                                                          |
 
 ### Rule placement
 
-Mechanical markdown (lists, tables, ATX syntax, line endings) belongs under top-level **`fmt:`** and **`wiki fmt`**. You may use an inline mapping in `wiki.yaml`, a relative path to a TOML file, or fall back to `.mdformat.toml` at the config root or above the page file. Wiki policy and link conventions belong under **`lint:`**. SHACL, routes, and layout keys belong under **`check:`** — never under `lint:`. See [Style Guide](Style_Guide.md) for the full matrix.
+Mechanical markdown (lists, tables, ATX syntax, line endings) belongs under top-level **`fmt:`** and **`wiki fmt`**. You may use an inline mapping in `wiki.yaml`, a relative path to a TOML file, or fall back to `.mdformat.toml` at the config root or above the page file. Wiki policy and link conventions belong under **`lint:`**. SHACL, JSON Schema, routes, and layout keys belong under **`check:`** — never under `lint:`. See [Style Guide](Style_Guide.md) for the full matrix.
 
 - **`wiki.filename_pattern`** is the regex string. **`lint.filename_pattern`** is the severity (`error`, `warning`, or `off`).
 - Putting a regex under `check.filename_pattern` fails at load with a hint.
@@ -405,8 +405,16 @@ Under `check`, each rule is `error`, `warning`, or `off`:
 | Rule key              | Default | What it audits                                                         |
 | --------------------- | ------- | ---------------------------------------------------------------------- |
 | `missing_layout_file` | `error` | `wazoo:layout` paths that do not resolve to a readable `.html.j2` file |
+| `frontmatter_schema`  | `error` | Frontmatter that fails JSON Schema validation                          |
+| `missing_schema_ref`  | `error` | `wazoo:jsonSchema` paths or URLs that cannot be loaded                 |
 
 Build-safety rules (unsafe URL characters, spaces in routes) and output URL collision detection always apply regardless of `check` settings.
+
+### JSON Schema frontmatter (`wazoo:jsonSchema`)
+
+`wiki check` validates frontmatter against JSON Schema in parallel with SHACL. Bind schemas on shape documents with **`wazoo:jsonSchema`** beside **`sh:targetClass`**; every page whose effective `type` matches that class must pass the bound schema(s). Individual pages may append extra schemas with their own `wazoo:jsonSchema` key (scalar or YAML list). Schema refs are local paths under the wiki config root (`.json` only) or remote `http(s)` URLs.
+
+Shape binding documents are not validated as instances — only their schema refs are checked for loadability. Authoring detail: [SHACL](SHACL.md), [Style Guide](Style_Guide.md). Example in this wiki: [Tech Article Shape](Tech_Article_Shape.md) → `schemas/tech-article.json`.
 
 ## Convention audits (`lint`)
 

--- a/docs/wiki/Wiki_Subcommand_check.md
+++ b/docs/wiki/Wiki_Subcommand_check.md
@@ -1,12 +1,12 @@
 ---
 type: TechArticle
 headline: wiki check
-description: Integrity checks — SHACL validation, route safety, and layout frontmatter.
+description: Integrity checks — SHACL validation, JSON Schema frontmatter, route safety, and layout frontmatter.
 ---
 
 # `wiki check`
 
-Run **integrity** checks on the wiki: strict **SHACL** validation, route safety, output collisions, and layout frontmatter contracts.
+Run **integrity** checks on the wiki: strict **SHACL** validation, **JSON Schema** frontmatter validation, route safety, output collisions, and layout frontmatter contracts.
 
 Exits **0 silently** on success unless `-v` is set. See [Design Philosophies](Design_Philosophies.md).
 
@@ -22,11 +22,11 @@ wiki check --strict
 
 ## Options
 
-| Flag              | Description                                                                  |
-| ----------------- | ---------------------------------------------------------------------------- |
-| `FILE...`         | Optional documents; otherwise entire wiki (scoped mode: SHACL per file only) |
-| `-v`, `--verbose` | Print warnings                                                               |
-| `--strict`        | Treat warnings as errors (exit 1)                                            |
+| Flag              | Description                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| `FILE...`         | Optional documents; otherwise entire wiki (scoped mode: SHACL + JSON Schema per file) |
+| `-v`, `--verbose` | Print warnings                                                                        |
+| `--strict`        | Treat warnings as errors (exit 1)                                                     |
 
 ## What is checked
 
@@ -45,14 +45,20 @@ wiki check --strict
 | Rule key              | What it audits                                                         |
 | --------------------- | ---------------------------------------------------------------------- |
 | `missing_layout_file` | `wazoo:layout` paths that do not resolve to a readable `.html.j2` file |
+| `frontmatter_schema`  | Frontmatter that fails JSON Schema validation                          |
+| `missing_schema_ref`  | `wazoo:jsonSchema` paths or URLs that cannot be loaded                 |
 
-Default: `missing_layout_file` is `error`.
+Default: `missing_layout_file`, `frontmatter_schema`, and `missing_schema_ref` are `error`.
+
+### JSON Schema frontmatter
+
+Bind schemas on `sh:NodeShape` documents with `wazoo:jsonSchema` and `sh:targetClass`. Type-level schemas apply to every matching page; pages may append extra schemas with their own `wazoo:jsonSchema` (string or list). Local refs resolve under the wiki config root; remote `http(s)` URLs are fetched at check time. Shape binding documents are excluded from instance validation. See [SHACL](SHACL.md) and [Style Guide](Style_Guide.md#shacl-shapes).
 
 Broken links, filename pattern, and heading style are **not** part of `wiki check` — use [Wiki Subcommand lint](Wiki_Subcommand_lint.md).
 
 ### Scoped mode (one or more FILE args)
 
-`wiki check path/to/Page.md` (or multiple paths) runs **SHACL only** per file. Route safety, output collisions, and layout frontmatter rules are **full-wiki only**. Cross-document SHACL interactions may only appear in a full-wiki check. Broken links on those pages require `wiki lint` with the same paths.
+`wiki check path/to/Page.md` (or multiple paths) runs **SHACL and JSON Schema** per file. Route safety, output collisions, and layout frontmatter rules are **full-wiki only**. Cross-document SHACL interactions may only appear in a full-wiki check. Broken links on those pages require `wiki lint` with the same paths.
 
 `--strict` applies only when warnings exist; scoped mode does not emit warnings today.
 
@@ -70,5 +76,6 @@ Broken links, filename pattern, and heading style are **not** part of `wiki chec
 ## Related
 
 - [Wiki Configuration](Wiki_Configuration.md) — `check.*` severities
+- [SHACL](SHACL.md) — shape and JSON Schema binding
 - [Wiki Subcommand lint](Wiki_Subcommand_lint.md) — convention lane
 - [Style Guide](Style_Guide.md)

--- a/docs/wiki/Wiki_Subcommand_init.md
+++ b/docs/wiki/Wiki_Subcommand_init.md
@@ -6,7 +6,7 @@ description: Scaffold wiki.yaml and starter wiki pages interactively.
 
 # `wiki init`
 
-Create a new workspace in the **current directory**: `wiki.yaml`, `README.md`, `layouts/`, and starter files under `wiki/`.
+Create a new workspace in the **current directory**: `wiki.yaml`, `README.md`, `layouts/`, `schemas/person.json`, and starter files under `wiki/`.
 
 Does not use loaded Config; safe to run before a config exists.
 
@@ -79,7 +79,8 @@ Init does **not** write `.mdformat.toml`. To use a separate TOML file instead, s
 
 - `layouts/default.html.j2` — copied from packaged [`layout_default.html.j2`](https://github.com/wazootech/wiki/blob/main/src/wiki/templates/layout_default.html.j2); search, tabs, backlinks, and TOC. Edit to customize the look and feel.
 - `README.md` — starter workspace overview and common commands
-- `wiki/Person_Shape.md` — starter `sh:NodeShape` for `schema:Person`
+- `schemas/person.json` — starter JSON Schema bound from `Person_Shape.md`
+- `wiki/Person_Shape.md` — starter `sh:NodeShape` for `schema:Person` (includes `wazoo:jsonSchema`)
 - `wiki/Ethan_Davidson.md` — starter `schema:Person` example
 
 By default `wiki init` does **not** create a Git repository. Use `--git` if you want to run `git init` immediately.

--- a/docs/wiki/Wiki_Subcommand_link.md
+++ b/docs/wiki/Wiki_Subcommand_link.md
@@ -53,13 +53,13 @@ It never auto-creates pages or deletes links. Asset links, metadata CURIEs, and 
 ## Why not check or lint?
 
 - **`wiki lint`** is the convention lane — broken links, filename pattern, heading style, and link style. It reports but does not edit files; repair is `wiki link --fix-broken`. Missing wikilinks are optional enrichment, not a lint violation.
-- **`wiki check`** is the integrity lane — SHACL, routes, collisions, layout frontmatter. It does not scan prose for broken links.
+- **`wiki check`** is the integrity lane — SHACL, JSON Schema frontmatter, routes, collisions, layout frontmatter. It does not scan prose for broken links.
 - **`wiki link`** requires explicit `--apply` or `--fix-broken` because suggestions are heuristic and repairs are conservative by design.
 - See [Design Philosophies](Design_Philosophies.md#check-lint-fmt-and-link) for the full lane model.
 
 ## Related
 
 - [Wiki Subcommand lint](Wiki_Subcommand_lint.md) — convention lane (`lint.broken_links`)
-- [Wiki Subcommand check](Wiki_Subcommand_check.md) — integrity lane (SHACL, routes, layout)
+- [Wiki Subcommand check](Wiki_Subcommand_check.md) — integrity lane (SHACL, JSON Schema, routes, layout)
 - [Style Guide](Style_Guide.md) — internal link conventions
 - [Wiki CLI](Wiki_CLI.md)

--- a/docs/wiki/Wiki_Subcommand_lint.md
+++ b/docs/wiki/Wiki_Subcommand_lint.md
@@ -54,12 +54,12 @@ Route safety errors (spaces, unsafe URL characters) abort lint with errors befor
 
 ## Related CI commands
 
-| Command               | Purpose                                                       |
-| --------------------- | ------------------------------------------------------------- |
-| `wiki fmt --check`    | mdformat consistency (`fmt:` in wiki config or fallback TOML) |
-| `wiki lint --strict`  | Conventions (`lint:` in yaml)                                 |
-| `wiki check --strict` | SHACL, route safety, layout frontmatter                       |
-| `wiki render --check` | Stale inline SPARQL result blocks                             |
+| Command               | Purpose                                                          |
+| --------------------- | ---------------------------------------------------------------- |
+| `wiki fmt --check`    | mdformat consistency (`fmt:` in wiki config or fallback TOML)    |
+| `wiki lint --strict`  | Conventions (`lint:` in yaml)                                    |
+| `wiki check --strict` | SHACL, JSON Schema frontmatter, route safety, layout frontmatter |
+| `wiki render --check` | Stale inline SPARQL result blocks                                |
 
 Run in that order in CI: `fmt`, then `lint`, then `check` — so mechanical fixes land before conventions and integrity checks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "mdformat-gfm>=0.3.5",
     "jinja2>=3.1.0",
     "pydantic>=2.0",
+    "jsonschema>=4.23",
 ]
 
 [project.scripts]
@@ -34,7 +35,7 @@ wikilink = "wiki.mdformat_wikilink"
 [tool.setuptools]
 package-dir = {"" = "src"}
 packages = {find = {where = ["src"], include = ["wiki*"]}}
-package-data = {"wiki" = ["templates/*"]}
+package-data = {"wiki" = ["templates/*", "templates/schemas/*"]}
 
 [dependency-groups]
 standalone = ["pyinstaller>=6.0"]

--- a/skills/wiki-create/references/wiki-yaml-preferences.md
+++ b/skills/wiki-create/references/wiki-yaml-preferences.md
@@ -29,6 +29,6 @@ Severity is `off`, `warning`, or `error`. Unknown top-level keys fail at config 
 | ----- | ------- | ------- |
 | `fmt:` | `wiki fmt` | Mechanical markdown |
 | `lint:` | `wiki lint` | Conventions |
-| `check:` | `wiki check` | SHACL, routes, layouts |
+| `check:` | `wiki check` | SHACL, JSON Schema, routes, layouts |
 
 Regex belongs in `wiki.filename_pattern`, not under `check:`.

--- a/skills/wiki-improve/SKILL.md
+++ b/skills/wiki-improve/SKILL.md
@@ -36,7 +36,7 @@ Prefers `wiki` on PATH when `wiki fmt --help` succeeds. In the **Wiki CLI checko
 | ----- | ------- | ------- |
 | `fmt:` | `wiki fmt` | Mechanical markdown |
 | `lint:` | `wiki lint` | Conventions — links, filenames, headings |
-| `check:` | `wiki check` | Integrity — SHACL, routes, layouts |
+| `check:` | `wiki check` | Integrity — SHACL, JSON Schema, routes, layouts |
 
 Regex belongs in `wiki.filename_pattern`, not under `check:`.
 

--- a/src/wiki/audit.py
+++ b/src/wiki/audit.py
@@ -36,6 +36,7 @@ from .document import (
     span_overlaps,
     split_frontmatter_text,
 )
+from .frontmatter_schema import check_frontmatter_schema
 from .wiki_links import LinkIndex
 from .schemas import BrokenLink, CheckConfig, LintConfig
 
@@ -458,7 +459,7 @@ def check_layout_frontmatter(
 
 
 def run_check(config: Config, file_filter: set[str] | None = None) -> dict[str, Any]:
-    """Run integrity checks: SHACL, route safety, collisions, and layout frontmatter."""
+    """Run integrity checks: SHACL, route safety, collisions, layout, and JSON Schema frontmatter."""
     results = _empty_results()
 
     try:
@@ -487,6 +488,13 @@ def run_check(config: Config, file_filter: set[str] | None = None) -> dict[str, 
 
     layout_issues = check_layout_frontmatter(config, file_filter=file_filter)
     _apply_issues(results, "missing_layout_file", layout_issues, config.check)
+
+    missing_schema_issues, schema_validation_issues = check_frontmatter_schema(
+        config,
+        file_filter=file_filter,
+    )
+    _apply_issues(results, "missing_schema_ref", missing_schema_issues, config.check)
+    _apply_issues(results, "frontmatter_schema", schema_validation_issues, config.check)
 
     return results
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -15,7 +15,14 @@ from .format import run_query, process_rdf_format
 from .render import render_markdown_files
 from .parser import document_data_from_path
 from .graph import load_graph, graph_stats
-from .audit import check_shacl_file, merge_results, run_check, run_lint
+from .audit import (
+    _apply_issues,
+    check_frontmatter_schema,
+    check_shacl_file,
+    merge_results,
+    run_check,
+    run_lint,
+)
 from .jqfilter import resolve_path
 from .format_choice import FormatChoice
 from .paths import (
@@ -102,13 +109,15 @@ def _print_check_messages(errors: list[str], warnings: list[str], verbose: bool)
 @click.option("--strict", is_flag=True, help="Elevate all warnings to errors and exit with code 1.")
 @click.pass_obj
 def check(config: Config, files: tuple[Path, ...], verbose: bool, strict: bool) -> None:
-    """Integrity checks: SHACL, routes, collisions, layout (FILE...: SHACL only)."""
+    """Integrity checks: SHACL, JSON Schema, routes, collisions, layout (FILE...: SHACL + JSON Schema)."""
     if files:
         conforms = True
         errors: list[str] = []
         warnings: list[str] = []
 
-        for file in files:
+        resolved_files = select_document_paths(config, files)
+
+        for file in resolved_files:
             res = check_shacl_file(file, config, verbose=verbose)
             if res is None:
                 errors.append(f"No valid document metadata found in {file.name}")
@@ -118,6 +127,18 @@ def check(config: Config, files: tuple[Path, ...], verbose: bool, strict: bool) 
                 if not shacl_conforms:
                     conforms = False
                     errors.append(f"SHACL Validation Violation in {file.name}:\n{shacl_text}")
+
+        missing_schema_issues, schema_validation_issues = check_frontmatter_schema(
+            config,
+            file_paths=resolved_files,
+        )
+        schema_results = {"conforms": True, "errors": [], "warnings": []}
+        _apply_issues(schema_results, "missing_schema_ref", missing_schema_issues, config.check)
+        _apply_issues(schema_results, "frontmatter_schema", schema_validation_issues, config.check)
+        if not schema_results["conforms"]:
+            conforms = False
+        errors.extend(schema_results["errors"])
+        warnings.extend(schema_results["warnings"])
 
         if strict and warnings:
             errors.extend(warnings)
@@ -650,6 +671,7 @@ def init(
 
     from .init_scaffold import (
         copy_default_layout,
+        copy_default_person_schema,
         render_wiki_yaml,
         resolve_init_options,
     )
@@ -708,10 +730,11 @@ def init(
         "## Workspace Layout\n\n"
         "- `wiki.yaml` — Workspace configuration, namespace prefixes, and `fmt` defaults.\n"
         "- `wiki/` — Contains markdown files with semantic frontmatter.\n"
-        "  - `Person_Shape.md` — Validation shape for Person documents.\n"
-        "  - `Ethan_Davidson.md` — An example Person document.\n\n"
+        "  - `Person_Shape.md` — SHACL shape and JSON Schema binding for Person documents.\n"
+        "  - `Ethan_Davidson.md` — An example Person document.\n"
+        "  - `schemas/person.json` — JSON Schema for Person frontmatter.\n\n"
         "## Commands\n\n"
-        "- **Check** (integrity: SHACL, route safety, layout frontmatter):\n"
+        "- **Check** (integrity: SHACL, JSON Schema, route safety, layout frontmatter):\n"
         "  ```bash\n"
         "  wiki check\n"
         "  ```\n"
@@ -734,6 +757,7 @@ def init(
         "id: wiki:PersonShape\n"
         "type: sh:NodeShape\n"
         "sh:targetClass: schema:Person\n"
+        "wazoo:jsonSchema: schemas/person.json\n"
         "sh:property:\n"
         "  - sh:path: schema:givenName\n"
         "    sh:datatype: xsd:string\n"
@@ -765,6 +789,10 @@ def init(
     if force or not default_layout_path.exists():
         copy_default_layout(default_layout_path)
 
+    person_schema_path = cwd / "schemas" / "person.json"
+    if force or not person_schema_path.exists():
+        copy_default_person_schema(person_schema_path)
+
     if init_git:
         if shutil.which("git") is None:
             click.echo("Error: git was requested with --git, but no git executable was found on PATH.", err=True)
@@ -776,7 +804,7 @@ def init(
             click.echo(f"Error: git init failed: {stderr}", err=True)
             sys.exit(1)
 
-    message = "Initialized wiki.yaml, README.md, wiki/ starter files, and layouts/default.html.j2."
+    message = "Initialized wiki.yaml, README.md, wiki/ starter files, schemas/person.json, and layouts/default.html.j2."
     if init_git:
         message += " Ran git init."
     click.echo(message)

--- a/src/wiki/frontmatter_schema.py
+++ b/src/wiki/frontmatter_schema.py
@@ -1,0 +1,329 @@
+"""JSON Schema validation for wiki document frontmatter."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from .config import Config
+from .graph import _effective_types, resolve_type
+from .parser import document_data_from_path
+from .paths import iter_document_files, route_for_document_file
+
+logger = logging.getLogger(__name__)
+
+JSON_SCHEMA_KEY = "wazoo:jsonSchema"
+TARGET_CLASS_KEY = "sh:targetClass"
+
+REMOTE_FETCH_TIMEOUT = 10
+MAX_SCHEMA_BYTES = 1_000_000
+
+SchemaIssue = tuple[str, str]  # (missing_schema_ref | frontmatter_schema, message)
+
+
+def coerce_schema_refs(value: object) -> list[str] | None:
+    """Normalize wazoo:jsonSchema to a non-empty list of strings, or None if absent."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else None
+    if isinstance(value, list):
+        refs: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError("wazoo:jsonSchema list items must be strings")
+            text = item.strip()
+            if not text:
+                raise ValueError("wazoo:jsonSchema list items must be non-empty strings")
+            refs.append(text)
+        return refs or None
+    raise ValueError("wazoo:jsonSchema must be a string or list of strings")
+
+
+def is_remote_schema_ref(ref: str) -> bool:
+    return ref.startswith("http://") or ref.startswith("https://")
+
+
+def resolve_local_schema_path(raw: str, config_root: Path) -> Path:
+    """Resolve a local wazoo:jsonSchema path relative to the wiki config root."""
+    text = raw.strip().replace("\\", "/")
+    path = Path(text)
+    if not path.is_absolute():
+        path = config_root / path
+    return path.resolve()
+
+
+def schema_path_within_root(path: Path, config_root: Path) -> bool:
+    try:
+        path.resolve().relative_to(config_root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def local_schema_is_valid(path: Path, config_root: Path) -> bool:
+    if not schema_path_within_root(path, config_root):
+        return False
+    return path.is_file() and path.name.lower().endswith(".json")
+
+
+def normalize_type_uri(type_token: object, config: Config) -> str:
+    return str(resolve_type(type_token, config.context))
+
+
+def is_schema_binding_document(fm_data: dict[str, Any]) -> bool:
+    if not fm_data.get(TARGET_CLASS_KEY):
+        return False
+    try:
+        return coerce_schema_refs(fm_data.get(JSON_SCHEMA_KEY)) is not None
+    except ValueError:
+        return False
+
+
+def validation_payload(fm_data: dict[str, Any]) -> dict[str, Any]:
+    """Frontmatter dict for JSON Schema validation (exclude schema pointers and SHACL keys)."""
+    payload: dict[str, Any] = {}
+    for key, value in fm_data.items():
+        if key.startswith("@"):
+            continue
+        if key in {"id", JSON_SCHEMA_KEY}:
+            continue
+        if key.startswith("sh:") or key == TARGET_CLASS_KEY:
+            continue
+        payload[key] = value
+    return payload
+
+
+def _dedupe_refs(refs: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for ref in refs:
+        if ref in seen:
+            continue
+        seen.add(ref)
+        ordered.append(ref)
+    return ordered
+
+
+def build_type_schema_registry(config: Config) -> dict[str, list[str]]:
+    """Map normalized target-class URI to schema reference strings from binding documents."""
+    registry: dict[str, list[str]] = {}
+    for file_path in iter_document_files(config):
+        fm_data = document_data_from_path(file_path, content_predicate=config.graph.content_predicate)
+        if not fm_data or not is_schema_binding_document(fm_data):
+            continue
+        try:
+            refs = coerce_schema_refs(fm_data.get(JSON_SCHEMA_KEY))
+        except ValueError:
+            continue
+        if not refs:
+            continue
+        target = fm_data.get(TARGET_CLASS_KEY)
+        if target is None:
+            continue
+        type_key = normalize_type_uri(target, config)
+        registry.setdefault(type_key, []).extend(refs)
+    return {key: _dedupe_refs(refs) for key, refs in registry.items()}
+
+
+class SchemaLoader:
+    """Load and cache JSON Schema documents from local paths or remote URLs."""
+
+    def __init__(self, config_root: Path) -> None:
+        self.config_root = config_root.resolve()
+        self._schema_cache: dict[str, tuple[dict[str, Any] | None, str | None]] = {}
+        self._validator_cache: dict[str, tuple[Draft202012Validator | None, str | None]] = {}
+
+    def load_schema(self, ref: str) -> tuple[dict[str, Any] | None, str | None]:
+        if ref in self._schema_cache:
+            return self._schema_cache[ref]
+
+        if is_remote_schema_ref(ref):
+            schema, error = self._fetch_remote(ref)
+        else:
+            schema, error = self._load_local(ref)
+
+        self._schema_cache[ref] = (schema, error)
+        return schema, error
+
+    def get_validator(self, ref: str) -> tuple[Draft202012Validator | None, str | None]:
+        if ref in self._validator_cache:
+            return self._validator_cache[ref]
+
+        schema, error = self.load_schema(ref)
+        if error or schema is None:
+            self._validator_cache[ref] = (None, error)
+            return None, error
+
+        try:
+            validator = Draft202012Validator(schema)
+        except Exception as exc:
+            message = f"invalid JSON Schema document ({exc})"
+            self._validator_cache[ref] = (None, message)
+            return None, message
+
+        self._validator_cache[ref] = (validator, None)
+        return validator, None
+
+    def _load_local(self, ref: str) -> tuple[dict[str, Any] | None, str | None]:
+        path = resolve_local_schema_path(ref, self.config_root)
+        if not local_schema_is_valid(path, self.config_root):
+            return None, "must resolve to a readable .json file under the wiki config root"
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return None, f"could not be read as JSON ({exc})"
+        if not isinstance(data, dict):
+            return None, "must contain a JSON object"
+        return data, None
+
+    def _fetch_remote(self, ref: str) -> tuple[dict[str, Any] | None, str | None]:
+        request = Request(ref, headers={"User-Agent": "Wiki-CLI/jsonschema"})
+        try:
+            with urlopen(request, timeout=REMOTE_FETCH_TIMEOUT) as response:
+                raw = response.read(MAX_SCHEMA_BYTES + 1)
+        except HTTPError as exc:
+            return None, f"HTTP {exc.code}"
+        except URLError as exc:
+            return None, str(exc.reason)
+        except TimeoutError:
+            return None, "request timed out"
+        except OSError as exc:
+            return None, str(exc)
+
+        if len(raw) > MAX_SCHEMA_BYTES:
+            return None, f"response exceeds {MAX_SCHEMA_BYTES} bytes"
+
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return None, f"response is not valid JSON ({exc})"
+        if not isinstance(data, dict):
+            return None, "response must be a JSON object"
+        return data, None
+
+
+def _effective_schema_refs(
+    fm_data: dict[str, Any],
+    registry: dict[str, list[str]],
+    config: Config,
+) -> list[tuple[str, str | None]]:
+    """Return (schema_ref, via_label) pairs to validate, deduped."""
+    refs: list[tuple[str, str | None]] = []
+    seen: set[str] = set()
+
+    for type_token in _effective_types(fm_data, config):
+        type_uri = normalize_type_uri(type_token, config)
+        for ref in registry.get(type_uri, []):
+            if ref in seen:
+                continue
+            seen.add(ref)
+            refs.append((ref, f"via type {type_token}"))
+
+    if not is_schema_binding_document(fm_data):
+        try:
+            page_refs = coerce_schema_refs(fm_data.get(JSON_SCHEMA_KEY))
+        except ValueError:
+            page_refs = None
+        if page_refs:
+            for ref in page_refs:
+                if ref in seen:
+                    continue
+                seen.add(ref)
+                refs.append((ref, None))
+
+    return refs
+
+
+def _format_missing_ref(route: str, ref: str, detail: str, *, binding: bool) -> str:
+    if is_remote_schema_ref(ref):
+        return f"In {route}: wazoo:jsonSchema {ref!r} could not be fetched ({detail})."
+    if binding:
+        return (
+            f"In {route}: wazoo:jsonSchema on type binding {ref!r} {detail}."
+        )
+    return f"In {route}: wazoo:jsonSchema {ref!r} {detail}."
+
+
+def _format_validation_error(route: str, ref: str, error: ValidationError, via: str | None) -> str:
+    via_part = f", {via}" if via else ""
+    return f"In {route}: {error.message} (schema: {ref}{via_part})"
+
+
+def check_frontmatter_schema(
+    config: Config,
+    file_filter: set[str] | None = None,
+    *,
+    file_paths: list[Path] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Return (missing_schema_ref issues, frontmatter_schema validation issues)."""
+    if config.check.frontmatter_schema == "off" and config.check.missing_schema_ref == "off":
+        return [], []
+
+    registry = build_type_schema_registry(config)
+    loader = SchemaLoader(config.config_root)
+    missing_issues: list[str] = []
+    validation_issues: list[str] = []
+
+    candidates = file_paths if file_paths is not None else iter_document_files(config)
+
+    for file_path in candidates:
+        try:
+            route = route_for_document_file(config, file_path)
+        except ValueError:
+            continue
+        if file_filter is not None and route not in file_filter:
+            continue
+
+        fm_data = document_data_from_path(file_path, content_predicate=config.graph.content_predicate)
+        if not fm_data:
+            continue
+
+        try:
+            coerce_schema_refs(fm_data.get(JSON_SCHEMA_KEY))
+        except ValueError as exc:
+            validation_issues.append(f"In {route}: {exc}.")
+            continue
+
+        if is_schema_binding_document(fm_data):
+            binding = True
+            try:
+                binding_refs = coerce_schema_refs(fm_data.get(JSON_SCHEMA_KEY)) or []
+            except ValueError:
+                binding_refs = []
+            for ref in binding_refs:
+                _, error = loader.load_schema(ref)
+                if error and config.check.missing_schema_ref != "off":
+                    missing_issues.append(
+                        _format_missing_ref(route, ref, error, binding=True)
+                    )
+            continue
+
+        schema_refs = _effective_schema_refs(fm_data, registry, config)
+        if not schema_refs:
+            continue
+
+        instance = validation_payload(fm_data)
+        for ref, via in schema_refs:
+            validator, error = loader.get_validator(ref)
+            if error:
+                if config.check.missing_schema_ref != "off":
+                    missing_issues.append(_format_missing_ref(route, ref, error, binding=False))
+                continue
+            if validator is None:
+                continue
+            for validation_error in sorted(validator.iter_errors(instance), key=lambda e: list(e.path)):
+                if config.check.frontmatter_schema != "off":
+                    validation_issues.append(
+                        _format_validation_error(route, ref, validation_error, via)
+                    )
+
+    return missing_issues, validation_issues

--- a/src/wiki/init_scaffold.py
+++ b/src/wiki/init_scaffold.py
@@ -18,6 +18,7 @@ __all__ = [
     "DOCS_WIKI_INIT_OPTIONS",
     "InitOptions",
     "copy_default_layout",
+    "copy_default_person_schema",
     "load_packaged_default_layout",
     "render_wiki_yaml",
     "resolve_init_options",
@@ -164,6 +165,7 @@ def resolve_init_options(
 
 _INIT_TEMPLATE_NAME = "wiki.yaml.j2"
 _DEFAULT_LAYOUT_TEMPLATE = "layout_default.html.j2"
+_DEFAULT_PERSON_SCHEMA = "schemas/person.json"
 _JINJA_COMMENT_PREFIX = "{# wiki init scaffold"
 
 
@@ -201,3 +203,10 @@ def copy_default_layout(dest: Path) -> None:
     """Copy the packaged default page layout into a workspace."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(load_packaged_default_layout(), encoding="utf-8")
+
+
+def copy_default_person_schema(dest: Path) -> None:
+    """Copy the packaged Person JSON Schema into a workspace."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    source = files("wiki").joinpath(f"templates/{_DEFAULT_PERSON_SCHEMA}").read_text(encoding="utf-8")
+    dest.write_text(source, encoding="utf-8")

--- a/src/wiki/schemas/rules.py
+++ b/src/wiki/schemas/rules.py
@@ -23,8 +23,10 @@ class CheckConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     missing_layout_file: Annotated[Severity, Field(default="error")] = "error"
+    frontmatter_schema: Annotated[Severity, Field(default="error")] = "error"
+    missing_schema_ref: Annotated[Severity, Field(default="error")] = "error"
 
-    @field_validator("missing_layout_file", mode="before")
+    @field_validator("missing_layout_file", "frontmatter_schema", "missing_schema_ref", mode="before")
     @classmethod
     def _validate_severity(cls, value: object) -> Severity:
         return coerce_severity(value)

--- a/src/wiki/templates/schemas/person.json
+++ b/src/wiki/templates/schemas/person.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["givenName", "familyName"],
+  "properties": {
+    "givenName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "familyName": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/wiki/templates/wiki.yaml.j2
+++ b/src/wiki/templates/wiki.yaml.j2
@@ -98,10 +98,14 @@ link:
   # renames:
   #   Old_Page_Name: New_Page_Name
 
-# Integrity severities (wiki check): SHACL, routes, layout files.
+# Integrity severities (wiki check): SHACL, JSON Schema, routes, layout files.
 check:
   # Error when wazoo:layout points at a missing .html.j2 file.
   missing_layout_file: error
+  # Error when frontmatter fails JSON Schema validation.
+  frontmatter_schema: error
+  # Error when wazoo:jsonSchema cannot be loaded (local or remote).
+  missing_schema_ref: error
 
 # Convention severities (wiki lint): links, filenames, headings.
 lint:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,6 +236,61 @@ name: Invalid Name
             )
             self.assertEqual(result.exit_code, 0)
 
+    def test_cli_check_scoped_frontmatter_schema(self) -> None:
+        """Scoped wiki check runs JSON Schema validation via file_paths wiring."""
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir)
+            wiki_dir = config_dir / "wiki"
+            wiki_dir.mkdir()
+            schemas_dir = config_dir / "schemas"
+            schemas_dir.mkdir()
+            (schemas_dir / "article.json").write_text(
+                json.dumps(
+                    {
+                        "type": "object",
+                        "required": ["headline", "description"],
+                        "properties": {
+                            "headline": {"type": "string"},
+                            "description": {"type": "string"},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (config_dir / "wiki.yaml").write_text(
+                yaml.dump({"wiki": {"inputs": ["wiki"]}}),
+                encoding="utf-8",
+            )
+            (wiki_dir / "Article_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:TechArticle\n"
+                "wazoo:jsonSchema: schemas/article.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            valid = wiki_dir / "Valid.md"
+            valid.write_text(
+                "---\ntype: TechArticle\nheadline: Ok\ndescription: Fine\n---\n",
+                encoding="utf-8",
+            )
+            broken = wiki_dir / "Broken.md"
+            broken.write_text("---\ntype: TechArticle\nheadline: Only\n---\n", encoding="utf-8")
+            other = wiki_dir / "Other_Broken.md"
+            other.write_text("---\ntype: TechArticle\nheadline: Other\n---\n", encoding="utf-8")
+
+            ok = runner.invoke(main, ["-c", str(config_dir), "check", str(valid)])
+            self.assertEqual(ok.exit_code, 0, msg=ok.output)
+
+            fail = runner.invoke(main, ["-c", str(config_dir), "check", str(broken)])
+            self.assertEqual(fail.exit_code, 1, msg=fail.output)
+            self.assertIn("description", fail.output)
+
+            scoped = runner.invoke(main, ["-c", str(config_dir), "check", str(valid)])
+            self.assertEqual(scoped.exit_code, 0, msg=scoped.output)
+            self.assertNotIn("Other_Broken", scoped.output)
+
     def test_cli_query_formats(self) -> None:
         """Test that wiki query executes successfully with various output formats."""
         runner = CliRunner()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,7 +89,9 @@ class TestConfig(unittest.TestCase):
                     }
                 },
                 "check": {
-                    "missing_layout_file": "error"
+                    "missing_layout_file": "error",
+                    "frontmatter_schema": "error",
+                    "missing_schema_ref": "warning",
                 },
                 "lint": {
                     "broken_links": "error",
@@ -104,6 +106,8 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config.wiki.assets, [base_path.absolute() / "assets", base_path.absolute() / "media/photos"])
             self.assertEqual(config.wiki.exclude, ["wiki/drafts/**", "assets/private/**"])
             self.assertEqual(config.check.missing_layout_file, "error")
+            self.assertEqual(config.check.frontmatter_schema, "error")
+            self.assertEqual(config.check.missing_schema_ref, "warning")
             self.assertEqual(config.lint.broken_links, "error")
             self.assertEqual(config.lint.filename_pattern, "error")
             self.assertEqual(config.wiki.filename_pattern, "[A-Za-z0-9_()-]+\\.md")

--- a/tests/test_frontmatter_schema.py
+++ b/tests/test_frontmatter_schema.py
@@ -1,0 +1,621 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+from wiki.config import Config
+from wiki.audit import run_check
+from wiki.frontmatter_schema import (
+    JSON_SCHEMA_KEY,
+    TARGET_CLASS_KEY,
+    build_type_schema_registry,
+    check_frontmatter_schema,
+    coerce_schema_refs,
+    is_schema_binding_document,
+    validation_payload,
+)
+
+
+class TestFrontmatterSchemaHelpers(unittest.TestCase):
+    def test_coerce_schema_refs_scalar_and_list(self) -> None:
+        self.assertEqual(coerce_schema_refs("schemas/a.json"), ["schemas/a.json"])
+        self.assertEqual(
+            coerce_schema_refs(["schemas/a.json", "schemas/b.json"]),
+            ["schemas/a.json", "schemas/b.json"],
+        )
+        self.assertIsNone(coerce_schema_refs(None))
+
+    def test_coerce_schema_refs_rejects_invalid_values(self) -> None:
+        with self.assertRaises(ValueError):
+            coerce_schema_refs(42)
+        with self.assertRaises(ValueError):
+            coerce_schema_refs(["schemas/a.json", 1])
+
+    def test_is_schema_binding_document(self) -> None:
+        self.assertTrue(
+            is_schema_binding_document(
+                {
+                    "type": "sh:NodeShape",
+                    TARGET_CLASS_KEY: "schema:Person",
+                    JSON_SCHEMA_KEY: "schemas/person.json",
+                }
+            )
+        )
+        self.assertFalse(is_schema_binding_document({TARGET_CLASS_KEY: "schema:Person"}))
+
+    def test_validation_payload_excludes_schema_and_shacl_keys(self) -> None:
+        payload = validation_payload(
+            {
+                "type": "TechArticle",
+                "headline": "Title",
+                JSON_SCHEMA_KEY: "schemas/extra.json",
+                TARGET_CLASS_KEY: "schema:TechArticle",
+                "sh:property": [],
+            }
+        )
+        self.assertEqual(payload, {"type": "TechArticle", "headline": "Title"})
+
+
+class TestFrontmatterSchemaValidation(unittest.TestCase):
+    def _write_schema(self, root: Path, rel: str, schema: dict) -> None:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(schema), encoding="utf-8")
+
+    def _person_schema(self) -> dict:
+        return {
+            "type": "object",
+            "required": ["givenName", "familyName"],
+            "properties": {
+                "givenName": {"type": "string", "minLength": 1},
+                "familyName": {"type": "string", "minLength": 1},
+            },
+        }
+
+    def test_type_binding_validates_matching_documents(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            self._write_schema(root, "schemas/person.json", self._person_schema())
+            (wiki / "Person_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Person\n"
+                "wazoo:jsonSchema: schemas/person.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Valid.md").write_text(
+                "---\ntype: schema:Person\ngivenName: Ada\nfamilyName: Lovelace\n---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Invalid.md").write_text(
+                "---\ntype: schema:Person\ngivenName: Ada\n---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(missing, [])
+            self.assertEqual(len(validation), 1)
+            self.assertIn("In Invalid:", validation[0])
+            self.assertIn("familyName", validation[0])
+
+    def test_binding_document_is_not_validated_as_instance(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            self._write_schema(
+                root,
+                "schemas/shape-only.json",
+                {"type": "object", "required": ["headline"], "properties": {"headline": {"type": "string"}}},
+            )
+            (wiki / "Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Person\n"
+                "wazoo:jsonSchema: schemas/shape-only.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(missing, [])
+            self.assertEqual(validation, [])
+
+    def test_per_page_schema_appends_to_type_binding(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            self._write_schema(root, "schemas/person.json", self._person_schema())
+            self._write_schema(
+                root,
+                "schemas/extra.json",
+                {"type": "object", "required": ["nickname"], "properties": {"nickname": {"type": "string"}}},
+            )
+            (wiki / "Person_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Person\n"
+                "wazoo:jsonSchema: schemas/person.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Page.md").write_text(
+                "---\n"
+                "type: schema:Person\n"
+                "givenName: Ada\n"
+                "familyName: Lovelace\n"
+                "wazoo:jsonSchema: schemas/extra.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(missing, [])
+            self.assertEqual(len(validation), 1)
+            self.assertIn("nickname", validation[0])
+
+    def test_missing_local_schema_ref(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "Person_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Person\n"
+                "wazoo:jsonSchema: schemas/missing.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Page.md").write_text(
+                "---\ntype: schema:Person\ngivenName: Ada\nfamilyName: Lovelace\n---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(validation, [])
+            self.assertEqual(len(missing), 2)
+            self.assertTrue(any("missing.json" in issue for issue in missing))
+
+    def test_scoped_check_uses_full_registry(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            self._write_schema(root, "schemas/person.json", self._person_schema())
+            (wiki / "Person_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Person\n"
+                "wazoo:jsonSchema: schemas/person.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            invalid = wiki / "Invalid.md"
+            invalid.write_text("---\ntype: schema:Person\ngivenName: Ada\n---\n", encoding="utf-8")
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config, file_paths=[invalid])
+            self.assertEqual(missing, [])
+            self.assertEqual(len(validation), 1)
+
+    def test_remote_schema_ref(self) -> None:
+        remote_schema = {
+            "type": "object",
+            "required": ["label"],
+            "properties": {"label": {"type": "string"}},
+        }
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return None
+
+            def read(self, max_bytes: int):
+                return json.dumps(remote_schema).encode("utf-8")
+
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "Remote_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Thing\n"
+                "wazoo:jsonSchema: https://example.org/schema.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Good.md").write_text(
+                "---\ntype: schema:Thing\nlabel: ok\n---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Bad.md").write_text(
+                "---\ntype: schema:Thing\n---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            with patch("wiki.frontmatter_schema.urlopen", return_value=FakeResponse()):
+                missing, validation = check_frontmatter_schema(config)
+
+            self.assertEqual(missing, [])
+            self.assertEqual(len(validation), 1)
+            self.assertIn("In Bad:", validation[0])
+
+    def test_build_type_schema_registry_dedupes_refs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            for name in ("A_Shape.md", "B_Shape.md"):
+                (wiki / name).write_text(
+                    "---\n"
+                    "type: sh:NodeShape\n"
+                    "sh:targetClass: schema:Person\n"
+                    "wazoo:jsonSchema: schemas/person.json\n"
+                    "---\n",
+                    encoding="utf-8",
+                )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            registry = build_type_schema_registry(config)
+            self.assertEqual(registry["https://schema.org/Person"], ["schemas/person.json"])
+
+    def test_run_check_includes_frontmatter_schema_errors(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            self._write_schema(
+                root,
+                "schemas/article.json",
+                {
+                    "type": "object",
+                    "required": ["headline", "description"],
+                    "properties": {
+                        "headline": {"type": "string"},
+                        "description": {"type": "string"},
+                    },
+                },
+            )
+            (wiki / "Article_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:TechArticle\n"
+                "wazoo:jsonSchema: schemas/article.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Broken.md").write_text("---\ntype: TechArticle\nheadline: Only\n---\n", encoding="utf-8")
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            results = run_check(config)
+            self.assertFalse(results["conforms"])
+            self.assertTrue(any("description" in err for err in results["errors"]))
+
+    def _setup_severity_fixture(self, root: Path) -> Path:
+        wiki = root / "wiki"
+        wiki.mkdir()
+        self._write_schema(
+            root,
+            "schemas/article.json",
+            {
+                "type": "object",
+                "required": ["headline", "description"],
+                "properties": {
+                    "headline": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+            },
+        )
+        (wiki / "Article_Shape.md").write_text(
+            "---\n"
+            "type: sh:NodeShape\n"
+            "sh:targetClass: schema:TechArticle\n"
+            "wazoo:jsonSchema: schemas/article.json\n"
+            "---\n",
+            encoding="utf-8",
+        )
+        (wiki / "Gadget_Shape.md").write_text(
+            "---\n"
+            "type: sh:NodeShape\n"
+            "sh:targetClass: schema:Product\n"
+            "wazoo:jsonSchema: schemas/missing.json\n"
+            "---\n",
+            encoding="utf-8",
+        )
+        (wiki / "Broken.md").write_text("---\ntype: TechArticle\nheadline: Only\n---\n", encoding="utf-8")
+        (wiki / "Product.md").write_text("---\ntype: schema:Product\nname: Gadget\n---\n", encoding="utf-8")
+        return wiki
+
+    @staticmethod
+    def _missing_ref_messages(results: dict) -> list[str]:
+        return [
+            msg
+            for msg in results["errors"] + results["warnings"]
+            if "missing.json" in msg
+        ]
+
+    @staticmethod
+    def _validation_messages(results: dict) -> list[str]:
+        return [
+            msg
+            for msg in results["errors"] + results["warnings"]
+            if "description" in msg
+        ]
+
+    def test_run_check_frontmatter_schema_severity_matrix(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = self._setup_severity_fixture(root)
+            base = {"wiki": {"inputs": [wiki]}, "config_root": root}
+
+            for severity, expect_errors, expect_warnings, expect_conforms in (
+                ("off", 0, 0, True),
+                ("warning", 0, 1, True),
+                ("error", 1, 0, False),
+            ):
+                with self.subTest(severity=severity):
+                    config = Config(
+                        **base,
+                        check={
+                            "frontmatter_schema": severity,
+                            "missing_schema_ref": "off",
+                        },
+                    )
+                    results = run_check(config)
+                    validation_errors = [
+                        msg for msg in results["errors"] if "description" in msg
+                    ]
+                    validation_warnings = [
+                        msg for msg in results["warnings"] if "description" in msg
+                    ]
+                    self.assertEqual(len(validation_errors), expect_errors)
+                    self.assertEqual(len(validation_warnings), expect_warnings)
+                    self.assertEqual(results["conforms"], expect_conforms)
+
+    def test_run_check_missing_schema_ref_severity_matrix(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = self._setup_severity_fixture(root)
+            base = {"wiki": {"inputs": [wiki]}, "config_root": root}
+
+            for severity, expect_errors, expect_warnings, expect_conforms in (
+                ("off", 0, 0, True),
+                ("warning", 0, 1, True),
+                ("error", 1, 0, False),
+            ):
+                with self.subTest(severity=severity):
+                    config = Config(
+                        **base,
+                        check={
+                            "frontmatter_schema": "off",
+                            "missing_schema_ref": severity,
+                        },
+                    )
+                    results = run_check(config)
+                    missing_errors = [
+                        msg for msg in results["errors"] if "missing.json" in msg
+                    ]
+                    missing_warnings = [
+                        msg for msg in results["warnings"] if "missing.json" in msg
+                    ]
+                    self.assertGreaterEqual(len(missing_errors), expect_errors)
+                    self.assertGreaterEqual(len(missing_warnings), expect_warnings)
+                    if severity == "off":
+                        self.assertEqual(missing_errors, [])
+                        self.assertEqual(missing_warnings, [])
+                    elif severity == "warning":
+                        self.assertEqual(missing_errors, [])
+                        self.assertGreater(len(missing_warnings), 0)
+                    else:
+                        self.assertGreater(len(missing_errors), 0)
+                        self.assertEqual(missing_warnings, [])
+                    self.assertEqual(results["conforms"], expect_conforms)
+
+    def test_run_check_both_schema_rules_off_skips_validation(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = self._setup_severity_fixture(root)
+            config = Config(
+                wiki={"inputs": [wiki]},
+                config_root=root,
+                check={"frontmatter_schema": "off", "missing_schema_ref": "off"},
+            )
+
+            results = run_check(config)
+            self.assertTrue(results["conforms"])
+            self.assertEqual(self._missing_ref_messages(results), [])
+            self.assertEqual(self._validation_messages(results), [])
+
+    def test_page_list_schema_union(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            self._write_schema(
+                root,
+                "schemas/a.json",
+                {"type": "object", "required": ["foo"], "properties": {"foo": {"type": "string"}}},
+            )
+            self._write_schema(
+                root,
+                "schemas/b.json",
+                {"type": "object", "required": ["bar"], "properties": {"bar": {"type": "string"}}},
+            )
+            (wiki / "Page.md").write_text(
+                "---\n"
+                "type: schema:WebPage\n"
+                "name: List union\n"
+                "foo: ok\n"
+                "wazoo:jsonSchema:\n"
+                "  - schemas/a.json\n"
+                "  - schemas/b.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(missing, [])
+            self.assertEqual(len(validation), 1)
+            self.assertIn("bar", validation[0])
+
+            (wiki / "Page.md").unlink()
+            (wiki / "PageBoth.md").write_text(
+                "---\n"
+                "type: schema:WebPage\n"
+                "name: Both missing\n"
+                "wazoo:jsonSchema:\n"
+                "  - schemas/a.json\n"
+                "  - schemas/b.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(missing, [])
+            self.assertEqual(len(validation), 2)
+            self.assertTrue(any("foo" in issue for issue in validation))
+            self.assertTrue(any("bar" in issue for issue in validation))
+
+    def test_missing_schema_ref_outside_config_root(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            outside = root.parent / "outside.json"
+            outside.write_text("{}", encoding="utf-8")
+            (wiki / "Page.md").write_text(
+                "---\n"
+                "type: schema:WebPage\n"
+                "name: Escape\n"
+                "wazoo:jsonSchema: ../outside.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(validation, [])
+            self.assertEqual(len(missing), 1)
+            self.assertIn("under the wiki config root", missing[0])
+
+    def test_missing_schema_ref_non_json_extension(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            self._write_schema(root, "schemas/rules.yaml", {"type": "object"})
+            (wiki / "Page.md").write_text(
+                "---\n"
+                "type: schema:WebPage\n"
+                "name: Wrong ext\n"
+                "wazoo:jsonSchema: schemas/rules.yaml\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            missing, validation = check_frontmatter_schema(config)
+            self.assertEqual(validation, [])
+            self.assertEqual(len(missing), 1)
+            self.assertIn(".json", missing[0])
+
+    def test_missing_schema_ref_invalid_json_schema_document(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            broken = root / "schemas" / "broken.json"
+            broken.parent.mkdir(parents=True, exist_ok=True)
+            broken.write_text(json.dumps({"type": "object"}), encoding="utf-8")
+            (wiki / "Page.md").write_text(
+                "---\n"
+                "type: schema:WebPage\n"
+                "name: Bad schema\n"
+                "wazoo:jsonSchema: schemas/broken.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            with patch(
+                "wiki.frontmatter_schema.Draft202012Validator",
+                side_effect=ValueError("schema document is invalid"),
+            ):
+                missing, validation = check_frontmatter_schema(config)
+
+            self.assertEqual(validation, [])
+            self.assertEqual(len(missing), 1)
+            self.assertIn("invalid JSON Schema", missing[0])
+
+    def test_remote_schema_ref_http_error(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "Remote_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Thing\n"
+                "wazoo:jsonSchema: https://example.org/schema.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Page.md").write_text("---\ntype: schema:Thing\nlabel: ok\n---\n", encoding="utf-8")
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            def raise_http_error(*args, **kwargs):
+                raise HTTPError(
+                    url="https://example.org/schema.json",
+                    code=404,
+                    msg="Not Found",
+                    hdrs=None,
+                    fp=None,
+                )
+
+            with patch("wiki.frontmatter_schema.urlopen", side_effect=raise_http_error):
+                missing, validation = check_frontmatter_schema(config)
+
+            self.assertEqual(validation, [])
+            self.assertGreater(len(missing), 0)
+            self.assertTrue(any("HTTP 404" in issue for issue in missing))
+
+    def test_remote_schema_ref_timeout(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            (wiki / "Remote_Shape.md").write_text(
+                "---\n"
+                "type: sh:NodeShape\n"
+                "sh:targetClass: schema:Thing\n"
+                "wazoo:jsonSchema: https://example.org/schema.json\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (wiki / "Page.md").write_text("---\ntype: schema:Thing\nlabel: ok\n---\n", encoding="utf-8")
+            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+
+            with patch("wiki.frontmatter_schema.urlopen", side_effect=TimeoutError):
+                missing, validation = check_frontmatter_schema(config)
+
+            self.assertEqual(validation, [])
+            self.assertGreater(len(missing), 0)
+            self.assertTrue(any("timed out" in issue for issue in missing))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_init_scaffold.py
+++ b/tests/test_init_scaffold.py
@@ -105,6 +105,8 @@ class TestRenderWikiYaml(TestCase):
         self.assertIn("duplicate_headings: off", rendered)
         self.assertIn("thematic_breaks: off", rendered)
         self.assertIn("missing_layout_file: error", rendered)
+        self.assertIn("frontmatter_schema: error", rendered)
+        self.assertIn("missing_schema_ref: error", rendered)
         self.assertIn("wrap: \"no\"", rendered)
         self.assertIn("extensions: [gfm, frontmatter, wikilink]", rendered)
         self.assertIn("# fmt: .mdformat.toml", rendered)

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -73,6 +82,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -502,6 +538,20 @@ html = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -512,6 +562,116 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
 ]
 
 [[package]]
@@ -570,6 +730,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
     { name = "jinja2" },
+    { name = "jsonschema" },
     { name = "markdown-it-py" },
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
@@ -593,6 +754,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "jinja2", specifier = ">=3.1.0" },
+    { name = "jsonschema", specifier = ">=4.23" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "mdformat", specifier = ">=0.7.19" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.1" },


### PR DESCRIPTION
## Summary

- Add parallel JSON Schema frontmatter validation in `wiki check` via `wazoo:jsonSchema` on SHACL shape bindings (`sh:targetClass`) and optional per-page schema refs (string or list union).
- Introduce `check.frontmatter_schema` and `check.missing_schema_ref` severity config, scoped `wiki check FILE...` wiring, and `wiki init` scaffold for `schemas/person.json`.
- Dogfood `docs/schemas/tech-article.json` from [Tech Article Shape](docs/wiki/Tech_Article_Shape.md).
- Expand test coverage for severity gating, CLI scoped check, multi-schema list validation, path safety, remote fetch failures, and config load.

Closes #71.

## Test plan

- [x] `PYTHONPATH=src uv run python -m unittest discover -s tests` (448 tests)
- [ ] CI: unit tests + `wiki -c docs/wiki.yaml fmt --check`, `lint --strict`, `check --strict`, `render --check`