### PR TITLE
Hidden SPARQL query syntax for inline render blocks (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Added
 
+- Hidden SPARQL queries in inline render blocks — wrap the fenced query in an HTML comment (`<!-- sparql:start` … `-->`) so built pages show only the results table; visible-query syntax is unchanged ([#73](https://github.com/wazootech/wiki/issues/73))
 - JSON Schema frontmatter validation in `wiki check` — bind schemas on SHACL shape documents with `wazoo:jsonSchema` + `sh:targetClass`, or append per-page schemas; configurable via `check.frontmatter_schema` and `check.missing_schema_ref` ([#71](https://github.com/wazootech/wiki/issues/71))
 - `wiki init` scaffolds `schemas/person.json` and binds it from `Person_Shape.md`
 - Dogfood schema at `docs/schemas/tech-article.json` bound from [Tech Article Shape](docs/wiki/Tech_Article_Shape.md)

--- a/docs/wiki/Style_Guide.md
+++ b/docs/wiki/Style_Guide.md
@@ -89,6 +89,12 @@ When writing `&lt;!-- sparql:start --&gt;` blocks or ad-hoc `wiki query` command
 - **Types** — use `rdf:type` with full URIs or configured prefixes (`schema:`, `wiki:`, `sh:`).
 - **Inference** — omit `--no-inference` in sparql blocks unless you intentionally want raw asserted triples only.
 
+Inline SPARQL blocks use `&lt;!-- sparql:start --&gt;` … `&lt;!-- sparql:end --&gt;` with a fenced `sparql` query and a GFM results table. `wiki render` runs the query and rewrites the table in place.
+
+**Visible query (default)** — close the start comment before the fence so the query appears in built HTML: `&lt;!-- sparql:start --&gt;`, then the `sparql` fence and table, then `&lt;!-- sparql:end --&gt;`.
+
+**Hidden query** — leave the start comment open (`&lt;!-- sparql:start` on its own line), put the `sparql` fence and query next, close the HTML comment with `--&gt;` on the line after the fence, then the results table and `&lt;!-- sparql:end --&gt;`. The query stays inside the HTML comment (invisible in built pages; still executed by `wiki render`). See the live block under [Active database summary](#active-database-summary) below.
+
 ## SHACL shapes
 
 Define constraints in frontmatter with `type: sh:NodeShape` (see `wiki init`'s `Person_Shape.md` or [Software Application Shape](Software_Application_Shape.md) in this wiki). Shapes in the wiki are loaded into the validation graph; [Wiki Subcommand check](Wiki_Subcommand_check.md) runs PySHACL against every document. Background: [SHACL](SHACL.md).
@@ -136,8 +142,7 @@ W3C-only topics need only the spec link. Keep `## Related` for internal wiki nav
 
 The table below queries the active graph to list all distinct classes currently instantiated in your wiki:
 
-<!-- sparql:start -->
-
+<!-- sparql:start
 ```sparql
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
@@ -147,6 +152,7 @@ SELECT DISTINCT ?class WHERE {
 }
 ORDER BY ?class
 ```
+-->
 
 | Class                                  |
 | -------------------------------------- |

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -149,8 +149,7 @@ wiki --wiki-inputs ./wiki --wiki-inputs ./imported query "SELECT * WHERE { ?s ?p
 
 Each subcommand has a dedicated page:
 
-<!-- sparql:start -->
-
+<!-- sparql:start
 ```sparql
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -163,6 +162,7 @@ SELECT ?command ?description WHERE {
 }
 ORDER BY ?command
 ```
+-->
 
 | command | description |
 | --- | --- |

--- a/docs/wiki/Wiki_Subcommand_render.md
+++ b/docs/wiki/Wiki_Subcommand_render.md
@@ -37,7 +37,7 @@ wiki render --cache
 
 ## Block format
 
-See [Style Guide](Style_Guide.md) for the `sparql:start` / `sparql:end` wrapper and fenced `sparql` code block.
+See [Style Guide](Style_Guide.md) for the `sparql:start` / `sparql:end` wrapper and fenced `sparql` code block. Close the start comment before the fence to show the query in built HTML; leave it open and close after the fence (`<!-- sparql:start` … `-->`) to hide the query from published pages while `wiki render` still updates the table.
 
 ## Related
 

--- a/src/wiki/fmt_util.py
+++ b/src/wiki/fmt_util.py
@@ -22,7 +22,7 @@ DEFAULT_FMT_OPTS: dict[str, Any] = {
 }
 
 SPARQL_REGION_RE = re.compile(
-    r"<!--\s*sparql:start\s*-->.*?<!--\s*sparql:end\s*-->",
+    r"<!--\s*sparql:start\b.*?<!--\s*sparql:end\s*-->",
     re.DOTALL | re.IGNORECASE,
 )
 _SPARQL_PLACEHOLDER = "WIKI_FMT_SPARQL_BLOCK_{index}"

--- a/src/wiki/render.py
+++ b/src/wiki/render.py
@@ -14,9 +14,12 @@ from wiki.mdit_py_plugins.wikilink import wikilink_plugin
 from .paths import iter_markdown_files, page_routes, select_markdown_paths
 
 # Matches SPARQL wrapper comments, fenced query, rendered table, and end comment.
+# Visible query: <!-- sparql:start --> ... fence ... table ... <!-- sparql:end -->
+# Hidden query:   <!-- sparql:start ... fence ... --> ... table ... <!-- sparql:end -->
 SPARQL_BLOCK_REGEX = re.compile(
-    r"(?P<start><!--\s*sparql:start\s*-->)(?P<prefix>\s*)"
+    r"(?P<start><!--\s*sparql:start(?:\s*-->)?)(?P<prefix>\s*)"
     r"(?P<fence>```sparql\s*(?P<query>.*?)\s*```)(?P<mid>\s*)"
+    r"(?:(?P<comment_end>-->)(?P<post_comment>\s*))?"
     r"(?P<table>.*?)(?P<suffix>\s*)(?P<end><!--\s*sparql:end\s*-->)",
     re.DOTALL | re.IGNORECASE,
 )
@@ -49,9 +52,12 @@ def _replace_sparql_table(match: re.Match[str], rendered_markdown: str) -> str:
     suffix = match.group("suffix")
     if not suffix:
         suffix = "\n"
+    comment_end = match.group("comment_end") or ""
+    post_comment = match.group("post_comment") or ""
     return (
         f"{match.group('start')}{match.group('prefix')}{match.group('fence')}"
-        f"{match.group('mid')}{rendered_markdown}{suffix}{match.group('end')}"
+        f"{match.group('mid')}{comment_end}{post_comment}{rendered_markdown}{suffix}"
+        f"{match.group('end')}"
     )
 
 

--- a/tests/test_fmt.py
+++ b/tests/test_fmt.py
@@ -102,6 +102,25 @@ class TestWikiFmt(unittest.TestCase):
             self.assertNotIn("| Class |", formatted)
             self.assertIn("```sparql", formatted)
 
+    def test_fmt_preserves_hidden_sparql_render_blocks(self) -> None:
+        compact_table = "| class |\n| --- |\n| owl:Class |\n"
+        original = (
+            "<!-- sparql:start\n"
+            "```sparql\nSELECT ?class WHERE { ?class a owl:Class }\n```\n"
+            "-->\n"
+            f"{compact_table}"
+            "<!-- sparql:end -->\n"
+        )
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "Query.md"
+            file_path.write_text(original, encoding="utf-8")
+            formatted = format_markdown(original, file_path, Config(config_root=Path(tmpdir)))
+            self.assertIn("| class |", formatted)
+            self.assertNotIn("| Class |", formatted)
+            self.assertIn("<!-- sparql:start\n", formatted)
+            self.assertIn("```sparql", formatted)
+            self.assertIn("-->\n", formatted)
+
     def test_read_view_type_label_badge(self) -> None:
         seed_template = jinja("<html><body>{page.type_label}<article id=\"article-top\">{page.content}</article></body></html>")
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -61,6 +61,50 @@ SELECT ?givenName WHERE {
             _, _, stale = render_markdown_files(config, graph, dry_run=True, explicit_files=(page,))
             self.assertEqual(stale, [])
 
+    def test_render_hidden_query_preserves_comment_structure(self) -> None:
+        """Hidden-query blocks update the table but keep the query inside HTML comments."""
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir)
+            page = wiki_dir / "hidden.md"
+            page.write_text(
+                """---
+type: Person
+givenName: Bob
+familyName: Jones
+---
+<!-- sparql:start
+```sparql
+SELECT ?givenName WHERE {
+  ?s <https://schema.org/givenName> ?givenName .
+  FILTER(STRSTARTS(STR(?s), "https://wiki.example.org/"))
+}
+```
+-->
+
+<!-- sparql:end -->
+""",
+                encoding="utf-8",
+            )
+            config = Config(
+                wiki={"inputs": [wiki_dir]},
+                config_root=wiki_dir,
+                graph={"context": {"wiki": "https://wiki.example.org/"}},
+            )
+            graph = load_graph(config, infer=False)
+
+            render_markdown_files(config, graph, explicit_files=(page,))
+            rendered = page.read_text(encoding="utf-8")
+
+            self.assertIn("<!-- sparql:start\n", rendered)
+            self.assertIn("```sparql\n", rendered)
+            self.assertIn("-->\n\n", rendered)
+            self.assertIn("  ?s <https://schema.org/givenName> ?givenName .", rendered)
+            self.assertRegex(rendered, r"\| givenName\s+\|")
+            self.assertIn("Bob", rendered)
+
+            _, _, stale = render_markdown_files(config, graph, dry_run=True, explicit_files=(page,))
+            self.assertEqual(stale, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -299,6 +299,34 @@ name: Project Atlas
         self.assertIn("&lt;tag&gt;", html)
         self.assertNotIn('class="highlight"', html)
 
+    def test_render_hidden_sparql_block_omits_query_from_html(self) -> None:
+        markdown = (
+            "<!-- sparql:start\n"
+            "```sparql\nSELECT ?name WHERE { ?person foaf:name ?name }\n```\n"
+            "-->\n\n"
+            "| name |\n| --- |\n| Alice |\n\n"
+            "<!-- sparql:end -->\n"
+        )
+        html = render_wiki_markdown(markdown)
+
+        self.assertIn("Alice", html)
+        self.assertIn("<table>", html)
+        self.assertNotIn("language-sparql", html)
+        self.assertNotIn('class="highlight"', html)
+        self.assertNotIn("<pre data-copy=", html)
+
+    def test_render_visible_sparql_block_shows_query_in_html(self) -> None:
+        markdown = (
+            "<!-- sparql:start -->\n"
+            "```sparql\nSELECT ?name WHERE { ?person foaf:name ?name }\n```\n\n"
+            "| name |\n| --- |\n| Alice |\n\n"
+            "<!-- sparql:end -->\n"
+        )
+        html = render_wiki_markdown(markdown)
+
+        self.assertIn("language-sparql", html)
+        self.assertIn("SELECT ?name", html)
+
     def test_render_copyable_pre_escapes_attribute_text(self) -> None:
         html = render_copyable_pre('line "one"\nline two', "&lt;tag&gt;")
 


### PR DESCRIPTION
## Summary
- Add optional hidden-query syntax for inline SPARQL render blocks: leave `<!-- sparql:start` open and close the HTML comment after the fenced query so built pages show only the results table while `wiki render` still executes the query.
- Extend `SPARQL_BLOCK_REGEX` and `SPARQL_REGION_RE`; preserve authored visible vs hidden style when rewriting tables.
- Dogfood hidden blocks on Style Guide and Wiki CLI command reference; keep `SPARQL.md` visible so the SPARQL doc page still shows the example query.

Closes #73

## Test plan
- [x] `wiki -c docs/wiki.yaml fmt --check`
- [x] `wiki -c docs/wiki.yaml lint --strict`
- [x] `wiki -c docs/wiki.yaml check --strict`
- [x] `wiki -c docs/wiki.yaml render --check`
- [x] `uv run python -m unittest discover -s tests` (452 tests)
- [x] Manual `wiki serve` — hidden blocks omit `language-sparql` in HTML; `SPARQL.md` still shows query fence
