### PR TITLE
Ship assets/logo.svg in wiki init scaffold

### DIFF
--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 200 200" width="80" height="80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="globeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="gridGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#93c5fd" stop-opacity="0.3" />
+    </linearGradient>
+  </defs>
+  <circle cx="100" cy="100" r="80" fill="url(#globeGrad)" />
+  <path d="M 100 20 Q 50 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="3" />
+  <path d="M 100 20 Q 150 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="3" />
+  <path d="M 100 20 Q 10 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" stroke-dasharray="3,3" />
+  <path d="M 100 20 Q 190 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" stroke-dasharray="3,3" />
+  <line x1="100" y1="20" x2="100" y2="180" stroke="url(#gridGrad)" stroke-width="2" />
+  <line x1="20" y1="100" x2="180" y2="100" stroke="url(#gridGrad)" stroke-width="2.5" />
+  <path d="M 30 70 Q 100 90 170 70" fill="none" stroke="url(#gridGrad)" stroke-width="2" />
+  <path d="M 30 130 Q 100 110 170 130" fill="none" stroke="url(#gridGrad)" stroke-width="2" />
+  <path d="M 45 45 Q 100 65 155 45" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" />
+  <path d="M 45 155 Q 100 135 155 155" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" />
+  <text x="100" y="112" font-family="'Inter', sans-serif" font-size="36" font-weight="900" fill="#ffffff" text-anchor="middle" style="letter-spacing: -2px;">W</text>
+</svg>

--- a/docs/layouts/default.html.j2
+++ b/docs/layouts/default.html.j2
@@ -15,7 +15,7 @@
 <aside id="mw-navigation">
   <div id="p-logo" role="banner">
     <a href="{{ site.base_url }}/" title="Visit the main page">
-      {{ site.logo_svg }}
+      <img src="{{ site.base_url }}/assets/logo.svg" alt="" width="80" height="80">
       <span class="logo-text">{{ site.manifest.short_name or site.manifest.name }}</span>
     </a>
   </div>

--- a/docs/wiki.yaml
+++ b/docs/wiki.yaml
@@ -5,8 +5,8 @@ wiki:
   inputs:
     - wiki
   # Static files for custom CSS, logos, favicons (copied on wiki build).
-  # assets:
-  #   - assets
+  assets:
+    - assets
   # Full-filename regex for markdown files (lint.filename_pattern severity).
   filename_pattern: "[A-Za-z0-9_()-]+\\.md"
   # Glob patterns skipped when indexing (POSIX paths relative to config root).

