### PR TITLE
Replace npm installer shell strings with argv-based spawning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
       run: |
         node -e "require('./npm/python')"
         node -e "require('./npm/setup')"
+        node npm/test-setup-argv.js
 
     - name: Verify npm can pack
       run: npm pack --dry-run

--- a/npm/setup.js
+++ b/npm/setup.js
@@ -1,4 +1,4 @@
-const { execSync, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const { findPython } = require('./python');
@@ -33,16 +33,19 @@ function die(message) {
   process.exit(1);
 }
 
-function run(cmd, description) {
+function run(command, args, description) {
   console.error(`  ${description}...`);
-  try {
-    execSync(cmd, { stdio: 'inherit', timeout: 300000 });
-  } catch (err) {
-    const msg = err.status
-      ? `  ${description} exited with code ${err.status}`
-      : `  Failed to run ${description.toLowerCase()}: ${err.message}`;
-    throw new Error(msg);
+  const result = spawnSync(command, args, { stdio: 'inherit', timeout: 300000 });
+  if (result.error) {
+    throw new Error(`  Failed to run ${description.toLowerCase()}: ${result.error.message}`);
   }
+  if (result.status !== 0) {
+    throw new Error(`  ${description} exited with code ${result.status}`);
+  }
+}
+
+function pipInstallArgv(pkgSpec) {
+  return ['-m', 'pip', 'install', pkgSpec];
 }
 
 function setup() {
@@ -71,11 +74,11 @@ Then rerun: npm install -g wazootech-wiki`);
   const pythonPath = pythonInfo.path;
   const venvPython = getVenvPython();
 
-  run(`"${pythonPath}" -m venv "${VENV_DIR}"`, 'Creating Python virtual environment');
-  run(`"${venvPython}" -m pip install --upgrade pip`, 'Upgrading pip');
+  run(pythonPath, ['-m', 'venv', VENV_DIR], 'Creating Python virtual environment');
+  run(venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip'], 'Upgrading pip');
 
   const pkgSpec = process.env.WIKI_PIP_SPEC || `wazootech-wiki==${version}`;
-  run(`"${venvPython}" -m pip install ${pkgSpec}`, 'Installing wazootech-wiki');
+  run(venvPython, pipInstallArgv(pkgSpec), 'Installing wazootech-wiki');
   console.error(`wazootech-wiki ${version} Python environment ready.`);
 }
 
@@ -84,3 +87,4 @@ if (require.main === module) {
 }
 
 module.exports = setup;
+module.exports.pipInstallArgv = pipInstallArgv;

--- a/npm/test-setup-argv.js
+++ b/npm/test-setup-argv.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { pipInstallArgv } = require('./setup');
+
+const malicious = 'wazootech-wiki==1.0.0; echo pwned';
+const argv = pipInstallArgv(malicious);
+
+assert.deepStrictEqual(argv, ['-m', 'pip', 'install', malicious]);
+assert.strictEqual(argv.length, 4);
+console.log('npm/setup argv regression ok');


### PR DESCRIPTION
## Summary
- Use spawnSync with argv arrays in npm/setup.js instead of execSync shell strings
- Pass WIKI_PIP_SPEC as one pip install argument
- Add argv regression check in CI

Closes #89

## Test plan
- [x] node npm/test-setup-argv.js
- [ ] CI green