### PR TITLE
Add Python static analysis CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         enable-cache: true
 
     - name: Install Dependencies
-      run: uv sync
+      run: uv sync --group dev
+
+    - name: Run Python static analysis
+      run: uv run ruff check .
 
     - name: Run Unit Tests
       env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ Use Markdown links for all internal and external URLs.
 Before submitting commits, format the wiki and verify against the active schema and guidelines. In this repo, mirror CI:
 
 ```bash
+# 0. Python static analysis (requires dev deps)
+uv sync --group dev
+uv run ruff check .
+
 # 1. Format (apply, then verify)
 wiki -c docs/wiki.yaml fmt
 wiki -c docs/wiki.yaml fmt --check

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Use this repo's docs wiki as the main contributor sandbox.
 # Install the project in editable mode
 uv pip install -e .
 
+# Python static analysis (dev dependency group)
+uv sync --group dev
+uv run ruff check .
+
 # Run the docs wiki integrity checks from the repo root
 wiki -c docs/wiki.yaml check
 wiki -c docs/wiki.yaml lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,20 @@ packages = {find = {where = ["src"], include = ["wiki*"]}}
 package-data = {"wiki" = ["templates/*", "templates/schemas/*", "templates/assets/*"]}
 
 [dependency-groups]
+dev = [
+    "ruff>=0.9.0",
+]
 standalone = ["pyinstaller>=6.0"]
 
 [tool.uv]
 package = true
+
+[tool.ruff]
+target-version = "py312"
+src = ["src", "tests", "scripts"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = [
+    "E501",  # defer line-wrap; existing codebase exceeds 88 cols widely
+]

--- a/src/wiki/assets.py
+++ b/src/wiki/assets.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import posixpath
 from pathlib import Path, PurePosixPath
-from urllib.parse import quote, unquote, urlsplit
+from urllib.parse import quote, unquote
 
 from .config import Config
 from .links import is_external_link, split_target

--- a/src/wiki/audit.py
+++ b/src/wiki/audit.py
@@ -5,13 +5,29 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Any, Optional
-from rdflib import Graph
+from typing import Any
+
 import pyshacl
+from rdflib import Graph
 
 from .assets import build_asset_manifest
 from .config import Config
+from .document import (
+    WIKILINK_FULL_REGEX,
+    body_code_spans,
+    markdown_body,
+    span_overlaps,
+    split_frontmatter_text,
+)
+from .frontmatter_schema import check_frontmatter_schema
+from .graph import frontmatter_to_graph, load_graph
 from .headings import parse_headings
+from .layout import (
+    LAYOUT_FRONTMATTER_KEY,
+    layout_file_is_valid,
+    resolve_layout_path,
+)
+from .parser import document_data_from_path, split_document_body
 from .paths import (
     build_page_manifest,
     detect_output_collisions,
@@ -21,23 +37,8 @@ from .paths import (
     validate_filename_pattern,
     validate_route_safety,
 )
-from .parser import document_data_from_path, split_document_body
-from .graph import frontmatter_to_graph, load_graph
-from .layout import (
-    LAYOUT_FRONTMATTER_KEY,
-    layout_file_is_valid,
-    resolve_layout_path,
-)
-from .document import (
-    WIKILINK_FULL_REGEX,
-    body_code_spans,
-    markdown_body,
-    span_overlaps,
-    split_frontmatter_text,
-)
-from .frontmatter_schema import check_frontmatter_schema
-from .wiki_links import LinkIndex
 from .schemas import BrokenLink, CheckConfig, LintConfig
+from .wiki_links import LinkIndex
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ def load_shapes(data_graph: Graph) -> Graph:
     return shapes_graph
 
 
-def check_shacl_file(file_path: Path, context: Config, verbose: bool = False) -> Optional[tuple[bool, str]]:
+def check_shacl_file(file_path: Path, context: Config, verbose: bool = False) -> tuple[bool, str] | None:
     """Validate a single document file's metadata against loaded shapes.
 
     Returns None if no document metadata is found, otherwise returns (conforms, results_text).

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -7,14 +7,10 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
+
 import click
 
-from .config import Config
-from .format import run_query, process_rdf_format
-from .render import render_markdown_files
-from .parser import document_data_from_path
-from .graph import load_graph, graph_stats
 from .audit import (
     _apply_issues,
     check_frontmatter_schema,
@@ -23,8 +19,12 @@ from .audit import (
     run_check,
     run_lint,
 )
-from .jqfilter import resolve_path
+from .config import Config
+from .format import process_rdf_format, run_query
 from .format_choice import FormatChoice
+from .graph import graph_stats, load_graph
+from .jqfilter import resolve_path
+from .parser import document_data_from_path
 from .paths import (
     iter_document_files,
     iter_markdown_files,
@@ -33,6 +33,7 @@ from .paths import (
     select_document_paths,
     select_markdown_paths,
 )
+from .render import render_markdown_files
 from .runtime import resolve_runtime_config
 
 FILE_COMMANDS = ("check", "lint", "link", "render", "export", "fmt")
@@ -207,7 +208,11 @@ def link(
     verbose: bool,
 ) -> None:
     """Suggest or repair internal links for wiki pages."""
-    from .link_fix import apply_broken_link_fixes, find_broken_link_fixes, remaining_broken_links
+    from .link_fix import (
+        apply_broken_link_fixes,
+        find_broken_link_fixes,
+        remaining_broken_links,
+    )
     from .link_suggest import apply_link_opportunities, find_link_opportunities
     from .links import format_internal_link
 
@@ -282,11 +287,11 @@ def query(
     context: Config,
     query_args: tuple[str, ...],
     output_format: str,
-    output: Optional[Path],
+    output: Path | None,
     no_inference: bool,
     reload: bool,
     disk_cache: bool,
-    jq: Optional[str],
+    jq: str | None,
     pretty: bool,
     verbose: bool,
 ) -> None:
@@ -467,7 +472,7 @@ def build(
 ) -> None:
     """Build static HTML site from wiki documents."""
     from .assets import build_asset_manifest
-    from .site import build_site, build_index_html, build_page_html
+    from .site import build_index_html, build_page_html, build_site
 
     runtime_config = resolve_runtime_config(config, base_url=site_base_url, url_style=site_url_style)
 
@@ -513,7 +518,6 @@ def build(
         default_layout = runtime_config.page_layout
 
     page_output_dir = output_dir / base_url.strip("/") if base_url else output_dir
-    from .assets import build_asset_manifest
     from .paths import build_page_manifest, detect_output_collisions, page_output_path
 
     manifest = (
@@ -583,7 +587,7 @@ def build(
 @click.option("-f", "--format", "rdf_format", type=FormatChoice(["dict", "json-ld", "turtle", "xml", "n3", "nt", "trig", "nquads"], case_sensitive=False), default="dict", show_default=True, help="Output format for RDF export.")
 @click.option("--mode", type=click.Choice(["expanded", "compacted"], case_sensitive=False), default="expanded", show_default=True, help="Serialization mode for formats that support compaction.")
 @click.pass_obj
-def export(context: Config, files: tuple[Path, ...], output: Optional[Path], rdf_format: str, mode: str) -> None:
+def export(context: Config, files: tuple[Path, ...], output: Path | None, rdf_format: str, mode: str) -> None:
     """Export document frontmatter as RDF or JSON-LD."""
     result_payload: Any = None
     _raw_formats = {"turtle", "xml", "n3", "nt", "trig", "nquads"}
@@ -904,7 +908,11 @@ def fmt(config: Config, files: tuple[Path, ...], check: bool, verbose: bool) -> 
 @click.option("-v", "--verbose", is_flag=True, help="Show pip install output.")
 def upgrade(check_only: bool, auto_yes: bool, verbose: bool) -> None:
     """Check for updates and upgrade the wiki CLI."""
-    from .upgrade import check_version, get_windows_path_mismatch_warning, perform_upgrade
+    from .upgrade import (
+        check_version,
+        get_windows_path_mismatch_warning,
+        perform_upgrade,
+    )
 
     current, latest, is_outdated = check_version()
     path_warning = get_windows_path_mismatch_warning()

--- a/src/wiki/config.py
+++ b/src/wiki/config.py
@@ -3,21 +3,10 @@
 from __future__ import annotations
 
 from .context import (
-    DC,
-    DCTERMS,
     DEFAULT_NAMESPACES,
-    FOAF,
-    OWL,
-    RDF,
-    RDFS,
-    SCHEMA,
-    SH,
     Context,
-    WAZOO,
-    WIKI,
-    XSD,
 )
-from .schemas import CheckConfig, LintConfig, Config
+from .schemas import CheckConfig, Config, LintConfig
 from .schemas.wiki_config import (
     CONFIG_FILENAMES,
     DEFAULT_BASE_URL,

--- a/src/wiki/context.py
+++ b/src/wiki/context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from rdflib import Namespace, RDF, RDFS, OWL
+from rdflib import OWL, RDF, RDFS, Namespace
 from rdflib.namespace import XSD
 
 SCHEMA = Namespace("https://schema.org/")

--- a/src/wiki/fmt_util.py
+++ b/src/wiki/fmt_util.py
@@ -8,8 +8,14 @@ from pathlib import Path
 from typing import Any
 
 import mdformat
-from mdformat._conf import DEFAULT_OPTS, InvalidConfError, read_toml_opts, _validate_keys, _validate_values
 import mdformat.plugins
+from mdformat._conf import (
+    DEFAULT_OPTS,
+    InvalidConfError,
+    _validate_keys,
+    _validate_values,
+    read_toml_opts,
+)
 
 from .config import Config
 

--- a/src/wiki/format.py
+++ b/src/wiki/format.py
@@ -13,7 +13,7 @@ from rich.console import Console
 from rich.table import Table
 
 from .format_choice import FormatChoice
-from .schemas.metadata import METADATA_VIEWS, MetadataView
+from .schemas.metadata import METADATA_VIEWS
 
 # Pygments has no dedicated N3/TriG/N-Triples lexers; "nt" aliases to NestedTextLexer.
 METADATA_PYGMENTS_LEXER_ALIASES: dict[str, str] = {

--- a/src/wiki/format_choice.py
+++ b/src/wiki/format_choice.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import re
 from difflib import get_close_matches
-from typing import Any, Optional
+from typing import Any
 
 import click
 
@@ -63,7 +62,7 @@ class FormatChoice(click.Choice):
     # Resolve MIME types before the normal Choice machinery runs
     # ------------------------------------------------------------------
 
-    def normalize_choice(self, choice: Any, ctx: Optional[click.Context]) -> str:
+    def normalize_choice(self, choice: Any, ctx: click.Context | None) -> str:
         raw = str(choice)
 
         # Alias lookup — case-insensitive when case_sensitive=False
@@ -84,7 +83,7 @@ class FormatChoice(click.Choice):
     # "Did you mean … ?"  when an invalid value is entered
     # ------------------------------------------------------------------
 
-    def get_invalid_choice_message(self, value: Any, ctx: Optional[click.Context]) -> str:
+    def get_invalid_choice_message(self, value: Any, ctx: click.Context | None) -> str:
         base = super().get_invalid_choice_message(value, ctx)
 
         valid = list(dict.fromkeys(str(c) for c in self.choices))

--- a/src/wiki/frontmatter_schema.py
+++ b/src/wiki/frontmatter_schema.py
@@ -322,7 +322,6 @@ def check_frontmatter_schema(
             continue
 
         if is_schema_binding_document(fm_data):
-            binding = True
             try:
                 binding_refs = coerce_schema_refs(fm_data.get(JSON_SCHEMA_KEY)) or []
             except ValueError:

--- a/src/wiki/graph.py
+++ b/src/wiki/graph.py
@@ -6,14 +6,15 @@ import logging
 import re
 import warnings
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
+
 from bs4 import BeautifulSoup, Tag, XMLParsedAsHTMLWarning
-from rdflib import Graph, Literal, URIRef, RDF, BNode
+from rdflib import RDF, BNode, Graph, Literal, URIRef
 from rdflib.namespace import XSD
 from rdflib.parser import InputSource, Parser, StringInputSource
 from rdflib.plugin import register
 
-from .config import Context, Config
+from .config import Config, Context
 from .parser import document_data_from_path
 from .paths import iter_document_files, route_for_document_file
 
@@ -178,8 +179,8 @@ def _effective_types(data: dict[str, Any], context: Context | Config) -> list[An
 def frontmatter_to_graph(
     data: dict[str, Any],
     context: Context | Config,
-    file_id: Optional[str] = None,
-    body: Optional[str] = None,
+    file_id: str | None = None,
+    body: str | None = None,
     include_file_extension: bool = False,
     file_ext: str = ".md",
     content_predicate: str | None = None,

--- a/src/wiki/infer.py
+++ b/src/wiki/infer.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
-from rdflib import Graph
+
 import owlrl
+from rdflib import Graph
 
 from .config import Context
 

--- a/src/wiki/init_scaffold.py
+++ b/src/wiki/init_scaffold.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import re
 import subprocess
+from collections.abc import Callable
 from functools import lru_cache
 from importlib.resources import files
 from pathlib import Path
-from typing import Callable
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 

--- a/src/wiki/jqfilter.py
+++ b/src/wiki/jqfilter.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import re
 from typing import Any
 
-
 _TOKEN_RE = re.compile(r"(\w+)|\[(\d+)\]|\[\]")
 
 

--- a/src/wiki/layout.py
+++ b/src/wiki/layout.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from .site.layout_template import layout_file_is_valid, layout_path_within_root, layout_stem
+from .site.layout_template import (
+    layout_file_is_valid,
+    layout_stem,
+)
 
 LAYOUT_FRONTMATTER_KEY = "wazoo:layout"
+
+__all__ = [
+    "LAYOUT_FRONTMATTER_KEY",
+    "layout_file_is_valid",
+    "layout_stem",
+    "parse_layout_from_frontmatter",
+    "resolve_layout_path",
+]
 
 
 def resolve_layout_path(raw: str, config_root: Path) -> Path:

--- a/src/wiki/link_fix.py
+++ b/src/wiki/link_fix.py
@@ -7,12 +7,12 @@ import re
 from pathlib import Path
 
 from .audit import collect_broken_links
-from .document import WIKILINK_FULL_REGEX, split_frontmatter_text
-from .schemas import BrokenLink, BrokenLinkFix
 from .config import Config
+from .document import WIKILINK_FULL_REGEX, split_frontmatter_text
 from .headings import GitHubHeadingSlugger
 from .links import fragment_id, resolve_page_route, split_target
 from .paths import iter_document_files, route_for_document_file
+from .schemas import BrokenLink, BrokenLinkFix
 
 MARKDOWN_LINK_FULL_REGEX = re.compile(r"(!?\[[^\]]*\]\()([^)]+)(\))")
 FUZZY_ROUTE_CUTOFF = 0.86

--- a/src/wiki/link_suggest.py
+++ b/src/wiki/link_suggest.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from .document import MARKDOWN_LINK_REGEX, WIKILINK_REGEX, markdown_body, split_frontmatter_text
-from .schemas import LinkOpportunity
+
 from .config import Config
-from .parser import document_data_from_path
+from .document import (
+    MARKDOWN_LINK_REGEX,
+    WIKILINK_REGEX,
+    markdown_body,
+    split_frontmatter_text,
+)
 from .links import format_internal_link
+from .parser import document_data_from_path
 from .paths import iter_markdown_files, route_for_document_file
+from .schemas import LinkOpportunity
 from .site import extract_title, humanize_route
 
 MIN_ALIAS_LENGTH = 4

--- a/src/wiki/links.py
+++ b/src/wiki/links.py
@@ -9,7 +9,6 @@ from urllib.parse import unquote, urlsplit
 from .headings import heading_slug
 from .paths import page_url
 
-
 EXTERNAL_SCHEMES = {"http", "https", "mailto", "tel"}
 PAGE_LINK_EXTENSIONS = {"", ".md", ".yaml", ".yml", ".json"}
 

--- a/src/wiki/parser.py
+++ b/src/wiki/parser.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Optional
-import yaml
+from typing import Any
 
+import yaml
 
 DOCUMENT_EXTENSIONS = {".md", ".yaml", ".yml", ".json"}
 DATA_DOCUMENT_EXTENSIONS = {".yaml", ".yml", ".json"}
 
 
-def parse_frontmatter(content: str) -> Optional[dict[str, Any]]:
+def parse_frontmatter(content: str) -> dict[str, Any] | None:
     """Parse YAML or JSON frontmatter block from a markdown content string."""
     if not content.startswith("---"):
         return None
@@ -56,7 +56,7 @@ def ensure_context(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-def document_data_from_path(path: Path, content_predicate: Optional[str] = None) -> Optional[dict[str, Any]]:
+def document_data_from_path(path: Path, content_predicate: str | None = None) -> dict[str, Any] | None:
     """Read a supported wiki document file and return its parsed data dict with context."""
     try:
         suffix = path.suffix.lower()
@@ -78,7 +78,7 @@ def document_data_from_path(path: Path, content_predicate: Optional[str] = None)
         return None
 
 
-def frontmatter_from_path(path: Path, content_predicate: Optional[str] = None) -> Optional[dict[str, Any]]:
+def frontmatter_from_path(path: Path, content_predicate: str | None = None) -> dict[str, Any] | None:
     """Read a markdown file and return its parsed frontmatter dict with context.
     
     Optionally appends the text content of the body using the provided predicate key.
@@ -102,7 +102,7 @@ def frontmatter_from_path(path: Path, content_predicate: Optional[str] = None) -
         return None
 
 
-def split_frontmatter_body(content: str) -> tuple[Optional[dict[str, Any]], str]:
+def split_frontmatter_body(content: str) -> tuple[dict[str, Any] | None, str]:
     """Split markdown content into (frontmatter_dict, body_text).
 
     Returns (None, content) if no valid frontmatter is found.
@@ -116,7 +116,7 @@ def split_frontmatter_body(content: str) -> tuple[Optional[dict[str, Any]], str]
     return split.data, split.body.strip()
 
 
-def split_document_body(path: Path) -> tuple[Optional[dict[str, Any]], str]:
+def split_document_body(path: Path) -> tuple[dict[str, Any] | None, str]:
     """Split a supported wiki document into (data, body_text)."""
     suffix = path.suffix.lower()
     if suffix == ".md":

--- a/src/wiki/render.py
+++ b/src/wiki/render.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Any
 
 import click
 from markdown_it import MarkdownIt
 
-from .format import run_query
 from wiki.mdit_py_plugins.wikilink import wikilink_plugin
+
+from .format import run_query
 from .paths import iter_markdown_files, page_routes, select_markdown_paths
 
 # Matches SPARQL wrapper comments, fenced query, rendered table, and end comment.

--- a/src/wiki/schemas/__init__.py
+++ b/src/wiki/schemas/__init__.py
@@ -6,13 +6,13 @@ from .metadata import METADATA_VIEWS, MetadataView
 from .rules import CheckConfig, LintConfig, Severity, coerce_severity
 from .site import InfoboxRow, TocItem, VirtualPage, WikiSite
 from .wiki_config import (
+    Config,
     FmtConfig,
     GraphConfig,
     LinkConfig,
     SiteConfig,
     SparqlServiceConfig,
     WikiConfig,
-    Config,
 )
 
 __all__ = [

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -5,29 +5,35 @@ from __future__ import annotations
 import html as html_module
 import json
 import mimetypes
-import re
 import sys
 import threading
 import time
 from dataclasses import dataclass
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs, urlsplit
-from typing import Any, Optional
 
 from .config import Config
-from .format import detect_query_form, is_sparql_update, normalize_metadata_format, normalize_metadata_mode, run_query
+from .format import (
+    detect_query_form,
+    is_sparql_update,
+    normalize_metadata_format,
+    normalize_metadata_mode,
+    run_query,
+)
 from .graph import load_graph
-from .sparql_service import build_service_description_graph, serialize_service_description
 from .site import (
-    WikiSite,
     VirtualPage,
-    build_site,
+    WikiSite,
     build_index_html,
     build_page_html,
+    build_site,
 )
-
-
+from .sparql_service import (
+    build_service_description_graph,
+    serialize_service_description,
+)
 
 
 @dataclass
@@ -210,7 +216,7 @@ class WikiHandler(BaseHTTPRequestHandler):
 <h1>{code}</h1>
 <p>{html_module.escape(message)}</p>
 </body>
-</html>""".encode("utf-8")
+</html>""".encode()
         self.send_response(code)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))

--- a/src/wiki/site/__init__.py
+++ b/src/wiki/site/__init__.py
@@ -2,7 +2,10 @@
 
 from ..schemas.site import InfoboxRow, TocItem, VirtualPage, WikiSite
 from .build import build_site
+
+# Test-only / internal exports kept for compatibility
 from .html import (
+    _build_logo_svg,  # noqa: F401
     build_index_html,
     build_infobox_rows,
     build_page_html,
@@ -20,9 +23,6 @@ from .markdown import (
     strip_leading_title_heading,
 )
 
-# Test-only / internal exports kept for compatibility
-from .html import _build_logo_svg  # noqa: F401
-
 __all__ = [
     "MINIMAL_LAYOUT_TEMPLATE",
     "INLINE_CSS",
@@ -32,6 +32,7 @@ __all__ = [
     "WikiSite",
     "build_layout_context",
     "build_logo_svg",
+    "build_index_html",
     "build_infobox_rows",
     "build_page_html",
     "build_site",

--- a/src/wiki/site/build.py
+++ b/src/wiki/site/build.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from ..config import Config
 from ..links import is_external_link
-from ..paths import iter_document_files, route_for_document_file
 from ..parser import split_document_body
+from ..paths import iter_document_files, route_for_document_file
 from ..schemas.site import VirtualPage, WikiSite
 from ..wiki_links import LinkIndex
 from .markdown import (
@@ -17,6 +17,7 @@ from .markdown import (
     render_wiki_markdown,
     strip_leading_title_heading,
 )
+
 
 def build_site(
     input_dirs: Config | list[Path] | Path,

--- a/src/wiki/site/html.py
+++ b/src/wiki/site/html.py
@@ -9,21 +9,23 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-from markupsafe import Markup
 from pygments import highlight
-from pygments.lexers import get_lexer_by_name
-from pygments.util import ClassNotFound
 from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 
 from ..config import DEFAULT_URL_STYLE, Config
-from ..format import process_rdf_format, resolve_metadata_pygments_lexer, resolve_metadata_view
+from ..format import (
+    process_rdf_format,
+    resolve_metadata_pygments_lexer,
+    resolve_metadata_view,
+)
 from ..links import is_external_link, resolve_page_route
-from ..paths import page_url
 from ..schemas.metadata import METADATA_VIEWS
 from ..schemas.site import InfoboxRow, VirtualPage, WikiSite
 from .backlinks import build_backlinks_html
 from .build import expand_known_curie
+from .layout_context import build_layout_context, build_logo_svg
+from .layout_template import get_layout_renderer
 from .markdown import (
     METADATA_HIDDEN_FIELDS,
     PYGMENTS_FORMATTER,
@@ -33,8 +35,6 @@ from .markdown import (
     render_copyable_pre,
     render_outline_title,
 )
-from .layout_context import build_layout_context, build_logo_svg
-from .layout_template import get_layout_renderer
 
 
 def build_index_html(

--- a/src/wiki/site/layout_template.py
+++ b/src/wiki/site/layout_template.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 
-from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader, select_autoescape
+from jinja2 import (
+    ChoiceLoader,
+    Environment,
+    FileSystemLoader,
+    PackageLoader,
+    select_autoescape,
+)
 
 MINIMAL_LAYOUT_TEMPLATE = "layout_minimal.html.j2"
 LAYOUT_SUFFIX = ".html.j2"

--- a/src/wiki/site/markdown.py
+++ b/src/wiki/site/markdown.py
@@ -3,28 +3,28 @@
 from __future__ import annotations
 
 import html as html_module
-import json
 import re
-from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
 from markdown_it import MarkdownIt
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
+
 from wiki.mdit_py_plugins.wikilink import wikilink_plugin
 
-from ..config import DEFAULT_URL_STYLE, Config
+from ..config import DEFAULT_URL_STYLE
 from ..headings import GitHubHeadingSlugger, heading_slug, parse_headings
-from ..format import process_rdf_format, resolve_metadata_pygments_lexer, resolve_metadata_view
-from ..schemas.metadata import METADATA_VIEWS
-from ..schemas.site import InfoboxRow, TocItem, VirtualPage, WikiSite
-from ..links import is_external_link, markdown_link_is_page, resolve_page_href, resolve_page_route
-from ..paths import iter_document_files, page_url, route_for_document_file
-from ..parser import split_document_body
+from ..links import (
+    is_external_link,
+    markdown_link_is_page,
+    resolve_page_href,
+)
+from ..paths import page_url
 from ..render import strip_sparql_wrappers_for_html
+from ..schemas.metadata import METADATA_VIEWS
+from ..schemas.site import TocItem, VirtualPage
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 

--- a/src/wiki/upgrade.py
+++ b/src/wiki/upgrade.py
@@ -9,8 +9,8 @@ import shutil
 import subprocess
 import sys
 import sysconfig
-from pathlib import PureWindowsPath
 from importlib.metadata import version
+from pathlib import PureWindowsPath
 from urllib.error import URLError
 from urllib.request import urlopen
 

--- a/src/wiki/wiki_links.py
+++ b/src/wiki/wiki_links.py
@@ -10,7 +10,6 @@ from urllib.parse import unquote
 
 from .assets import asset_reference_issue, audit_assets
 from .config import Config
-from .headings import parse_headings
 from .document import (
     MARKDOWN_LINK_FULL_REGEX,
     WIKILINK_FULL_REGEX,
@@ -19,7 +18,14 @@ from .document import (
     split_frontmatter_text,
     strip_inline_code,
 )
-from .links import fragment_id, is_external_link, markdown_link_is_page, resolve_page_route, split_target
+from .headings import parse_headings
+from .links import (
+    fragment_id,
+    is_external_link,
+    markdown_link_is_page,
+    resolve_page_route,
+    split_target,
+)
 from .parser import document_data_from_path
 from .paths import iter_document_files, route_for_document_file
 from .schemas import BrokenLink

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,22 +2,21 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from wiki.config import Config
 from wiki.audit import (
+    check_layout_frontmatter,
+    check_shacl_all,
+    check_shacl_file,
     lint_broken_links,
     lint_duplicate_headings,
     lint_filenames,
     lint_heading_levels,
     lint_headings,
-    lint_thematic_breaks,
     lint_link_style,
-    check_layout_frontmatter,
+    lint_thematic_breaks,
     load_shapes,
-    check_shacl_file,
-    check_shacl_all,
-    run_check,
     run_lint,
 )
+from wiki.config import Config
 
 
 class TestChecking(unittest.TestCase):
@@ -117,8 +116,9 @@ And a valid Markdown link [Target](target-page.md) and a broken Markdown link [B
 
     def test_load_shapes_edge_cases(self) -> None:
         """Test load_shapes behaves predictably with different underlying graph states."""
-        from wiki.graph import load_graph
         from rdflib import Graph
+
+        from wiki.graph import load_graph
 
         # Empty graph
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,12 +5,15 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from layout_helpers import write_layout
 from wiki.cli import main
 from wiki.config import Config
+from wiki.init_scaffold import (
+    DOCS_WIKI_INIT_OPTIONS,
+    load_packaged_default_layout,
+    render_wiki_yaml,
+)
 from wiki.paths import page_output_path
-from wiki.init_scaffold import DOCS_WIKI_INIT_OPTIONS, InitOptions, load_packaged_default_layout, render_wiki_yaml
-
-from layout_helpers import write_layout
 
 
 class TestWikiBuild(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,18 +2,23 @@ import json
 import threading
 import time
 import unittest
-import yaml
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
-from urllib.request import urlopen
 from urllib.error import URLError
+from urllib.request import urlopen
 
+import yaml
 from click.testing import CliRunner
 
 from wiki.cli import FILE_COMMANDS, main
 from wiki.config import Config
-from wiki.init_scaffold import InitOptions, load_packaged_default_layout, load_packaged_default_logo, render_wiki_yaml
+from wiki.init_scaffold import (
+    InitOptions,
+    load_packaged_default_layout,
+    load_packaged_default_logo,
+    render_wiki_yaml,
+)
 
 
 class TestCLI(unittest.TestCase):
@@ -1444,6 +1449,7 @@ ex:foo ex:bar "from-import-dir" .
     def test_server_serve_real_request(self) -> None:
         """Test wiki serve with real --host/--port via HTTP request."""
         import socket
+
         from wiki.config import Config
         from wiki.serve import run_server
 
@@ -1485,6 +1491,7 @@ Hello from server test.
     def test_server_serve_custom_base_url(self) -> None:
         """Test wiki serve with custom --site-base-url."""
         import socket
+
         from wiki.config import Config
         from wiki.serve import run_server
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,17 @@ import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
 import yaml
 from rdflib import Graph, Namespace
 
-from wiki.config import Context, Config, DEFAULT_CHECK_CONFIG, DEFAULT_LINT_CONFIG, DEFAULT_NAMESPACES
+from wiki.config import (
+    DEFAULT_CHECK_CONFIG,
+    DEFAULT_LINT_CONFIG,
+    DEFAULT_NAMESPACES,
+    Config,
+    Context,
+)
 from wiki.schemas import FmtConfig
 
 MINIMAL_WIKI_YAML = "wiki:\n  inputs: [wiki]\n"

--- a/tests/test_fmt.py
+++ b/tests/test_fmt.py
@@ -5,17 +5,15 @@ from tempfile import TemporaryDirectory
 import mdformat
 from click.testing import CliRunner
 
+from layout_helpers import write_layout
 from wiki.cli import main
 from wiki.config import Config
 from wiki.fmt_util import (
-    DEFAULT_FMT_OPTS,
     _resolve_fmt_toml_opts,
     describe_fmt_source,
     format_markdown,
 )
 from wiki.site import build_page_html, build_site
-
-from layout_helpers import write_layout
 
 
 class TestWikiFmt(unittest.TestCase):

--- a/tests/test_format_choice.py
+++ b/tests/test_format_choice.py
@@ -1,11 +1,11 @@
 """Unit tests for the FormatChoice custom Click type."""
 
 import unittest
-from click.testing import CliRunner
+
 import click
+from click.testing import CliRunner
 
 from wiki.format_choice import FormatChoice
-
 
 QUERY_FORMATS = ["table", "json", "csv", "tsv", "turtle", "n3", "markdown"]
 EXPORT_FORMATS = ["dict", "json-ld", "turtle", "xml", "n3", "nt", "trig", "nquads"]

--- a/tests/test_frontmatter_schema.py
+++ b/tests/test_frontmatter_schema.py
@@ -5,8 +5,8 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 from urllib.error import HTTPError
 
-from wiki.config import Config
 from wiki.audit import run_check
+from wiki.config import Config
 from wiki.frontmatter_schema import (
     JSON_SCHEMA_KEY,
     TARGET_CLASS_KEY,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,17 +1,17 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from rdflib import Graph, URIRef, RDF, Literal
+
+from rdflib import RDF, Graph, Literal, URIRef
 from rdflib.namespace import XSD
 
-from wiki.config import Context, Config
+from wiki.config import Config
 from wiki.graph import (
     frontmatter_to_graph,
     kebab_case,
-    resolve_predicate,
-    resolve_object,
     load_graph,
-    graph_stats,
+    resolve_object,
+    resolve_predicate,
 )
 
 
@@ -447,7 +447,6 @@ Raw Body Text.
 
     def test_load_graph_logs_warnings_on_bad_files(self) -> None:
         """Test that load_graph emits warnings for unparseable content instead of silent pass."""
-        import logging
         from wiki.graph import logger as graph_logger
 
         with TemporaryDirectory() as tmpdir:
@@ -518,7 +517,6 @@ name: Good Page
             config = Config(
                 wiki={"inputs": [wiki_dir]},
                 graph={
-                    "context": {"wiki": "https://example.test/wiki/"},
                     "context": {"schema": "https://schema.org/", "wiki": "https://example.test/wiki/"},
                 },
             )

--- a/tests/test_graph_cache.py
+++ b/tests/test_graph_cache.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from wiki.config import Config
 from wiki import graph as graph_module
-from wiki.graph import load_graph, graph_stats
+from wiki.config import Config
+from wiki.graph import graph_stats, load_graph
 from wiki.graph_cache import (
     cache_dir,
     clear_all_process_graphs,

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,11 +1,13 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from rdflib import URIRef, RDF, RDFS, Namespace
+
+from rdflib import RDF, RDFS, Namespace, URIRef
 
 from wiki.config import Config
-from wiki.infer import apply_inference
 from wiki.graph import load_graph
+from wiki.infer import apply_inference
+
 
 class TestReasoning(unittest.TestCase):
     def test_full_reasoning_pipeline(self) -> None:

--- a/tests/test_init_scaffold.py
+++ b/tests/test_init_scaffold.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import subprocess
-import yaml
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
+import yaml
+
 from wiki.config import Config
 from wiki.fmt_util import DEFAULT_FMT_OPTS
-from wiki.schemas.wiki_config import normalize_base_iri
 from wiki.init_scaffold import (
     InitOptions,
     copy_default_layout,
@@ -25,6 +25,7 @@ from wiki.init_scaffold import (
     render_wiki_yaml,
     resolve_init_options,
 )
+from wiki.schemas.wiki_config import normalize_base_iri
 
 
 class TestParseGithubRepo(TestCase):
@@ -271,7 +272,8 @@ class TestInitLockstep(TestCase):
 
     def test_init_options_map_to_valid_config_paths(self) -> None:
         """Ensure every InitOptions field maps to a valid Pydantic model path on Config."""
-        from typing import get_args, get_origin, Union
+        from typing import Union, get_args, get_origin
+
         from pydantic import BaseModel
         for field, path in INIT_OPTIONS_TO_CONFIG_PATH.items():
             self.assertIn(field, InitOptions.model_fields, f"Mapped field '{field}' is not in InitOptions.")

--- a/tests/test_jqfilter.py
+++ b/tests/test_jqfilter.py
@@ -1,4 +1,5 @@
 import unittest
+
 from wiki.jqfilter import resolve_path
 
 

--- a/tests/test_link_fix.py
+++ b/tests/test_link_fix.py
@@ -2,9 +2,13 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from wiki.audit import lint_broken_links, collect_broken_links
+from wiki.audit import collect_broken_links, lint_broken_links
 from wiki.config import Config
-from wiki.link_fix import apply_broken_link_fixes, find_broken_link_fixes, remaining_broken_links
+from wiki.link_fix import (
+    apply_broken_link_fixes,
+    find_broken_link_fixes,
+    remaining_broken_links,
+)
 
 
 class TestLinkFix(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,12 +1,13 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
 from wiki.parser import (
     document_data_from_path,
-    parse_frontmatter,
-    split_frontmatter_body,
-    split_document_body,
     ensure_context,
+    parse_frontmatter,
+    split_document_body,
+    split_frontmatter_body,
 )
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,11 +2,13 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from wiki.assets import build_asset_manifest, iter_asset_files
+from wiki.audit import lint_broken_links
 from wiki.config import Config
 from wiki.paths import (
+    OutputEntry,
     build_page_manifest,
     detect_output_collisions,
-    OutputEntry,
     page_output_path,
     page_routes,
     page_url,
@@ -14,8 +16,6 @@ from wiki.paths import (
     validate_filename_pattern,
     validate_route_safety,
 )
-from wiki.audit import lint_broken_links
-from wiki.assets import build_asset_manifest, iter_asset_files
 
 
 class TestWikiPaths(unittest.TestCase):

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 import socket
 import threading
 import unittest
-from io import BytesIO
+from collections.abc import Generator
 from http.client import HTTPConnection
+from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from time import sleep
-from typing import Generator
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from layout_helpers import write_layout
 from wiki.cli import main
 from wiki.config import Config
 from wiki.serve import (
@@ -34,8 +35,6 @@ def _free_port() -> int:
     s.close()
     return port
 
-
-from layout_helpers import write_layout
 
 _RICH_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from layout_helpers import write_layout
 from wiki.config import Config
 from wiki.format import METADATA_VIEWS
 from wiki.init_scaffold import load_packaged_default_layout
@@ -14,8 +15,6 @@ from wiki.site import (
     render_wiki_markdown,
     strip_leading_title_heading,
 )
-
-from layout_helpers import write_layout
 
 _FULL_TEST_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
@@ -578,7 +577,6 @@ specialty: Diagnostics
             self.assertNotIn("On this page", html)
 
     def test_default_layout_read_view_includes_first_heading(self) -> None:
-        seed_template = load_packaged_default_layout()
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             wiki = root / "wiki"
@@ -597,7 +595,6 @@ specialty: Diagnostics
             self.assertIn("Lead paragraph.", html)
 
     def test_read_view_does_not_include_generic_site_sub(self) -> None:
-        seed_template = load_packaged_default_layout()
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             wiki = root / "wiki"

--- a/tests/test_sparql_service.py
+++ b/tests/test_sparql_service.py
@@ -6,7 +6,11 @@ import unittest
 
 from rdflib import Graph
 
-from wiki.sparql_service import SD, build_service_description_graph, serialize_service_description
+from wiki.sparql_service import (
+    SD,
+    build_service_description_graph,
+    serialize_service_description,
+)
 
 
 class SparqlServiceDescriptionTests(unittest.TestCase):

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import subprocess
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -20,7 +19,6 @@ from wiki.upgrade import (
     get_windows_path_mismatch_warning,
     is_frozen_install,
 )
-
 
 PYPI_RESPONSE_LATEST = {
     "info": {"version": "1.0.0"},

--- a/uv.lock
+++ b/uv.lock
@@ -684,6 +684,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -745,6 +770,9 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
 standalone = [
     { name = "pyinstaller" },
 ]
@@ -769,6 +797,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.9.0" }]
 standalone = [{ name = "pyinstaller", specifier = ">=6.0" }]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Ruff to a `dev` dependency group with narrow `E`/`F`/`I`/`UP` lint config (ignore `E501` to avoid line-wrap churn).
- Run `uv run ruff check .` in CI before unit tests; document the command in AGENTS.md and README.
- Apply minimal import/unused-import and pyupgrade fixes to keep the gate green.

Closes #93

## Test plan
- [x] `uv sync --group dev`
- [x] `uv run ruff check .`
- [x] `uv run python -m unittest discover -s tests`
- [x] `uv run wiki -c docs/wiki.yaml fmt --check`
- [x] `uv run wiki -c docs/wiki.yaml lint --strict`
- [x] `uv run wiki -c docs/wiki.yaml check --strict`
- [ ] CI green