--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -33,7 +33,7 @@ wiki init --repo wazootech/wiki
 wiki init --git
 ```
 
-`wiki init` writes `wiki.yaml`, `README.md`, `layouts/`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. See [Wiki Subcommand init](Wiki_Subcommand_init.md) for all flags and `--force` behavior.
+`wiki init` writes `wiki.yaml`, `README.md`, `layouts/`, `assets/logo.svg`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). The scaffold enables `wiki.assets` and wires the default layout to the logo file. Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. See [Wiki Subcommand init](Wiki_Subcommand_init.md) for all flags and `--force` behavior.
 
 ## Daily workflow
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -271,19 +271,19 @@ The bundled stylesheet injected as `{{ site.inline_css }}` covers the default Wi
 
 ### Custom logos and icons
 
-The default layout uses `{{ site.logo_svg }}` inside `#p-logo`. When you do not customize the layout, Wiki CLI injects a built-in globe SVG: the center glyph is the first character of resolved `site.manifest.name`, and the gradient comes from `site.manifest.theme_color` (fallback `#3b82f6`). There is no `site.logo` or `site.favicon` yaml key — customize branding through `wiki.assets` and `site.layout`, the same pattern as [Custom CSS](#custom-css).
+Fresh `wiki init` workspaces ship `assets/logo.svg`, enable `wiki.assets`, and reference the file from the copied default layout (`<img src="{{ site.base_url }}/assets/logo.svg" …>`). Replace that SVG or switch back to `{{ site.logo_svg }}` for a theme-color-aware built-in globe (center glyph from `site.manifest.name`; gradient from `site.manifest.theme_color`, fallback `#3b82f6`). There is no `site.logo` or `site.favicon` yaml key — customize branding through `wiki.assets` and `site.layout`, the same pattern as [Custom CSS](#custom-css).
 
 **Custom sidebar logo**
 
-1. Enable `wiki.assets` (uncomment or add an `assets:` directory in `wiki.yaml`).
+1. Enable `wiki.assets` (already enabled in the init scaffold, or add an `assets:` directory in `wiki.yaml`).
 1. Place a file under assets, for example `assets/logo.svg` or `assets/logo.png`.
-1. Edit `site.layout` and replace `{{ site.logo_svg }}` with an asset reference:
+1. Edit `site.layout` and reference the asset (init already uses this pattern):
 
 ```html
 <img src="{{ site.base_url }}/assets/logo.svg" alt="" width="80" height="80">
 ```
 
-You can also embed inline SVG directly in the layout file (no asset copy).
+You can also embed inline SVG directly in the layout file (no asset copy), or use `{{ site.logo_svg }}` instead of an asset file.
 
 **Favicons and touch icons**
 

--- a/docs/wiki/Wiki_Page_Layouts.md
+++ b/docs/wiki/Wiki_Page_Layouts.md
@@ -20,7 +20,7 @@ site:
   layout: layouts/default.html.j2
 ```
 
-`wiki init` copies `layouts/default.html.j2` from the packaged default layout. To customize CSS, edit the layout HTML or link stylesheets from `wiki.assets`; see [Wiki Configuration](Wiki_Configuration.md#custom-css).
+`wiki init` copies `layouts/default.html.j2` from the packaged default layout. The sidebar logo uses `assets/logo.svg` via `wiki.assets`. To customize CSS, edit the layout HTML or link stylesheets from `wiki.assets`; see [Wiki Configuration](Wiki_Configuration.md#custom-css).
 
 ## `wazoo:layout`
 

--- a/docs/wiki/Wiki_Subcommand_init.md
+++ b/docs/wiki/Wiki_Subcommand_init.md
@@ -65,6 +65,7 @@ Always includes `schema`, `wiki`, `wazoo`, `foaf`, `dc`, `dcterms`, `sh`, and `x
 New workspaces receive a plain `wiki.yaml`. The packaged scaffold that `wiki init` renders from is [`src/wiki/templates/wiki.yaml.j2`](https://github.com/wazootech/wiki/blob/main/src/wiki/templates/wiki.yaml.j2) (Jinja2). Contributors edit that `.j2` file; Jinja variables (such as `graph_context_wiki`, `site_base_url`, `site_url_style`, `graph_content_predicate`, `link_style`, and other parameters mapped from Click CLI flags) render into nested `graph:`, `site:`, and `link:` blocks via `{% if %}`.
 
 - `wiki.inputs: [wiki]`
+- `wiki.assets: [assets]` — static files (logo, CSS, favicons) copied on build/serve
 - `graph.context.wiki` — default namespace for `wiki:` CURIEs and auto-generated document IRIs
 - Commented `graph.implicit_types` / `graph.implicit_types_policy` examples (uncomment to apply wiki-wide default `rdf:type` CURIEs)
 - Commented `graph.base_iri` example (uncomment only when document IRIs must differ from `context.wiki`)
@@ -77,7 +78,8 @@ Init does **not** write `.mdformat.toml`. To use a separate TOML file instead, s
 
 ## Generated files
 
-- `layouts/default.html.j2` — copied from packaged [`layout_default.html.j2`](https://github.com/wazootech/wiki/blob/main/src/wiki/templates/layout_default.html.j2); search, tabs, backlinks, and TOC. Edit to customize the look and feel.
+- `layouts/default.html.j2` — copied from packaged [`layout_default.html.j2`](https://github.com/wazootech/wiki/blob/main/src/wiki/templates/layout_default.html.j2); search, tabs, backlinks, and TOC. Sidebar logo references `assets/logo.svg`. Edit to customize the look and feel.
+- `assets/logo.svg` — starter sidebar logo (served at `{{ site.base_url }}/assets/logo.svg`)
 - `README.md` — starter workspace overview and common commands
 - `wiki/Person_Shape.md` — starter `sh:NodeShape` for `schema:Person`
 - `wiki/Ethan_Davidson.md` — starter `schema:Person` example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ wikilink = "wiki.mdformat_wikilink"
 [tool.setuptools]
 package-dir = {"" = "src"}
 packages = {find = {where = ["src"], include = ["wiki*"]}}
-package-data = {"wiki" = ["templates/*", "templates/schemas/*"]}
+package-data = {"wiki" = ["templates/*", "templates/schemas/*", "templates/assets/*"]}
 
 [dependency-groups]
 standalone = ["pyinstaller>=6.0"]

--- a/skills/wiki-create/SKILL.md
+++ b/skills/wiki-create/SKILL.md
@@ -67,7 +67,7 @@ When context already supplies values, **do not re-prompt**:
 
 ### Phase A — Init
 
-1. **Directory** — Confirm workspace root. `wiki init` writes to the **current directory** (`wiki.yaml`, `README.md`, `wiki/`, `layouts/`).
+1. **Directory** — Confirm workspace root. `wiki init` writes to the **current directory** (`wiki.yaml`, `README.md`, `wiki/`, `layouts/`, `assets/logo.svg`).
 2. **Init options** — Run `wiki init --help` (same resolved `wiki` command as above) and map the user’s answers to flags from the output. Prefer flags over bare `wiki init` — stdin prompts block agents.
 
 **Optional preferences (one turn):** If not already inferred, ask link style (markdown vs Obsidian) and whether they want a custom site display name (`--site-manifest-name`). Only ask about theme color, inputs directory, or other flags when the user wants to customize.
@@ -134,6 +134,7 @@ Gather **before init** when it affects flags (`--repo`, `--link-style`). **After
 
 - `wiki.yaml` — wiki, graph, site, lint, fmt defaults
 - `layouts/default.html.j2`
+- `assets/logo.svg`
 - `wiki/Person_Shape.md`, `wiki/Ethan_Davidson.md`
 - `README.md`
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -671,6 +671,7 @@ def init(
 
     from .init_scaffold import (
         copy_default_layout,
+        copy_default_logo,
         render_wiki_yaml,
         resolve_init_options,
     )
@@ -728,6 +729,7 @@ def init(
         "A semantic markdown knowledge base powered by the Wiki CLI.\n\n"
         "## Workspace Layout\n\n"
         "- `wiki.yaml` — Workspace configuration, namespace prefixes, and `fmt` defaults.\n"
+        "- `assets/logo.svg` — Sidebar logo (served via `wiki.assets`).\n"
         "- `wiki/` — Contains markdown files with semantic frontmatter.\n"
         "  - `Person_Shape.md` — SHACL shape for Person documents.\n"
         "  - `Ethan_Davidson.md` — An example Person document.\n\n"
@@ -786,6 +788,10 @@ def init(
     if force or not default_layout_path.exists():
         copy_default_layout(default_layout_path)
 
+    logo_path = cwd / "assets" / "logo.svg"
+    if force or not logo_path.exists():
+        copy_default_logo(logo_path)
+
     if init_git:
         if shutil.which("git") is None:
             click.echo("Error: git was requested with --git, but no git executable was found on PATH.", err=True)
@@ -797,7 +803,7 @@ def init(
             click.echo(f"Error: git init failed: {stderr}", err=True)
             sys.exit(1)
 
-    message = "Initialized wiki.yaml, README.md, wiki/ starter files, and layouts/default.html.j2."
+    message = "Initialized wiki.yaml, README.md, wiki/ starter files, assets/logo.svg, and layouts/default.html.j2."
     if init_git:
         message += " Ran git init."
     click.echo(message)

--- a/src/wiki/init_scaffold.py
+++ b/src/wiki/init_scaffold.py
@@ -18,7 +18,9 @@ __all__ = [
     "DOCS_WIKI_INIT_OPTIONS",
     "InitOptions",
     "copy_default_layout",
+    "copy_default_logo",
     "load_packaged_default_layout",
+    "load_packaged_default_logo",
     "render_wiki_yaml",
     "resolve_init_options",
 ]
@@ -164,6 +166,7 @@ def resolve_init_options(
 
 _INIT_TEMPLATE_NAME = "wiki.yaml.j2"
 _DEFAULT_LAYOUT_TEMPLATE = "layout_default.html.j2"
+_DEFAULT_LOGO_TEMPLATE = "assets/logo.svg"
 _JINJA_COMMENT_PREFIX = "{# wiki init scaffold"
 
 
@@ -201,3 +204,14 @@ def copy_default_layout(dest: Path) -> None:
     """Copy the packaged default page layout into a workspace."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(load_packaged_default_layout(), encoding="utf-8")
+
+
+def load_packaged_default_logo() -> str:
+    """Return the packaged default sidebar logo SVG content."""
+    return files("wiki").joinpath(f"templates/{_DEFAULT_LOGO_TEMPLATE}").read_text(encoding="utf-8")
+
+
+def copy_default_logo(dest: Path) -> None:
+    """Copy the packaged default sidebar logo into a workspace."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(load_packaged_default_logo(), encoding="utf-8")

--- a/src/wiki/templates/assets/logo.svg
+++ b/src/wiki/templates/assets/logo.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 200 200" width="80" height="80" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="globeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="gridGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#93c5fd" stop-opacity="0.3" />
+    </linearGradient>
+  </defs>
+  <circle cx="100" cy="100" r="80" fill="url(#globeGrad)" />
+  <path d="M 100 20 Q 50 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="3" />
+  <path d="M 100 20 Q 150 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="3" />
+  <path d="M 100 20 Q 10 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" stroke-dasharray="3,3" />
+  <path d="M 100 20 Q 190 100 100 180" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" stroke-dasharray="3,3" />
+  <line x1="100" y1="20" x2="100" y2="180" stroke="url(#gridGrad)" stroke-width="2" />
+  <line x1="20" y1="100" x2="180" y2="100" stroke="url(#gridGrad)" stroke-width="2.5" />
+  <path d="M 30 70 Q 100 90 170 70" fill="none" stroke="url(#gridGrad)" stroke-width="2" />
+  <path d="M 30 130 Q 100 110 170 130" fill="none" stroke="url(#gridGrad)" stroke-width="2" />
+  <path d="M 45 45 Q 100 65 155 45" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" />
+  <path d="M 45 155 Q 100 135 155 155" fill="none" stroke="url(#gridGrad)" stroke-width="1.5" />
+  <text x="100" y="112" font-family="'Inter', sans-serif" font-size="36" font-weight="900" fill="#ffffff" text-anchor="middle" style="letter-spacing: -2px;">W</text>
+</svg>

--- a/src/wiki/templates/layout_default.html.j2
+++ b/src/wiki/templates/layout_default.html.j2
@@ -15,7 +15,7 @@
 <aside id="mw-navigation">
   <div id="p-logo" role="banner">
     <a href="{{ site.base_url }}/" title="Visit the main page">
-      {{ site.logo_svg }}
+      <img src="{{ site.base_url }}/assets/logo.svg" alt="" width="80" height="80">
       <span class="logo-text">{{ site.manifest.short_name or site.manifest.name }}</span>
     </a>
   </div>

--- a/src/wiki/templates/wiki.yaml.j2
+++ b/src/wiki/templates/wiki.yaml.j2
@@ -12,8 +12,8 @@ wiki:
     - wiki
 {% endif %}
   # Static files for custom CSS, logos, favicons (copied on wiki build).
-  # assets:
-  #   - assets
+  assets:
+    - assets
   # Full-filename regex for markdown files (lint.filename_pattern severity).
   filename_pattern: "[A-Za-z0-9_()-]+\\.md"
   # Glob patterns skipped when indexing (POSIX paths relative to config root).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from wiki.cli import FILE_COMMANDS, main
 from wiki.config import Config
-from wiki.init_scaffold import InitOptions, load_packaged_default_layout, render_wiki_yaml
+from wiki.init_scaffold import InitOptions, load_packaged_default_layout, load_packaged_default_logo, render_wiki_yaml
 
 
 class TestCLI(unittest.TestCase):
@@ -521,11 +521,21 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
                 # Check site layout is configured and seeded
                 self.assertIn("name: Wiki CLI", config_content)
                 self.assertIn("layout: layouts/default.html.j2", config_content)
+                self.assertIn("assets:", config_content)
+                self.assertIn("- assets", config_content)
                 default_layout = Path("layouts") / "default.html.j2"
                 self.assertTrue(default_layout.is_file())
                 expected_layout = load_packaged_default_layout()
                 self.assertEqual(default_layout.read_text(encoding="utf-8"), expected_layout)
+                self.assertIn("/assets/logo.svg", expected_layout)
+                self.assertNotIn("{{ site.logo_svg }}", expected_layout)
                 self.assertIn("{{ site.manifest.name }}", expected_layout)
+
+                default_logo = Path("assets") / "logo.svg"
+                self.assertTrue(default_logo.is_file())
+                expected_logo = load_packaged_default_logo()
+                self.assertEqual(default_logo.read_text(encoding="utf-8"), expected_logo)
+                self.assertIn("<svg", expected_logo)
 
                 expected_content = render_wiki_yaml(
                     InitOptions(graph_context_wiki="https://wiki.example.org/"),

--- a/tests/test_init_scaffold.py
+++ b/tests/test_init_scaffold.py
@@ -15,9 +15,11 @@ from wiki.schemas.wiki_config import normalize_base_iri
 from wiki.init_scaffold import (
     InitOptions,
     copy_default_layout,
+    copy_default_logo,
     detect_origin_repo,
     infer_github_pages_urls,
     load_packaged_default_layout,
+    load_packaged_default_logo,
     normalize_base_url,
     parse_github_repo,
     render_wiki_yaml,
@@ -109,6 +111,8 @@ class TestRenderWikiYaml(TestCase):
         self.assertIn("missing_schema_ref: error", rendered)
         self.assertIn("wrap: \"no\"", rendered)
         self.assertIn("extensions: [gfm, frontmatter, wikilink]", rendered)
+        self.assertIn("assets:", rendered)
+        self.assertIn("- assets", rendered)
         self.assertIn("# fmt: .mdformat.toml", rendered)
         self.assertNotIn("{#", rendered)
         self.assertNotIn("__", rendered)
@@ -145,12 +149,26 @@ class TestRenderWikiYaml(TestCase):
         self.assertNotIn("{# wiki init scaffold", rendered)
         self.assertIn("<title>{{ page.title }} - {{ site.manifest.name }}</title>", rendered)
         self.assertIn('placeholder="Search {{ site.manifest.name }}"', rendered)
+        self.assertIn("/assets/logo.svg", rendered)
+        self.assertNotIn("{{ site.logo_svg }}", rendered)
+
+    def test_load_packaged_default_logo(self) -> None:
+        rendered = load_packaged_default_logo()
+        self.assertIn("<svg", rendered)
+        self.assertIn('viewBox="0 0 200 200"', rendered)
+        self.assertIn(">W</text>", rendered)
 
     def test_copy_default_layout(self) -> None:
         with TemporaryDirectory() as tmpdir:
             dest = Path(tmpdir) / "layouts" / "default.html.j2"
             copy_default_layout(dest)
             self.assertEqual(dest.read_text(encoding="utf-8"), load_packaged_default_layout())
+
+    def test_copy_default_logo(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir) / "assets" / "logo.svg"
+            copy_default_logo(dest)
+            self.assertEqual(dest.read_text(encoding="utf-8"), load_packaged_default_logo())
 
 
 class TestResolveInitOptions(TestCase):


### PR DESCRIPTION
## Summary
- Add packaged \ssets/logo.svg\ to \wiki init\ with \wiki.assets\ enabled in the generated \wiki.yaml\
- Update the init default layout to reference the asset logo instead of \{{ site.logo_svg }}\
- Mirror the same assets + layout wiring in the dogfood \docs/\ wiki
- Document the scaffold in wiki pages and the wiki-create skill; extend init tests

## Test plan
- [x] \unittest tests.test_cli.TestCLI.test_cli_init_scaffolds_workspace_files tests.test_init_scaffold\
- [x] \wiki -c docs/wiki.yaml check --strict\
- [x] \wiki -c docs/wiki.yaml lint --strict\
- [ ] CI green on PR