### PR TITLE
Typed layout context contract and init branding docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - **Library-first Python API** ([#112](https://github.com/wazootech/wiki/issues/112)) — `Workspace` session, typed `AuditReport` / `Issue` and operation result models, `build_workspace`, `scaffold_workspace`, link/render/export/fmt library ops, curated `wiki.__all__`, and `py.typed`. See [Wiki Programmatic API](docs/wiki/Wiki_Programmatic_API.md).
-- Typed **layout context** models (`LayoutContext`) validated at `build_layout_context` with expanded layout token contract tests ([#106](https://github.com/wazootech/wiki/issues/106)).
+- Typed **layout context** models (`LayoutContext`) validated at `build_layout_context` with expanded layout slot contract tests ([#106](https://github.com/wazootech/wiki/issues/106)).
 
 ### Fixed
 
@@ -14,7 +14,7 @@
 ### Changed
 
 - Init/branding docs: Getting Started branding subsection; clarify tweak-comment workflow ([#107](https://github.com/wazootech/wiki/issues/107)).
-- Page layouts use **`%wiki.*%` layout tokens** instead of Jinja. Packaged layouts: `layouts/wikipedia.html` (Vector UI, copied on init), `layouts/index.html` (minimal full page when `site.layout` is unset). Bundled styles ship as linked `assets/wikipedia.css` (layout + metadata-format + Pygments merged); runtime `site.inline_css` removed.
+- Page layouts use **`%wiki.*%` layout slots** instead of Jinja. Packaged layouts: `layouts/wikipedia.html` (Vector UI, copied on init), `layouts/index.html` (minimal full page when `site.layout` is unset). Bundled styles ship as linked `assets/wikipedia.css` (layout + metadata-format + Pygments merged); runtime `site.inline_css` removed.
 - Document npm/npx install parity with `wiki` subcommands (README, Getting Started, Wiki CLI, wiki agent skill).
 - Consolidate agent skills — `wiki-install`, `wiki-create`, `wiki-improve`, and `wiki-deploy` merge into single **`wiki`** skill under `skills/wiki/` with workflow references and `verify-cli.sh` / `audit.sh` scripts.
 - Rename `link.style` values: `markdown` → `standard`, `obsidian` → `wikilink` (`wiki init --link-style`, validators, docs). Old values fail at load (no aliases).
@@ -30,9 +30,9 @@
 - **Library API:** If you imported audit dict helpers or relied on `run_check` / `run_lint` returning `dict[str, Any]`, switch to `AuditReport` and `Issue` (`report.ok`, `report.errors`, `issue.code`). Prefer `from wiki import Workspace, AuditReport` for new integrations.
 
 - Remove `--force`, `--site-name`, and `--site-theme-color` from scripts and CI. To customize logo letter or theme after init, edit tweak comments in `assets/logo.svg` and `layouts/wikipedia.html` instead.
-- Replace Jinja `{{ page.* }}` / `{{ site.* }}` in custom layouts with `%wiki.*%` tokens (see [Layout tokens](docs/wiki/Wiki_Configuration.md#layout-tokens)). Remove `<style>{{ site.inline_css }}</style>`; link `%wiki.base_url%/assets/wikipedia.css` instead.
+- Replace Jinja `{{ page.* }}` / `{{ site.* }}` in custom layouts with `%wiki.*%` slots (see [Layout slots](docs/wiki/Wiki_Configuration.md#layout-slots)). Remove `<style>{{ site.inline_css }}</style>`; link `%wiki.base_url%/assets/wikipedia.css` instead.
 - Fresh `wiki init` writes **`wiki.yml`** (scaffold source: `src/wiki/templates/wiki.yml`), `layouts/wikipedia.html`, `assets/wikipedia.css`, and sets `site.layout: layouts/wikipedia.html` by default. Existing **`wiki.yaml`** configs still load; rename manually to `wiki.yml` or remove before re-init. `--site-layout minimal` omits `site.layout` (packaged `index.html` fallback).
-- Workspaces that copied `layouts/shell.html` from an earlier unreleased build should replace it with `layouts/wikipedia.html` and update `site.layout` accordingly. Remove `%wiki.body%` from custom layouts; use monolithic page layouts with layout tokens instead.
+- Workspaces that copied `layouts/shell.html` from an earlier unreleased build should replace it with `layouts/wikipedia.html` and update `site.layout` accordingly. Remove `%wiki.body%` from custom layouts; use monolithic page layouts with layout slots instead.
 - Rename `site.layout` and `wazoo:layout` paths from `*.html.j2` to `*.html` if you have not already.
 - Reinstall the consolidated skill: `npx skills add wazootech/wiki@wiki -g -y`
 - Remove stale copies from `~/.agents/skills/` or project `.agents/skills/`: `wiki-install`, `wiki-create`, `wiki-improve`, `wiki-deploy`
@@ -67,7 +67,7 @@ link:
 ### Migration
 
 - Delete the entire `site.manifest` block from `wiki.yaml`.
-- Move branding into your `site.layout` file (for example `layouts/wikipedia.html`): edit sidebar label, `theme-color` meta tags, and asset URLs such as `%wiki.base_url%/assets/logo.svg`. Use `%wiki.*%` layout tokens, not Jinja (see Unreleased migration).
+- Move branding into your `site.layout` file (for example `layouts/wikipedia.html`): edit sidebar label, `theme-color` meta tags, and asset URLs such as `%wiki.base_url%/assets/logo.svg`. Use `%wiki.*%` layout slots, not Jinja (see Unreleased migration).
 - Replace legacy manifest placeholders and Jinja `{{ site.manifest.* }}` paths with literals or `%wiki.base_url%/assets/…` in custom layouts.
 - Remove `<link rel="manifest">` and any dependency on built/served `manifest.webmanifest`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Library-first Python API** ([#112](https://github.com/wazootech/wiki/issues/112)) — `Workspace` session, typed `AuditReport` / `Issue` and operation result models, `build_workspace`, `scaffold_workspace`, link/render/export/fmt library ops, curated `wiki.__all__`, and `py.typed`. See [Wiki Programmatic API](docs/wiki/Wiki_Programmatic_API.md).
+- Typed **layout context** models (`LayoutContext`) validated at `build_layout_context` with expanded layout token contract tests ([#106](https://github.com/wazootech/wiki/issues/106)).
 
 ### Fixed
 
@@ -12,6 +13,7 @@
 
 ### Changed
 
+- Init/branding docs: Getting Started branding subsection; clarify tweak-comment workflow ([#107](https://github.com/wazootech/wiki/issues/107)).
 - Page layouts use **`%wiki.*%` layout tokens** instead of Jinja. Packaged layouts: `layouts/wikipedia.html` (Vector UI, copied on init), `layouts/index.html` (minimal full page when `site.layout` is unset). Bundled styles ship as linked `assets/wikipedia.css` (layout + metadata-format + Pygments merged); runtime `site.inline_css` removed.
 - Document npm/npx install parity with `wiki` subcommands (README, Getting Started, Wiki CLI, wiki agent skill).
 - Consolidate agent skills — `wiki-install`, `wiki-create`, `wiki-improve`, and `wiki-deploy` merge into single **`wiki`** skill under `skills/wiki/` with workflow references and `verify-cli.sh` / `audit.sh` scripts.
@@ -58,15 +60,15 @@ link:
 ### Changed
 
 - Consolidate [Wiki CLI templates](docs/wiki/Wiki_CLI.md#ecosystem-templates) registry in Wiki_CLI: single shipped/planned table, SPARQL single-repo (`wiki-yasgui-template` absorbs Virtuoso scope), `wiki-{stack}-template` integration slugs, planned `wiki-astro-template` ([#96](https://github.com/wazootech/wiki/issues/96)). Slim README and downstream wiki pages to point at the canonical section; retire stale slugs (`sparql-service-template`, bare `nextjs-template`, `obsidian-quartz-template`, etc.).
-- Remove `site.manifest` and `manifest.webmanifest`. Branding (site name, theme color, favicon, sidebar logo) lives in `site.layout` only; `wiki.yaml` `site:` keeps `layout`, `base_url`, and `url_style`. Init flags rename to `--site-name` and `--site-theme-color` (logo asset only; not persisted to yaml).
+- Remove `site.manifest` and `manifest.webmanifest`. Branding (site name, theme color, favicon, sidebar logo) lives in `site.layout` only; `wiki.yaml` `site:` keeps `layout`, `base_url`, and `url_style`. A brief 0.1.14 release added `--site-name` and `--site-theme-color` for logo SVG only; those init flags were removed before the next release — see Unreleased migration for the tweak-comment workflow.
 - `wiki init` omits `lint:` keys that default to `off` (`headings`, `heading_levels`, `duplicate_headings`, `thematic_breaks`).
 - Docs and agent skills use title-case H1 headings and sentence-case H2+ without numbered headings.
 
 ### Migration
 
 - Delete the entire `site.manifest` block from `wiki.yaml`.
-- Move branding into `layouts/default.html.j2` (or your `site.layout` file): edit `<title>`, sidebar label, `theme-color` meta tags, and asset URLs such as `{{ site.base_url }}/assets/logo.svg` directly.
-- Replace `{{ site.manifest.* }}` template variables with literals or `{{ site.base_url }}/assets/…` paths in custom layouts.
+- Move branding into your `site.layout` file (for example `layouts/wikipedia.html`): edit sidebar label, `theme-color` meta tags, and asset URLs such as `%wiki.base_url%/assets/logo.svg`. Use `%wiki.*%` layout tokens, not Jinja (see Unreleased migration).
+- Replace legacy manifest placeholders and Jinja `{{ site.manifest.* }}` paths with literals or `%wiki.base_url%/assets/…` in custom layouts.
 - Remove `<link rel="manifest">` and any dependency on built/served `manifest.webmanifest`.
 
 ## 0.1.13 — 2026-06-10

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ knows: wiki:Bella_Davidson
 url: https://gregorydavidson.com
 ```
 
-When `wazoo:layout` is omitted, the page uses `site.layout`. Layout files are `.html` page layouts: use `%wiki.page.content%`, `%wiki.nav.infobox%`, `%wiki.page.layout.class%`, and the other layout tokens listed in [Layout tokens](docs/wiki/Wiki_Configuration.md#layout-tokens).
+When `wazoo:layout` is omitted, the page uses `site.layout`. Layout files are `.html` page layouts: use `%wiki.page.content%`, `%wiki.nav.infobox%`, `%wiki.page.layout.class%`, and the other layout slots listed in [Layout slots](docs/wiki/Wiki_Configuration.md#layout-slots).
 
 Any article with displayable frontmatter gets a sidebar infobox. Structural keys such as `@context`, `@id`, `id`, `@type`, and `type` are hidden from the infobox. Infobox values become links automatically when they reference another wiki page or an external URL.
 

--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -55,6 +55,10 @@ wiki init --git
 
 `wiki init` writes `wiki.yml`, `README.md`, `layouts/`, `assets/logo.svg`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). The scaffold enables `wiki.assets` and wires the default layout to the logo file. Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. Init requires a clean directory (no existing `wiki.yml`, `README.md`, or non-empty `wiki/`). See [Wiki Subcommand init](Wiki_Subcommand_init.md) for all flags.
 
+### Branding
+
+Site name, theme color, logo, and favicon are **not** `wiki.yml` keys. They live in `site.layout` (for example `layouts/wikipedia.html`) and files under `wiki.assets` (for example `assets/logo.svg`). After init, edit `<!-- wiki tweak: … -->` comments in those scaffold files rather than adding branding keys to config. See [Wiki Configuration — Custom logos and icons](Wiki_Configuration.md#custom-logos-and-icons) and [Wiki Subcommand init](Wiki_Subcommand_init.md).
+
 Alternatively, start from a GitHub template: [wiki-template](https://github.com/wazootech/wiki-template) (generic workspace) or the [LLM Wiki](LLM_Wiki.md) starter [llm-wiki-template](https://github.com/wazootech/llm-wiki-template). See [Wiki CLI templates](Wiki_CLI.md#ecosystem-templates).
 
 ## Daily workflow

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -292,7 +292,7 @@ When `site.layout` is set, the CLI renders every page through that page layout (
 
 The first-class presentation contract in this repository is layout files under `layouts/` (for example `layouts/wikipedia.html` referenced from `site.layout`).
 
-- The [Wiki CLI](Wiki_CLI.md) owns the semantic markdown-to-HTML pipeline and layout token contract.
+- The [Wiki CLI](Wiki_CLI.md) owns the semantic markdown-to-HTML pipeline and layout slot contract.
 - Wiki page layout files are the primary built-in extension point for presentation.
 - Framework-specific sites such as Next.js, Mintlify, or other external docs stacks are better treated as downstream integrations or separate layout repositories unless they need core CLI changes.
 
@@ -300,15 +300,15 @@ The first-class presentation contract in this repository is layout files under `
 
 Without a configured layout file (or when the path is missing), every page is rendered with the packaged `index.html` layout (`<h1>` + content, linked `assets/wikipedia.css`). It does not include sidebar, tabs, infobox, table of contents, backlinks, or categories. Use `wiki init --site-layout wikipedia` (default) for the full Vector layout.
 
-### Layout tokens
+### Layout slots
 
-Layout files use `%wiki.*%` token substitution (not Jinja). On each page render, the CLI builds a token map from the current page context and replaces every known token in your layout file. Unknown `%wiki.*%` spellings are left unchanged.
+Layout files use `%wiki.*%` slot substitution (not Jinja). On each page render, the CLI builds a slot map from the current page context and replaces every known slot in your layout file. Unknown `%wiki.*%` spellings are left unchanged.
 
-Programmatic consumers and contract tests use `wiki.site.layout_tokens.build_layout_token_map` as the single boundary for token production. See [Wiki Programmatic API](Wiki_Programmatic_API.md#layout-token-contract).
+Programmatic consumers and contract tests use `wiki.site.layout_tokens.build_layout_token_map` as the single boundary for slot production. See [Wiki Programmatic API](Wiki_Programmatic_API.md#layout-slot-contract).
 
-Canonical token list (22 tokens):
+Canonical slot list (22 slots):
 
-| Token                       | Source                    | Substitution                                                  |
+| Slot                        | Source                    | Substitution                                                  |
 | --------------------------- | ------------------------- | ------------------------------------------------------------- |
 | `%wiki.base_url%`           | `site.base_url`           | HTML-escaped text (`/wiki`, or `""` for site root)            |
 | `%wiki.assets%`             | same as `%wiki.base_url%` | HTML-escaped text (alias for asset `href` / `src` prefixes)   |
@@ -333,13 +333,13 @@ Canonical token list (22 tokens):
 | `%wiki.wiki.pages_json%`    | all pages for search JS   | Raw JSON array (`[{slug, title}, …]`)                         |
 | `%wiki.page.slug_json%`     | current page slug         | Raw JSON string (for client-side talk notes)                  |
 
-**Pre-built HTML** tokens are assembled by the site builder (infobox, TOC, metadata panes, and so on). Treat them as trusted markup from Wiki CLI, not as user-authored template fragments.
+**Pre-built HTML** slots are assembled by the site builder (infobox, TOC, metadata panes, and so on). Treat them as trusted markup from Wiki CLI, not as user-authored template fragments.
 
 **Packaged layouts**
 
-| File                     | When used                                                                     | Typical tokens                                                                                                             |
+| File                     | When used                                                                     | Typical slots                                                                                                              |
 | ------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `layouts/wikipedia.html` | `site.layout` after `wiki init --site-layout wikipedia` (copied to workspace) | All tokens above (Vector chrome + search script)                                                                           |
+| `layouts/wikipedia.html` | `site.layout` after `wiki init --site-layout wikipedia` (copied to workspace) | All slots above (Vector chrome + search script)                                                                            |
 | `layouts/index.html`     | `site.layout` unset or missing file                                           | `%wiki.head%`, `%wiki.base_url%`, `%wiki.page.body_class%`, `%wiki.page.kind%`, `%wiki.page.title%`, `%wiki.page.content%` |
 
 Example excerpt (`layouts/wikipedia.html` after `wiki init`):

--- a/docs/wiki/Wiki_Page_Layouts.md
+++ b/docs/wiki/Wiki_Page_Layouts.md
@@ -48,9 +48,9 @@ When `wazoo:layout` is omitted, the page uses `site.layout`. Layout files must e
 
 `wazoo:layout` is ordinary frontmatter: it appears in the RDF graph, infobox, and metadata pane like other properties.
 
-## Layout tokens
+## Layout slots
 
-Layout files use `%wiki.*%` token substitution (not Jinja). The **canonical reference** is [Layout tokens](Wiki_Configuration.md#layout-tokens) in Wiki Configuration — a full table of every `%wiki.*%` token, its source field, and whether the value is HTML-escaped, pre-built markup, or raw JSON.
+Layout files use `%wiki.*%` slot substitution (not Jinja). The **canonical reference** is [Layout slots](Wiki_Configuration.md#layout-slots) in Wiki Configuration — a full table of every `%wiki.*%` slot, its source field, and whether the value is HTML-escaped, pre-built markup, or raw JSON.
 
 Custom logos and favicons are layout markup plus `wiki.assets` overrides; see [Custom logos and icons](Wiki_Configuration.md#custom-logos-and-icons) in Wiki_Configuration.
 

--- a/docs/wiki/Wiki_Programmatic_API.md
+++ b/docs/wiki/Wiki_Programmatic_API.md
@@ -132,7 +132,7 @@ Interactive `wiki init` still owns prompts, `--git`, and preflight guards in the
 
 ## Layout token contract
 
-Page layouts substitute `%wiki.*%` tokens. The contract boundary for tests and downstream layout tools is `wiki.site.layout_tokens.build_layout_token_map` (alias: `build_layout_context` → token map). Contract tests in the repository assert every token in packaged layouts is produced by that map. See [Wiki Configuration](Wiki_Configuration.md#layout-tokens).
+Page layouts substitute `%wiki.*%` tokens. `build_layout_context` validates a typed `LayoutContext` (internal schema in `wiki.schemas.layout`) before markup and token substitution. The contract boundary for tests and downstream layout tools is `wiki.site.layout_tokens.build_layout_token_map`. Contract tests assert the context key tree, markup paths, and that every token in packaged layouts is produced by that map. See [Wiki Configuration](Wiki_Configuration.md#layout-tokens).
 
 ## Exceptions
 

--- a/docs/wiki/Wiki_Programmatic_API.md
+++ b/docs/wiki/Wiki_Programmatic_API.md
@@ -130,9 +130,9 @@ print(result.written_paths)
 
 Interactive `wiki init` still owns prompts, `--git`, and preflight guards in the CLI.
 
-## Layout token contract
+## Layout slot contract
 
-Page layouts substitute `%wiki.*%` tokens. `build_layout_context` validates a typed `LayoutContext` (internal schema in `wiki.schemas.layout`) before markup and token substitution. The contract boundary for tests and downstream layout tools is `wiki.site.layout_tokens.build_layout_token_map`. Contract tests assert the context key tree, markup paths, and that every token in packaged layouts is produced by that map. See [Wiki Configuration](Wiki_Configuration.md#layout-tokens).
+Page layouts substitute `%wiki.*%` slots. `build_layout_context` validates a typed `LayoutContext` (internal schema in `wiki.schemas.layout`) before markup and slot substitution. The contract boundary for tests and downstream layout tools is `wiki.site.layout_tokens.build_layout_token_map`. Contract tests assert the context key tree, markup paths, and that every slot in packaged layouts is produced by that map. See [Wiki Configuration](Wiki_Configuration.md#layout-slots).
 
 ## Exceptions
 

--- a/docs/wiki/Wiki_Subcommand_build.md
+++ b/docs/wiki/Wiki_Subcommand_build.md
@@ -49,7 +49,7 @@ Each built page embeds compacted JSON-LD plus Turtle, N3, RDF/XML, N-Triples, Tr
 
 ## Wiki page layout
 
-If your [Wiki Configuration](Wiki_Configuration.md#page-layout) sets `site.layout`, every page is rendered through that page layout unless `wazoo:layout` overrides it. The builder substitutes layout tokens (see [Layout tokens](Wiki_Configuration.md#layout-tokens)).
+If your [Wiki Configuration](Wiki_Configuration.md#page-layout) sets `site.layout`, every page is rendered through that page layout unless `wazoo:layout` overrides it. The builder substitutes layout slots (see [Layout slots](Wiki_Configuration.md#layout-slots)).
 
 If the configured page layout file is missing, the packaged `index.html` fallback is used silently.
 

--- a/src/wiki/schemas/__init__.py
+++ b/src/wiki/schemas/__init__.py
@@ -2,6 +2,17 @@
 
 from .domain import BrokenLink, BrokenLinkFix, LinkOpportunity, OutputEntry, PageRoute
 from .init import DEFAULT_INIT_LAYOUT, InitOptions
+from .layout import (
+    LAYOUT_MARKUP_PATHS,
+    LAYOUT_RAW_JSON_PATHS,
+    LayoutContext,
+    PageLayoutContext,
+    PageLayoutPart,
+    PageMetadataContext,
+    PageNavContext,
+    SiteLayoutContext,
+    WikiLayoutContext,
+)
 from .metadata import METADATA_VIEWS, MetadataView
 from .reports import (
     AuditReport,
@@ -43,18 +54,27 @@ __all__ = [
     "GraphConfig",
     "InfoboxRow",
     "InitOptions",
+    "LAYOUT_MARKUP_PATHS",
+    "LAYOUT_RAW_JSON_PATHS",
+    "LayoutContext",
     "LinkConfig",
     "LinkOpportunity",
     "LintConfig",
+    "PageLayoutContext",
+    "PageLayoutPart",
+    "PageMetadataContext",
+    "PageNavContext",
     "METADATA_VIEWS",
     "MetadataView",
     "OutputEntry",
     "PageRoute",
     "Severity",
     "SiteConfig",
+    "SiteLayoutContext",
     "SparqlServiceConfig",
     "TocItem",
     "WikiConfig",
+    "WikiLayoutContext",
     "VirtualPage",
     "Config",
     "DEFAULT_INIT_LAYOUT",

--- a/src/wiki/schemas/layout.py
+++ b/src/wiki/schemas/layout.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
-# Leaf paths wrapped as Markup before token substitution (shared by layout_context + layout_tokens).
+# Leaf paths wrapped as Markup before slot substitution (shared by layout_context + layout_tokens).
 LAYOUT_MARKUP_PATHS: frozenset[tuple[str, ...]] = frozenset(
     {
         ("page", "content"),

--- a/src/wiki/schemas/layout.py
+++ b/src/wiki/schemas/layout.py
@@ -1,0 +1,93 @@
+"""Typed layout template context models for page shell rendering."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Leaf paths wrapped as Markup before token substitution (shared by layout_context + layout_tokens).
+LAYOUT_MARKUP_PATHS: frozenset[tuple[str, ...]] = frozenset(
+    {
+        ("page", "content"),
+        ("page", "layout", "label"),
+        ("page", "type_label"),
+        ("page", "nav", "infobox"),
+        ("page", "nav", "toc"),
+        ("page", "nav", "backlinks"),
+        ("page", "nav", "categories"),
+        ("page", "nav", "sidebar"),
+        ("page", "metadata", "tool"),
+        ("page", "metadata", "tab"),
+        ("page", "metadata", "pane"),
+        ("wiki", "pages_json"),
+    }
+)
+
+# JSON string leaves emitted without HTML escaping in the token map.
+LAYOUT_RAW_JSON_PATHS: frozenset[tuple[str, ...]] = frozenset(
+    {
+        ("wiki", "pages_json"),
+        ("page", "slug_json"),
+    }
+)
+
+
+class SiteLayoutContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    base_url: str
+    url_style: str
+
+
+class PageLayoutPart(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    class_: str = Field(default="", alias="class")
+    label: str = ""
+
+
+class PageNavContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    infobox: str = ""
+    toc: str = ""
+    backlinks: str = ""
+    categories: str = ""
+    sidebar: str = ""
+
+
+class PageMetadataContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tool: str = ""
+    tab: str = ""
+    pane: str = ""
+
+
+class PageLayoutContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    kind: str
+    body_class: str
+    content: str
+    source: str = ""
+    slug: str = ""
+    slug_json: str = ""
+    layout: PageLayoutPart = Field(default_factory=PageLayoutPart)
+    type_label: str = ""
+    nav: PageNavContext = Field(default_factory=PageNavContext)
+    metadata: PageMetadataContext = Field(default_factory=PageMetadataContext)
+
+
+class WikiLayoutContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pages_json: str
+
+
+class LayoutContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    site: SiteLayoutContext
+    page: PageLayoutContext
+    wiki: WikiLayoutContext

--- a/src/wiki/site/layout_context.py
+++ b/src/wiki/site/layout_context.py
@@ -9,26 +9,13 @@ from typing import Any
 from markupsafe import Markup
 
 from ..config import DEFAULT_URL_STYLE
+from ..schemas.layout import LAYOUT_MARKUP_PATHS, LayoutContext
 from ..schemas.site import VirtualPage, WikiSite
 
 _DEFAULT_LOGO_THEME = ("#3b82f6", "#1d4ed8", "#93c5fd")
 
-LAYOUT_CONTEXT_MARKUP_PATHS: frozenset[tuple[str, ...]] = frozenset(
-    {
-        ("page", "content"),
-        ("page", "layout", "label"),
-        ("page", "type_label"),
-        ("page", "nav", "infobox"),
-        ("page", "nav", "toc"),
-        ("page", "nav", "backlinks"),
-        ("page", "nav", "categories"),
-        ("page", "nav", "sidebar"),
-        ("page", "metadata", "tool"),
-        ("page", "metadata", "tab"),
-        ("page", "metadata", "pane"),
-        ("wiki", "pages_json"),
-    }
-)
+# Backward-compatible alias for tests and internal callers.
+LAYOUT_CONTEXT_MARKUP_PATHS = LAYOUT_MARKUP_PATHS
 
 
 def _parse_hex_color(value: str) -> tuple[int, int, int]:
@@ -95,7 +82,7 @@ def _site_context(*, base_url: str, url_style: str) -> dict[str, Any]:
 
 
 def _apply_markup(context: dict[str, Any]) -> dict[str, Any]:
-    for path in LAYOUT_CONTEXT_MARKUP_PATHS:
+    for path in LAYOUT_MARKUP_PATHS:
         node: Any = context
         for key in path[:-1]:
             node = node[key]
@@ -168,4 +155,5 @@ def build_layout_context(
             "pages_json": pages_json,
         },
     }
+    LayoutContext.model_validate(raw)
     return _apply_markup(raw)

--- a/src/wiki/site/layout_template.py
+++ b/src/wiki/site/layout_template.py
@@ -1,4 +1,4 @@
-"""Layout token substitution for wiki page layout files."""
+"""Layout slot substitution for wiki page layout files."""
 
 from __future__ import annotations
 

--- a/src/wiki/site/layout_tokens.py
+++ b/src/wiki/site/layout_tokens.py
@@ -10,35 +10,14 @@ from typing import Any
 
 from markupsafe import Markup
 
+from ..schemas.layout import LAYOUT_MARKUP_PATHS, LAYOUT_RAW_JSON_PATHS
+
 PACKAGED_MINIMAL_LAYOUT = "index.html"
 PACKAGED_WIKIPEDIA_LAYOUT = "wikipedia.html"
 
 _TOKEN_PATTERN = re.compile(r"%wiki\.[a-z0-9_.]+%", re.IGNORECASE)
 
-# Context leaf paths: True = inject as Markup/raw HTML, False = HTML-escape text.
-_MARKUP_LEAVES: frozenset[tuple[str, ...]] = frozenset(
-    {
-        ("page", "content"),
-        ("page", "layout", "label"),
-        ("page", "type_label"),
-        ("page", "nav", "infobox"),
-        ("page", "nav", "toc"),
-        ("page", "nav", "backlinks"),
-        ("page", "nav", "categories"),
-        ("page", "nav", "sidebar"),
-        ("page", "metadata", "tool"),
-        ("page", "metadata", "tab"),
-        ("page", "metadata", "pane"),
-        ("wiki", "pages_json"),
-    }
-)
-
-_RAW_JSON_LEAVES: frozenset[tuple[str, ...]] = frozenset(
-    {
-        ("wiki", "pages_json"),
-        ("page", "slug_json"),
-    }
-)
+_RAW_JSON_LEAVES = LAYOUT_RAW_JSON_PATHS
 
 
 def _context_leaf(context: dict[str, Any], path: tuple[str, ...]) -> Any:
@@ -53,7 +32,7 @@ def _format_leaf(value: Any, *, path: tuple[str, ...]) -> str:
         return ""
     if path in _RAW_JSON_LEAVES:
         return str(value)
-    if path in _MARKUP_LEAVES or isinstance(value, Markup):
+    if path in LAYOUT_MARKUP_PATHS or isinstance(value, Markup):
         return str(value)
     return html_module.escape(str(value))
 

--- a/src/wiki/site/layout_tokens.py
+++ b/src/wiki/site/layout_tokens.py
@@ -44,7 +44,7 @@ def build_head_markup(context: dict[str, Any]) -> str:
 
 
 def build_layout_token_map(context: dict[str, Any]) -> dict[str, str]:
-    """Public alias for layout token contract boundary."""
+    """Public alias for layout slot contract boundary."""
     return build_token_map(context)
 
 

--- a/tests/test_layout_context.py
+++ b/tests/test_layout_context.py
@@ -39,8 +39,6 @@ class TestLayoutContext(unittest.TestCase):
             self.assertEqual(context["site"]["base_url"], "/wiki")
             self.assertEqual(context["page"]["title"], "All Pages")
             self.assertEqual(context["page"]["kind"], "index")
-            self.assertNotIn("inline_css", context["site"])
-            self.assertNotIn("manifest", context["site"])
             self.assertIsInstance(context["wiki"]["pages_json"], Markup)
 
     def test_article_context_includes_slug(self) -> None:
@@ -69,9 +67,8 @@ class TestLayoutContext(unittest.TestCase):
             self.assertEqual(context["page"]["slug"], "Bob")
             self.assertIn("Bob", context["page"]["slug_json"])
 
-    def test_markup_paths_registered(self) -> None:
+    def test_markup_paths_include_content(self) -> None:
         self.assertIn(("page", "content"), LAYOUT_CONTEXT_MARKUP_PATHS)
-        self.assertNotIn(("site", "manifest", "json"), LAYOUT_CONTEXT_MARKUP_PATHS)
 
 
 if __name__ == "__main__":

--- a/tests/test_layout_contract.py
+++ b/tests/test_layout_contract.py
@@ -1,18 +1,62 @@
-"""Layout token contract tests (#106 alignment)."""
+"""Layout token and context contract tests (#106 alignment)."""
+
+from __future__ import annotations
 
 import re
 import unittest
 from pathlib import Path
+from typing import Any
+
+from markupsafe import Markup
 
 from wiki.init_scaffold import load_packaged_official_layout
+from wiki.schemas.layout import LAYOUT_MARKUP_PATHS, LayoutContext
 from wiki.schemas.site import VirtualPage, WikiSite
 from wiki.site.layout_context import build_layout_context
-from wiki.site.layout_tokens import build_layout_token_map, unknown_tokens
+from wiki.site.layout_tokens import (
+    build_layout_token_map,
+    build_token_map,
+    unknown_tokens,
+)
 
 _TOKEN_PATTERN = re.compile(r"%wiki\.[a-z0-9_.]+%", re.IGNORECASE)
 
+_FORBIDDEN_TOP_LEVEL_KEYS = frozenset(
+    {
+        "page_title",
+        "site_manifest_name",
+        "site_manifest_theme_color",
+        "manifest_json",
+    }
+)
 
-def _sample_context() -> dict:
+# Token spellings → context leaf paths (%wiki.head% is synthesized; not a context leaf).
+_TOKEN_CONTEXT_PATHS: dict[str, tuple[str, ...]] = {
+    "%wiki.base_url%": ("site", "base_url"),
+    "%wiki.assets%": ("site", "base_url"),
+    "%wiki.site.url_style%": ("site", "url_style"),
+    "%wiki.page.title%": ("page", "title"),
+    "%wiki.page.content%": ("page", "content"),
+    "%wiki.page.source%": ("page", "source"),
+    "%wiki.page.body_class%": ("page", "body_class"),
+    "%wiki.page.kind%": ("page", "kind"),
+    "%wiki.page.type_label%": ("page", "type_label"),
+    "%wiki.page.layout.class%": ("page", "layout", "class"),
+    "%wiki.page.layout.label%": ("page", "layout", "label"),
+    "%wiki.nav.infobox%": ("page", "nav", "infobox"),
+    "%wiki.nav.toc%": ("page", "nav", "toc"),
+    "%wiki.nav.backlinks%": ("page", "nav", "backlinks"),
+    "%wiki.nav.categories%": ("page", "nav", "categories"),
+    "%wiki.nav.sidebar%": ("page", "nav", "sidebar"),
+    "%wiki.page.metadata.tool%": ("page", "metadata", "tool"),
+    "%wiki.page.metadata.tab%": ("page", "metadata", "tab"),
+    "%wiki.page.metadata.pane%": ("page", "metadata", "pane"),
+    "%wiki.wiki.pages_json%": ("wiki", "pages_json"),
+    "%wiki.page.slug_json%": ("page", "slug_json"),
+}
+
+
+def _sample_context() -> dict[str, Any]:
     site = WikiSite(
         pages=[
             VirtualPage(
@@ -33,6 +77,8 @@ def _sample_context() -> dict:
         body_class="wiki-page",
         kind="article",
         slug="Sample",
+        layout_label="<span>custom</span>",
+        type_label="<span>Article</span>",
         nav_infobox="<div>infobox</div>",
         nav_toc="<nav>toc</nav>",
         nav_backlinks="<ul>back</ul>",
@@ -42,6 +88,19 @@ def _sample_context() -> dict:
         metadata_tab="<div>tab</div>",
         metadata_pane="<div>pane</div>",
     )
+
+
+def _key_tree(value: Any) -> object:
+    if isinstance(value, dict):
+        return {key: _key_tree(child) for key, child in sorted(value.items())}
+    return None
+
+
+def _context_leaf(context: dict[str, Any], path: tuple[str, ...]) -> Any:
+    node: Any = context
+    for key in path:
+        node = node[key]
+    return node
 
 
 class TestLayoutContract(unittest.TestCase):
@@ -60,3 +119,54 @@ class TestLayoutContract(unittest.TestCase):
         found = sorted(set(_TOKEN_PATTERN.findall(template)))
         missing = [token for token in found if token not in tokens]
         self.assertEqual(missing, [])
+
+    def test_context_key_tree_matches_layout_model(self) -> None:
+        context = _sample_context()
+        expected = _key_tree(
+            LayoutContext.model_validate(_unwrap_markup(context)).model_dump(by_alias=True)
+        )
+        actual = _key_tree(context)
+        self.assertEqual(actual, expected)
+
+    def test_forbidden_legacy_keys_absent(self) -> None:
+        context = _sample_context()
+        site = context.get("site", {})
+        self.assertNotIn("manifest", site)
+        self.assertNotIn("inline_css", site)
+        for key in _FORBIDDEN_TOP_LEVEL_KEYS:
+            self.assertNotIn(key, context)
+
+    def test_markup_paths_shared_registry(self) -> None:
+        from wiki.site import layout_context as layout_context_module
+        from wiki.site import layout_tokens as layout_tokens_module
+
+        self.assertIs(layout_context_module.LAYOUT_CONTEXT_MARKUP_PATHS, LAYOUT_MARKUP_PATHS)
+        self.assertEqual(len(LAYOUT_MARKUP_PATHS), 12)
+
+        for path in LAYOUT_MARKUP_PATHS:
+            context = _sample_context()
+            value = _context_leaf(context, path)
+            self.assertIsInstance(value, Markup, msg=f"expected Markup at {path}")
+            formatted = layout_tokens_module._format_leaf(value, path=path)
+            self.assertEqual(formatted, str(value), msg=f"markup path should pass through at {path}")
+
+    def test_token_map_covers_documented_context_paths(self) -> None:
+        context = _sample_context()
+        tokens = build_token_map(context)
+        for token, path in _TOKEN_CONTEXT_PATHS.items():
+            self.assertIn(token, tokens)
+            _context_leaf(context, path)
+        self.assertIn("%wiki.head%", tokens)
+
+
+def _unwrap_markup(context: dict[str, Any]) -> dict[str, Any]:
+    """Convert Markup leaves to plain strings for Pydantic validation."""
+    if isinstance(context, Markup):
+        return str(context)
+    if not isinstance(context, dict):
+        return context
+    return {key: _unwrap_markup(value) for key, value in context.items()}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_layout_contract.py
+++ b/tests/test_layout_contract.py
@@ -1,4 +1,4 @@
-"""Layout token and context contract tests (#106 alignment)."""
+"""Layout slot and context contract tests (#106 alignment)."""
 
 from __future__ import annotations
 
@@ -108,9 +108,9 @@ class TestLayoutContract(unittest.TestCase):
         template = load_packaged_official_layout("wikipedia")
         tokens = build_layout_token_map(_sample_context())
         unknown = unknown_tokens(template, tokens)
-        self.assertEqual(unknown, [], msg=f"Unknown layout tokens: {unknown}")
+        self.assertEqual(unknown, [], msg=f"Unknown layout slots: {unknown}")
 
-    def test_docs_wikipedia_layout_tokens_are_known(self) -> None:
+    def test_docs_wikipedia_layout_slots_are_known(self) -> None:
         docs_layout = Path(__file__).resolve().parents[1] / "docs" / "layouts" / "wikipedia.html"
         if not docs_layout.is_file():
             self.skipTest("docs layout not present")

--- a/tests/test_layout_tokens.py
+++ b/tests/test_layout_tokens.py
@@ -1,4 +1,4 @@
-"""Tests for layout token substitution."""
+"""Tests for layout slot substitution."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Add typed `LayoutContext` Pydantic models with shared `LAYOUT_MARKUP_PATHS` / `LAYOUT_RAW_JSON_PATHS` registries; validate in `build_layout_context` before markup is applied.
- Expand layout contract tests (key tree, forbidden legacy keys, markup registry parity, token coverage).
- Document tweak-comment branding in Getting Started, fix CHANGELOG 0.1.14 drift, and note internal layout validation in the programmatic API docs.

Closes #106
Closes #107

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run python -m unittest discover -s tests -q`
- [x] `wiki -c docs/wiki.yml fmt`
- [x] `wiki -c docs/wiki.yml fmt --check`
- [x] `wiki -c docs/wiki.yml lint --strict`
- [x] `wiki -c docs/wiki.yml check --strict`
