### PR TITLE
Consolidate ecosystem template registry in Wiki_CLI docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Consolidate [Wiki CLI templates](docs/wiki/Wiki_CLI.md#ecosystem-templates) registry in Wiki_CLI: hybrid naming tiers, full shipped/planned table, SPARQL single-repo (`wiki-yasgui-template` absorbs Virtuoso scope), `wiki-{stack}-template` integration slugs, planned `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Slim README and downstream wiki pages to point at the canonical section; retire stale slugs (`sparql-service-template`, bare `nextjs-template`, `obsidian-quartz-template`, etc.).
+- Consolidate [Wiki CLI templates](docs/wiki/Wiki_CLI.md#ecosystem-templates) registry in Wiki_CLI: single shipped/planned table, SPARQL single-repo (`wiki-yasgui-template` absorbs Virtuoso scope), `wiki-{stack}-template` integration slugs, planned `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Slim README and downstream wiki pages to point at the canonical section; retire stale slugs (`sparql-service-template`, bare `nextjs-template`, `obsidian-quartz-template`, etc.).
 
 - Remove non-spec `site.manifest.logo` and layout variables `{{ site.manifest.logo }}` / `{{ site.manifest.logo_url }}`. Use W3C `site.manifest.icons` with `{{ site.manifest.icons[0].url }}` for sidebar logo and favicon links. Remove `{{ site.manifest.primary_icon_url }}` and `{{ site.manifest.json }}` from layout context. `wiki init` scaffolds a default `icons` entry for `assets/logo.svg` and generates that asset from `site.manifest.name` and optional `site.manifest.theme_color`. Keep `{{ site.manifest.url }}` for the manifest file link.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Consolidate ecosystem template registry in [Wiki CLI — Ecosystem templates](docs/wiki/Wiki_CLI.md#ecosystem-templates): hybrid naming tiers, full shipped/planned table, SPARQL single-repo (`wiki-yasgui-template` absorbs Virtuoso scope), `wiki-{stack}-template` integration slugs, planned `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Slim README and downstream wiki pages to point at the canonical section; retire stale slugs (`sparql-service-template`, bare `nextjs-template`, `obsidian-quartz-template`, etc.).
+
 - Remove non-spec `site.manifest.logo` and layout variables `{{ site.manifest.logo }}` / `{{ site.manifest.logo_url }}`. Use W3C `site.manifest.icons` with `{{ site.manifest.icons[0].url }}` for sidebar logo and favicon links. Remove `{{ site.manifest.primary_icon_url }}` and `{{ site.manifest.json }}` from layout context. `wiki init` scaffolds a default `icons` entry for `assets/logo.svg` and generates that asset from `site.manifest.name` and optional `site.manifest.theme_color`. Keep `{{ site.manifest.url }}` for the manifest file link.
 
 ### Migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Consolidate ecosystem template registry in [Wiki CLI — Ecosystem templates](docs/wiki/Wiki_CLI.md#ecosystem-templates): hybrid naming tiers, full shipped/planned table, SPARQL single-repo (`wiki-yasgui-template` absorbs Virtuoso scope), `wiki-{stack}-template` integration slugs, planned `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Slim README and downstream wiki pages to point at the canonical section; retire stale slugs (`sparql-service-template`, bare `nextjs-template`, `obsidian-quartz-template`, etc.).
+- Consolidate [Wiki CLI templates](docs/wiki/Wiki_CLI.md#ecosystem-templates) registry in Wiki_CLI: hybrid naming tiers, full shipped/planned table, SPARQL single-repo (`wiki-yasgui-template` absorbs Virtuoso scope), `wiki-{stack}-template` integration slugs, planned `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Slim README and downstream wiki pages to point at the canonical section; retire stale slugs (`sparql-service-template`, bare `nextjs-template`, `obsidian-quartz-template`, etc.).
 
 - Remove non-spec `site.manifest.logo` and layout variables `{{ site.manifest.logo }}` / `{{ site.manifest.logo_url }}`. Use W3C `site.manifest.icons` with `{{ site.manifest.icons[0].url }}` for sidebar logo and favicon links. Remove `{{ site.manifest.primary_icon_url }}` and `{{ site.manifest.json }}` from layout context. `wiki init` scaffolds a default `icons` entry for `assets/logo.svg` and generates that asset from `site.manifest.name` and optional `site.manifest.theme_color`. Keep `{{ site.manifest.url }}` for the manifest file link.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Repository: [github.com/wazootech/wiki](https://github.com/wazootech/wiki). CLI command: `wiki`. Install via [pip](https://pypi.org/project/wazootech-wiki/) or [npm](https://www.npmjs.com/package/wazootech-wiki).
 
-Starter template: [github.com/wazootech/wiki-template](https://github.com/wazootech/wiki-template) (GitHub **Use this template**).
+Starter template: [wiki-template](https://github.com/wazootech/wiki-template) (generic workspace). Full registry: [Wiki CLI — Ecosystem templates](docs/wiki/Wiki_CLI.md#ecosystem-templates).
 
 
 ## Use cases and integrations
@@ -44,13 +44,7 @@ Also: [`init`](#init) scaffolds `wiki.yaml`; `wiki query --pretty` renders Rich 
 
 ## Ecosystem templates
 
-| Template | Purpose |
-|----------|---------|
-| [wiki-template](https://github.com/wazootech/wiki-template) | Starter wiki — use GitHub **Use this template** |
-| [sparql-service-template](https://github.com/wazootech/sparql-service-template) ([Pages demo](https://wazootech.github.io/sparql-service-template/)) | YASGUI demo against exported Turtle or a live `wiki serve` endpoint |
-| [nextjs-template](https://github.com/wazootech/nextjs-template) | OAuth 2.0-protected, Next.js wiki viewer ([#15](https://github.com/wazootech/wiki/issues/15)) |
-| [obsidian-quartz-template](https://github.com/wazootech/obsidian-quartz-template) | Obsidian PKM viewer ([#16](https://github.com/wazootech/wiki/issues/16)) |
-| [wiki-mintlify-template](https://github.com/wazootech/wiki-mintlify-template) | Mintlify/Holocron viewer ([#31](https://github.com/wazootech/wiki/issues/31)) |
+Shipped and planned GitHub template repos (starters, SPARQL query UI, publish integrations) are listed in [Wiki CLI — Ecosystem templates](docs/wiki/Wiki_CLI.md#ecosystem-templates). Quick links: [wiki-template](https://github.com/wazootech/wiki-template), [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) ([Pages demo](https://wazootech.github.io/wiki-yasgui-template/)).
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Repository: [github.com/wazootech/wiki](https://github.com/wazootech/wiki). CLI command: `wiki`. Install via [pip](https://pypi.org/project/wazootech-wiki/) or [npm](https://www.npmjs.com/package/wazootech-wiki).
 
-Starter template: [wiki-template](https://github.com/wazootech/wiki-template) (generic workspace). Full registry: [Wiki CLI — Ecosystem templates](docs/wiki/Wiki_CLI.md#ecosystem-templates).
+Starter template: [wiki-template](https://github.com/wazootech/wiki-template) (generic workspace). See [Wiki CLI templates](docs/wiki/Wiki_CLI.md#ecosystem-templates).
 
 
 ## Use cases and integrations
@@ -44,7 +44,7 @@ Also: [`init`](#init) scaffolds `wiki.yaml`; `wiki query --pretty` renders Rich 
 
 ## Ecosystem templates
 
-Shipped and planned GitHub template repos (starters, SPARQL query UI, publish integrations) are listed in [Wiki CLI — Ecosystem templates](docs/wiki/Wiki_CLI.md#ecosystem-templates). Quick links: [wiki-template](https://github.com/wazootech/wiki-template), [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) ([Pages demo](https://wazootech.github.io/wiki-yasgui-template/)).
+Shipped and planned GitHub template repos (starters, SPARQL query UI, publish integrations) are listed in [Wiki CLI templates](docs/wiki/Wiki_CLI.md#ecosystem-templates). Quick links: [wiki-template](https://github.com/wazootech/wiki-template), [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) ([Pages demo](https://wazootech.github.io/wiki-yasgui-template/)).
 
 
 ## Installation

--- a/docs/wiki/Design_Philosophies.md
+++ b/docs/wiki/Design_Philosophies.md
@@ -59,7 +59,7 @@ Subcommands are top-level (`wiki check`, not `wiki wiki check`). Global options 
 
 ## Userland over platform lock-in
 
-Printing, PDF, and heavy formatting stay in your shell (`pr`, `lp`, Pandoc, etc.). The wiki tool focuses on graph construction, validation, and site generation. [Ecosystem template repos](Wiki_CLI.md#ecosystem-templates) and editor integrations stay at the edges; core scope is the semantic layer — see [Wiki CLI](Wiki_CLI.md#toolchain-vs-authoring-surface).
+Printing, PDF, and heavy formatting stay in your shell (`pr`, `lp`, Pandoc, etc.). The wiki tool focuses on graph construction, validation, and site generation. [Wiki CLI templates](Wiki_CLI.md#ecosystem-templates) and editor integrations stay at the edges; core scope is the semantic layer — see [Wiki CLI](Wiki_CLI.md#toolchain-vs-authoring-surface).
 
 ## Related
 

--- a/docs/wiki/Design_Philosophies.md
+++ b/docs/wiki/Design_Philosophies.md
@@ -59,7 +59,7 @@ Subcommands are top-level (`wiki check`, not `wiki wiki check`). Global options 
 
 ## Userland over platform lock-in
 
-Printing, PDF, and heavy formatting stay in your shell (`pr`, `lp`, Pandoc, etc.). The wiki tool focuses on graph construction, validation, and site generation. Template repos and editor integrations stay at the edges; core scope is the semantic layer — see [Wiki CLI](Wiki_CLI.md#toolchain-vs-authoring-surface).
+Printing, PDF, and heavy formatting stay in your shell (`pr`, `lp`, Pandoc, etc.). The wiki tool focuses on graph construction, validation, and site generation. [Ecosystem template repos](Wiki_CLI.md#ecosystem-templates) and editor integrations stay at the edges; core scope is the semantic layer — see [Wiki CLI](Wiki_CLI.md#toolchain-vs-authoring-surface).
 
 ## Related
 

--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -35,6 +35,8 @@ wiki init --git
 
 `wiki init` writes `wiki.yaml`, `README.md`, `layouts/`, `assets/logo.svg`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). The scaffold enables `wiki.assets` and wires the default layout to the logo file. Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. See [Wiki Subcommand init](Wiki_Subcommand_init.md) for all flags and `--force` behavior.
 
+Alternatively, start from a GitHub template: [wiki-template](https://github.com/wazootech/wiki-template) (generic workspace) or the planned [LLM Wiki](LLM_Wiki.md) starter `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83)). Full registry: [Wiki CLI — Ecosystem templates](Wiki_CLI.md#ecosystem-templates).
+
 ## Daily workflow
 
 ```bash

--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -35,7 +35,7 @@ wiki init --git
 
 `wiki init` writes `wiki.yaml`, `README.md`, `layouts/`, `assets/logo.svg`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). The scaffold enables `wiki.assets` and wires the default layout to the logo file. Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. See [Wiki Subcommand init](Wiki_Subcommand_init.md) for all flags and `--force` behavior.
 
-Alternatively, start from a GitHub template: [wiki-template](https://github.com/wazootech/wiki-template) (generic workspace) or the planned [LLM Wiki](LLM_Wiki.md) starter `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83)). Full registry: [Wiki CLI — Ecosystem templates](Wiki_CLI.md#ecosystem-templates).
+Alternatively, start from a GitHub template: [wiki-template](https://github.com/wazootech/wiki-template) (generic workspace) or the planned [LLM Wiki](LLM_Wiki.md) starter `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83)). See [Wiki CLI templates](Wiki_CLI.md#ecosystem-templates).
 
 ## Daily workflow
 

--- a/docs/wiki/LLM_Wiki.md
+++ b/docs/wiki/LLM_Wiki.md
@@ -44,7 +44,7 @@ This [Wiki CLI](Wiki_CLI.md) repository is built directly on the principles of t
 
 ## Related
 
-- [Wiki CLI](Wiki_CLI.md)
+- [Wiki CLI](Wiki_CLI.md) — including [ecosystem templates](Wiki_CLI.md#ecosystem-templates) (`llm-wiki-template` planned ([#83](https://github.com/wazootech/wiki/issues/83)))
 - [Declarative Knowledge](Declarative_Knowledge.md)
 - [Procedural Knowledge](Procedural_Knowledge.md)
 - [Farzapedia](Farzapedia.md)

--- a/docs/wiki/LLM_Wiki.md
+++ b/docs/wiki/LLM_Wiki.md
@@ -44,7 +44,7 @@ This [Wiki CLI](Wiki_CLI.md) repository is built directly on the principles of t
 
 ## Related
 
-- [Wiki CLI](Wiki_CLI.md) — including [ecosystem templates](Wiki_CLI.md#ecosystem-templates) (`llm-wiki-template` planned ([#83](https://github.com/wazootech/wiki/issues/83)))
+- [Wiki CLI](Wiki_CLI.md) — including [Wiki CLI templates](Wiki_CLI.md#ecosystem-templates) (`llm-wiki-template` planned ([#83](https://github.com/wazootech/wiki/issues/83)))
 - [Declarative Knowledge](Declarative_Knowledge.md)
 - [Procedural Knowledge](Procedural_Knowledge.md)
 - [Farzapedia](Farzapedia.md)

--- a/docs/wiki/SPARQL.md
+++ b/docs/wiki/SPARQL.md
@@ -78,7 +78,7 @@ ORDER BY ?class
 - [Wiki Subcommand query](Wiki_Subcommand_query.md) — ad-hoc queries from the terminal
 - [Wiki Subcommand render](Wiki_Subcommand_render.md) — refresh inline SPARQL result tables in markdown
 - [Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint) — optional read-only HTTP endpoint on `wiki serve`
-- [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) — external YASGUI template repository ([ecosystem registry](Wiki_CLI.md#ecosystem-templates))
+- [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) — external YASGUI template repository ([Wiki CLI templates](Wiki_CLI.md#ecosystem-templates))
 - [Style Guide](Style_Guide.md) — `sparql:start` / `sparql:end` block conventions
 
 ## References

--- a/docs/wiki/SPARQL.md
+++ b/docs/wiki/SPARQL.md
@@ -78,7 +78,7 @@ ORDER BY ?class
 - [Wiki Subcommand query](Wiki_Subcommand_query.md) — ad-hoc queries from the terminal
 - [Wiki Subcommand render](Wiki_Subcommand_render.md) — refresh inline SPARQL result tables in markdown
 - [Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint) — optional read-only HTTP endpoint on `wiki serve`
-- [sparql-service-template](https://github.com/wazootech/sparql-service-template) — external YASGUI template repository
+- [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) — external YASGUI template repository ([ecosystem registry](Wiki_CLI.md#ecosystem-templates))
 - [Style Guide](Style_Guide.md) — `sparql:start` / `sparql:end` block conventions
 
 ## References

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -88,13 +88,63 @@ Design rationale for silence, pipes, and flat subcommands: [Design philosophies]
 
 ## Ecosystem templates
 
-| Template                                                                          | Purpose                                                                                       |
-| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [wiki-template](https://github.com/wazootech/wiki-template)                       | Starter wiki                                                                                  |
-| [sparql-service-template](https://github.com/wazootech/sparql-service-template)   | YASGUI + sample wiki or live endpoint for exploring wiki RDF                                  |
-| [nextjs-template](https://github.com/wazootech/nextjs-template)                   | OAuth 2.0-protected, Next.js wiki viewer ([#15](https://github.com/wazootech/wiki/issues/15)) |
-| [obsidian-quartz-template](https://github.com/wazootech/obsidian-quartz-template) | Obsidian PKM viewer ([#16](https://github.com/wazootech/wiki/issues/16))                      |
-| [wiki-mintlify-template](https://github.com/wazootech/wiki-mintlify-template)     | Mintlify/Holocron viewer ([#31](https://github.com/wazootech/wiki/issues/31))                 |
+GitHub **template repositories** in the [wazootech](https://github.com/wazootech) org sit at the edges of the toolchain — publish surfaces, query UIs, and starter vaults — while Wiki CLI owns the semantic layer ([Design philosophies](Design_Philosophies.md)). This section is the canonical registry.
+
+### Naming convention
+
+| Tier               | When                                                         | Slug shape                                     | Examples                                                                                        |
+| ------------------ | ------------------------------------------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Privileged starter | The one generic Wiki CLI workspace                           | `wiki-template`                                | [wiki-template](https://github.com/wazootech/wiki-template)                                     |
+| Pattern starter    | Repo implements a named pattern that already contains “wiki” | `{pattern}-template` (no extra `wiki-` prefix) | `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83))                        |
+| Integration        | Third-party stack plus Wiki CLI artifact contract            | `wiki-{stack}-template`                        | `wiki-nextjs-template`, `wiki-quartz-template`, `wiki-mintlify-template`, `wiki-astro-template` |
+| Legacy shipped     | Already published under an older convention                  | keep until optional rename                     | [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template)                       |
+
+All templates use kebab-case, end with `-template`, and never use `wiki-cli` in slugs. Link to the **repo** when it exists; link to the **tracking issue** when it does not. Do not rely on slug prefix alone — use this registry.
+
+### Registry
+
+| Slug                                                                      | Status  | Purpose                                                                                            | Tracking                                                                                               |
+| ------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [wiki-template](https://github.com/wazootech/wiki-template)               | Shipped | Minimal generic Wiki CLI workspace (`wiki init` parity plus deploy)                                | —                                                                                                      |
+| `llm-wiki-template`                                                       | Planned | [LLM Wiki](LLM_Wiki.md) pattern vault — shapes, agent DX, gardening                                | [#83](https://github.com/wazootech/wiki/issues/83)                                                     |
+| [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) | Shipped | SPARQL query editor UI (YASGUI); `wiki serve` `/api/sparql`, export TTL, optional Virtuoso backend | [#14](https://github.com/wazootech/wiki/issues/14), [#81](https://github.com/wazootech/wiki/issues/81) |
+| `wiki-nextjs-template`                                                    | Planned | Next.js SSG consumer of `wiki export`                                                              | [#15](https://github.com/wazootech/wiki/issues/15)                                                     |
+| `wiki-quartz-template`                                                    | Planned | Quartz static site from a compatible vault plus `wiki check` CI                                    | [#16](https://github.com/wazootech/wiki/issues/16)                                                     |
+| `wiki-mintlify-template`                                                  | Planned | Mintlify or Holocron docs site from a compatible vault                                             | [#31](https://github.com/wazootech/wiki/issues/31)                                                     |
+| `wiki-astro-template`                                                     | Planned | Astro SSG consumer of `wiki export`                                                                | [#96](https://github.com/wazootech/wiki/issues/96)                                                     |
+
+### Starter vaults
+
+- **[wiki-template](https://github.com/wazootech/wiki-template)** — generic scaffold. Use GitHub **Use this template** or `wiki init` locally.
+- **`llm-wiki-template`** (planned) — opinionated [LLM Wiki](LLM_Wiki.md) vault following the Karpathy pattern; distinct from the generic starter ([#83](https://github.com/wazootech/wiki/issues/83)).
+
+The shipped `wiki-template` repo description on GitHub still says “LLM Wiki starter template”; docs treat it as generic until `llm-wiki-template` ships.
+
+### SPARQL query UI
+
+One template repo — **[wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template)** — not a separate Virtuoso template ([#81](https://github.com/wazootech/wiki/issues/81) folds into this repo’s README in a later phase).
+
+| Mode               | How                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Live dev endpoint  | `wiki serve` with `sparql_service.enabled: true` — read-only `/api/sparql` ([Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint), [SPARQL](SPARQL.md)) |
+| Static export      | `wiki export` Turtle or TriG; point YASGUI at the file                                                                                                              |
+| Persistent backend | Optional Virtuoso export→load docs in the same template (planned)                                                                                                   |
+
+### Publish integrations
+
+Planned GitHub templates wire Wiki CLI output into third-party static-site or docs stacks: `wiki-nextjs-template` ([#15](https://github.com/wazootech/wiki/issues/15)), `wiki-quartz-template` ([#16](https://github.com/wazootech/wiki/issues/16)), `wiki-mintlify-template` ([#31](https://github.com/wazootech/wiki/issues/31)), `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Obsidian remains a supported authoring surface in prose; the Quartz slug does not include `obsidian`.
+
+### Artifact contract
+
+External templates consume Wiki CLI outputs — they do not replace the compiler:
+
+- **`wiki.yaml`** — config root; `wiki.inputs`, `graph.*`, `site.*`
+- **`wiki export`** — JSON-LD, Turtle, TriG, and other RDF serializations
+- **`wiki build`** — static HTML under `site.base_url`
+
+### Retired slugs
+
+Do not use these in new prose: `sparql-service-template` (→ `wiki-yasgui-template`); `wiki-virtuoso-template` (→ folded into `wiki-yasgui-template`); `wiki-obsidian-quartz-template`, `obsidian-quartz-template` (→ `wiki-quartz-template`); bare `nextjs-template`, `mintlify-template`, `astro-template` (→ `wiki-*` counterparts).
 
 ## Features
 
@@ -223,7 +273,7 @@ For **frontmatter-only validation** without the full semantic toolchain, see [Br
 ## Repository
 
 - Source and issues: [github.com/wazootech/wiki](https://github.com/wazootech/wiki)
-- Starter template: [github.com/wazootech/wiki-template](https://github.com/wazootech/wiki-template)
+- Ecosystem templates: [registry above](#ecosystem-templates) — generic starter [wiki-template](https://github.com/wazootech/wiki-template); planned [LLM Wiki](LLM_Wiki.md) starter `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83))
 
 ## Background
 

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -41,7 +41,7 @@ Adoption path: `wiki init` → `wiki check` → `wiki serve`, then add `lint`, `
 - The **primary editor** or daily note-taking surface
 - A **replacement** for Obsidian, Logseq, or another wiki UI
 - A **note app clone**, CMS, or authenticated multi-user web product
-- An **auth layer** — local-first CLI and static publish; see deferred scope in [ecosystem templates](#ecosystem-templates) below
+- An **auth layer** — local-first CLI and static publish; see deferred scope in [Wiki CLI templates](#ecosystem-templates) below
 
 Humans and agents keep writing where they already write. `wiki` makes that content **trustworthy** (SHACL, JSON Schema, and conventions), **searchable** (SPARQL + OWL-RL), and **publishable** (static HTML, JSON-LD, Turtle, optional read-only SPARQL over `wiki serve`).
 
@@ -273,7 +273,7 @@ For **frontmatter-only validation** without the full semantic toolchain, see [Br
 ## Repository
 
 - Source and issues: [github.com/wazootech/wiki](https://github.com/wazootech/wiki)
-- Ecosystem templates: [registry above](#ecosystem-templates) — generic starter [wiki-template](https://github.com/wazootech/wiki-template); planned [LLM Wiki](LLM_Wiki.md) starter `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83))
+- [Wiki CLI templates](#ecosystem-templates) — generic starter [wiki-template](https://github.com/wazootech/wiki-template); planned [LLM Wiki](LLM_Wiki.md) starter `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83))
 
 ## Background
 

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -90,49 +90,15 @@ Design rationale for silence, pipes, and flat subcommands: [Design philosophies]
 
 GitHub **template repositories** in the [wazootech](https://github.com/wazootech) org sit at the edges of the toolchain — publish surfaces, query UIs, and starter vaults — while Wiki CLI owns the semantic layer ([Design philosophies](Design_Philosophies.md)). This section is the canonical registry.
 
-### Naming convention
-
-| Tier               | When                                                         | Slug shape                                     | Examples                                                                                        |
-| ------------------ | ------------------------------------------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Privileged starter | The one generic Wiki CLI workspace                           | `wiki-template`                                | [wiki-template](https://github.com/wazootech/wiki-template)                                     |
-| Pattern starter    | Repo implements a named pattern that already contains “wiki” | `{pattern}-template` (no extra `wiki-` prefix) | `llm-wiki-template` ([#83](https://github.com/wazootech/wiki/issues/83))                        |
-| Integration        | Third-party stack plus Wiki CLI artifact contract            | `wiki-{stack}-template`                        | `wiki-nextjs-template`, `wiki-quartz-template`, `wiki-mintlify-template`, `wiki-astro-template` |
-| Legacy shipped     | Already published under an older convention                  | keep until optional rename                     | [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template)                       |
-
-All templates use kebab-case, end with `-template`, and never use `wiki-cli` in slugs. Link to the **repo** when it exists; link to the **tracking issue** when it does not. Do not rely on slug prefix alone — use this registry.
-
-### Registry
-
-| Slug                                                                      | Status  | Purpose                                                                                            | Tracking                                                                                               |
-| ------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| [wiki-template](https://github.com/wazootech/wiki-template)               | Shipped | Minimal generic Wiki CLI workspace (`wiki init` parity plus deploy)                                | —                                                                                                      |
-| `llm-wiki-template`                                                       | Planned | [LLM Wiki](LLM_Wiki.md) pattern vault — shapes, agent DX, gardening                                | [#83](https://github.com/wazootech/wiki/issues/83)                                                     |
-| [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) | Shipped | SPARQL query editor UI (YASGUI); `wiki serve` `/api/sparql`, export TTL, optional Virtuoso backend | [#14](https://github.com/wazootech/wiki/issues/14), [#81](https://github.com/wazootech/wiki/issues/81) |
-| `wiki-nextjs-template`                                                    | Planned | Next.js SSG consumer of `wiki export`                                                              | [#15](https://github.com/wazootech/wiki/issues/15)                                                     |
-| `wiki-quartz-template`                                                    | Planned | Quartz static site from a compatible vault plus `wiki check` CI                                    | [#16](https://github.com/wazootech/wiki/issues/16)                                                     |
-| `wiki-mintlify-template`                                                  | Planned | Mintlify or Holocron docs site from a compatible vault                                             | [#31](https://github.com/wazootech/wiki/issues/31)                                                     |
-| `wiki-astro-template`                                                     | Planned | Astro SSG consumer of `wiki export`                                                                | [#96](https://github.com/wazootech/wiki/issues/96)                                                     |
-
-### Starter vaults
-
-- **[wiki-template](https://github.com/wazootech/wiki-template)** — generic scaffold. Use GitHub **Use this template** or `wiki init` locally.
-- **`llm-wiki-template`** (planned) — opinionated [LLM Wiki](LLM_Wiki.md) vault following the Karpathy pattern; distinct from the generic starter ([#83](https://github.com/wazootech/wiki/issues/83)).
-
-The shipped `wiki-template` repo description on GitHub still says “LLM Wiki starter template”; docs treat it as generic until `llm-wiki-template` ships.
-
-### SPARQL query UI
-
-One template repo — **[wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template)** — not a separate Virtuoso template ([#81](https://github.com/wazootech/wiki/issues/81) folds into this repo’s README in a later phase).
-
-| Mode               | How                                                                                                                                                                 |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Live dev endpoint  | `wiki serve` with `sparql_service.enabled: true` — read-only `/api/sparql` ([Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint), [SPARQL](SPARQL.md)) |
-| Static export      | `wiki export` Turtle or TriG; point YASGUI at the file                                                                                                              |
-| Persistent backend | Optional Virtuoso export→load docs in the same template (planned)                                                                                                   |
-
-### Publish integrations
-
-Planned GitHub templates wire Wiki CLI output into third-party static-site or docs stacks: `wiki-nextjs-template` ([#15](https://github.com/wazootech/wiki/issues/15)), `wiki-quartz-template` ([#16](https://github.com/wazootech/wiki/issues/16)), `wiki-mintlify-template` ([#31](https://github.com/wazootech/wiki/issues/31)), `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Obsidian remains a supported authoring surface in prose; the Quartz slug does not include `obsidian`.
+| Template                                                                  | Description                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [wiki-template](https://github.com/wazootech/wiki-template)               | Generic Wiki CLI workspace (`wiki init` parity plus deploy)                                                                                                                                                         |
+| [wiki-yasgui-template](https://github.com/wazootech/wiki-yasgui-template) | SPARQL query editor UI (YASGUI); `wiki serve` `/api/sparql`, export TTL ([#14](https://github.com/wazootech/wiki/issues/14), [#81](https://github.com/wazootech/wiki/issues/81))                                    |
+| `llm-wiki-template`                                                       | Planned [LLM Wiki](LLM_Wiki.md) starter ([#83](https://github.com/wazootech/wiki/issues/83))                                                                                                                        |
+| `wiki-nextjs-template`                                                    | Planned Next.js SSG consumer of `wiki export` ([#15](https://github.com/wazootech/wiki/issues/15))                                                                                                                  |
+| `wiki-quartz-template`                                                    | Planned Quartz static site from a compatible vault plus `wiki check` CI ([#16](https://github.com/wazootech/wiki/issues/16)); Obsidian remains a supported authoring surface — the slug does not include `obsidian` |
+| `wiki-mintlify-template`                                                  | Planned Mintlify or Holocron docs site from a compatible vault ([#31](https://github.com/wazootech/wiki/issues/31))                                                                                                 |
+| `wiki-astro-template`                                                     | Planned Astro SSG consumer of `wiki export` ([#96](https://github.com/wazootech/wiki/issues/96))                                                                                                                    |
 
 ### Artifact contract
 


### PR DESCRIPTION
## Summary

- Expand [Wiki CLI — Ecosystem templates](docs/wiki/Wiki_CLI.md#ecosystem-templates) into the canonical registry: naming tiers, shipped/planned table, SPARQL single-repo guidance, artifact contract, and retired slugs.
- Slim README ecosystem section to link the registry; update Getting Started, SPARQL, LLM Wiki, and Design Philosophies cross-links.
- Document the change in CHANGELOG (closes naming drift tracked in #96).

## Test plan

- [x] `wiki -c docs/wiki.yaml fmt` on changed wiki pages
- [x] `wiki -c docs/wiki.yaml lint --strict` on changed wiki pages
- [x] `wiki -c docs/wiki.yaml check --strict` on changed wiki pages
