### PR TITLE
Guard wiki build from deleting source or unsafe output directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,14 +332,14 @@ wiki build
 # Build with explicit .html URLs instead
 wiki build --site-url-style file
 
-# Build to a custom directory with verbose output
-wiki build --output-dir docs -v
+# Build to a disposable directory with verbose output (must not overlap wiki inputs)
+wiki build --output-dir _site -v
 
 # Build for a project site under /my-wiki/
 wiki build --site-base-url /my-wiki --output-dir _site
 
-# Build with pages at root level (no prefix)
-wiki build --site-base-url '' --output-dir docs
+# Build with pages at root level (no prefix); output must be separate from source
+wiki build --site-base-url '' --output-dir _site
 
 # Automatically update all dynamic SPARQL blocks in source files before building
 wiki build --render

--- a/docs/wiki/Wiki_Subcommand_build.md
+++ b/docs/wiki/Wiki_Subcommand_build.md
@@ -57,6 +57,8 @@ If the configured template file is missing, the fallback shell is used silently.
 
 By default, convention (`wiki lint`) then integrity (`wiki check`) preflight must pass before the output directory is wiped and rebuilt. Output path collisions abort the build with errors.
 
+`--output-dir` must point at a disposable directory that does not overlap the wiki config root, input directories, asset directories, or the page layout folder. The build refuses to delete paths that would remove source or config files.
+
 ## Related
 
 - [Deploying to GitHub Pages](Deploying_to_GitHub_Pages.md)

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -406,6 +406,41 @@ def render(
         click.echo(f"Rendered SPARQL: {', '.join(parts)}.")
 
 
+def _path_is_same_or_ancestor(ancestor: Path, descendant: Path) -> bool:
+    ancestor = ancestor.resolve()
+    descendant = descendant.resolve()
+    if ancestor == descendant:
+        return True
+    try:
+        descendant.relative_to(ancestor)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_build_output_dir(page_output_dir: Path, runtime_config: Config) -> None:
+    page_output_dir = page_output_dir.resolve()
+    protected: list[tuple[str, Path]] = [
+        ("config root", runtime_config.config_root.resolve()),
+    ]
+    for input_dir in runtime_config.wiki.inputs:
+        protected.append(("wiki input", input_dir.resolve()))
+    for asset_dir in runtime_config.wiki.assets:
+        protected.append(("wiki asset", asset_dir.resolve()))
+    layout = runtime_config.page_layout
+    if layout is not None and layout.is_file():
+        protected.append(("page layout", layout.parent.resolve()))
+
+    for label, path in protected:
+        if _path_is_same_or_ancestor(page_output_dir, path):
+            click.echo(
+                f"Error: refusing to clean build output path {page_output_dir} because it "
+                f"overlaps {label} at {path}. Choose a separate output directory such as _site.",
+                err=True,
+            )
+            sys.exit(1)
+
+
 @main.command()
 @click.option("--output-dir", default="_site", show_default=True,
               type=click.Path(path_type=Path), help="Directory to write site files.")
@@ -491,6 +526,9 @@ def build(
     if collision_issues:
         _print_check_messages(collision_issues, [], verbose=True)
         sys.exit(1)
+
+    page_output_dir = page_output_dir.resolve()
+    _validate_build_output_dir(page_output_dir, runtime_config)
 
     if page_output_dir.exists():
         shutil.rmtree(page_output_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1318,6 +1318,69 @@ Hello from [[alice]].""", encoding="utf-8")
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Error", result.output)
 
+    def test_cli_build_rejects_output_overlapping_config_root(self) -> None:
+        """Build must not wipe the config root when --output-dir overlaps it."""
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir)
+            wiki_dir = config_dir / "wiki"
+            wiki_dir.mkdir()
+            page = wiki_dir / "page.md"
+            page.write_text("# Page\n", encoding="utf-8")
+            (config_dir / "wiki.yaml").write_text("wiki:\n  inputs:\n    - wiki\n", encoding="utf-8")
+
+            result = runner.invoke(main, [
+                "-c", str(config_dir),
+                "build",
+                "--output-dir", str(config_dir),
+                "--site-base-url", "",
+                "--no-check",
+            ])
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("refusing to clean build output path", result.output)
+            self.assertTrue(page.exists())
+
+    def test_cli_build_rejects_output_containing_wiki_inputs(self) -> None:
+        """Build must not wipe a parent directory that contains wiki inputs."""
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            wiki_dir = root / "wiki"
+            wiki_dir.mkdir()
+            page = wiki_dir / "page.md"
+            page.write_text("# Page\n", encoding="utf-8")
+
+            result = runner.invoke(main, [
+                "--wiki-inputs", str(wiki_dir),
+                "build",
+                "--output-dir", str(root),
+                "--site-base-url", "",
+                "--no-check",
+            ])
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("overlaps wiki input", result.output)
+            self.assertTrue(page.exists())
+
+    def test_cli_build_rejects_output_equal_to_wiki_input(self) -> None:
+        """Build must not use the wiki input directory itself as page output."""
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            wiki_dir = Path(tmpdir) / "wiki"
+            wiki_dir.mkdir()
+            page = wiki_dir / "page.md"
+            page.write_text("# Page\n", encoding="utf-8")
+
+            result = runner.invoke(main, [
+                "--wiki-inputs", str(wiki_dir),
+                "build",
+                "--output-dir", str(wiki_dir),
+                "--site-base-url", "",
+                "--no-check",
+            ])
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("overlaps wiki input", result.output)
+            self.assertTrue(page.exists())
+
     def test_global_raw_dir_flag(self) -> None:
         """Test --wiki-inputs with multiple directories: loads files from both."""
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- Add output path safety validation before `wiki build` wipes the page output directory
- Reject paths that overlap config root, wiki inputs/assets, or page layout parent
- Add regression tests and document the disposable-output requirement

Closes #88

## Test plan
- [x] `uv run python -m unittest discover -s tests`
- [ ] CI green