### PR TITLE
docs: clarify Wiki CLI scope boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,22 @@ Use Markdown links for all internal and external URLs.
 
 ## Developer notes
 
+### Scope boundaries
+
+Wiki CLI aims to be a one-stop semantic Markdown wiki toolchain, similar in spirit to Go/Deno-style batteries-included tooling for its domain. Keep core scope focused on trust (`check`, `lint`, `fmt`), intelligence (`query`, `render`, `export`), and publish/preview (`build`, `serve`) workflows: graph construction, SHACL and JSON Schema validation, RDF/JSON-LD export, SPARQL query/render workflows, static HTML build, local preview, and CI-friendly checks.
+
+Before adding a subcommand, ask whether it strengthens the semantic Markdown wiki toolchain. If it belongs to validation, graph construction, RDF/JSON-LD/SPARQL interoperability, static publishing, local preview, or CI checks, it may belong in Wiki CLI. If it is generic authoring, Obsidian app control, vault search, daily notes, task/tag dashboards, sync, history, PDF/print conversion, or generic file/process automation, use or document existing primitives instead.
+
+Do not add Wiki CLI features that duplicate existing primitives unless there is a clear semantic-wiki reason:
+
+- Use Obsidian CLI or Obsidian plugins for app/vault authoring workflows: daily notes, append/read current note, templates, task lists, tag dashboards, vault search, plugin reload, DevTools, screenshots, DOM/CSS inspection, and sync.
+- Use shell tools for generic file operations, printing, process composition, text filtering, and one-off automation.
+- Use Git for history, diff, branching, sync, and collaboration workflows.
+- Use Pandoc or dedicated document tools for PDF/print/export formats outside Wiki CLI's semantic RDF/static HTML outputs.
+- Use static-site templates or downstream apps for custom publish surfaces; Wiki CLI owns the artifact contract, not every frontend.
+
+Compatibility is allowed at the edges. Wiki CLI may parse, validate, preserve, and render Obsidian-authored Markdown, including wikilinks, but should not become an Obsidian automation layer. Prefer standard Markdown links in this docs wiki.
+
 ### Running validations
 Before submitting commits, format the wiki and verify against the active schema and guidelines. In this repo, mirror CI:
 
@@ -65,7 +81,7 @@ wiki -c docs/wiki.yml check -v
 wiki -c docs/wiki.yml lint -v
 ```
 
-`wiki link` is **report-only by default** — it lists missing wikilink opportunities but does not write files or fail the build. Run it manually before commit (`wiki link --apply` to insert suggestions); CI gates link hygiene only if `wiki link --check` is wired in.
+`wiki link` is **report-only by default** — it lists missing wikilink opportunities but does not write files or fail the build. `wiki link --fix-broken` supports link hygiene for publishable wikis. `wiki link --apply` is optional wiki-gardening: useful when desired, but not required for validation, publishing, or Obsidian compatibility. CI gates link hygiene only if `wiki link --check` is wired in.
 
 For library-level validation and build in Python (without subprocess), see [Wiki Python Library](docs/wiki/Wiki_Programmatic_API.md). Unit tests target `Wiki` class methods under `tests/`.
 

--- a/docs/wiki/Design_Philosophies.md
+++ b/docs/wiki/Design_Philosophies.md
@@ -59,7 +59,7 @@ Subcommands are top-level (`wiki check`, not `wiki wiki check`). Global options 
 
 ## Userland over platform lock-in
 
-Printing, PDF, and heavy formatting stay in your shell (`pr`, `lp`, Pandoc, etc.). The wiki tool focuses on graph construction, validation, and site generation. [Wiki CLI templates](Wiki_CLI.md#ecosystem-templates) and editor integrations stay at the edges; core scope is the semantic layer — see [Wiki CLI](Wiki_CLI.md#toolchain-vs-authoring-surface).
+Printing, PDF, and heavy formatting stay in your shell (`pr`, `lp`, Pandoc, etc.). Daily notes, note templates, vault search, task/tag dashboards, plugin reloads, DevTools, screenshots, DOM/CSS inspection, and sync belong to Obsidian CLI or Obsidian plugins. History and collaboration belong to Git. The wiki tool focuses on graph construction, validation, and site generation. [Wiki CLI templates](Wiki_CLI.md#ecosystem-templates) and editor integrations stay at the edges; core scope is the semantic layer — see [Wiki CLI](Wiki_CLI.md#toolchain-vs-authoring-surface).
 
 ## Related
 

--- a/docs/wiki/Obsidian_Integration.md
+++ b/docs/wiki/Obsidian_Integration.md
@@ -20,6 +20,18 @@ Use the community **Shell Commands** plugin to run `wiki` against your wiki root
 
 Point the plugin’s working directory at the folder containing `wiki.yaml`.
 
+## Boundary with Obsidian CLI
+
+### Use Obsidian CLI for
+
+Use Obsidian CLI for Obsidian-native authoring and app automation: daily notes, creating or appending notes, reading the current file, vault search, task and tag workflows, plugin reloads, DevTools, screenshots, DOM/CSS inspection, and Obsidian Sync/headless sync.
+
+### Use Wiki CLI for
+
+Use Wiki CLI for semantic wiki workflows: SHACL and JSON Schema validation, route-safe publishing checks, RDF/JSON-LD export, SPARQL queries, inline SPARQL render blocks, static HTML builds, local preview, and the optional read-only SPARQL endpoint.
+
+Wiki CLI remains compatible with Obsidian-authored Markdown, but it should not duplicate Obsidian CLI's app-control surface.
+
 ## Internal links
 
 This wiki uses Markdown links (`Page_Name.md`). [Obsidian](Obsidian.md) wikis may use wikilinks (`[[Page]]`); the [Wiki CLI](Wiki_CLI.md) still resolves them when filenames follow wiki route rules, and `lint.broken_links` validates that each link resolves.

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -38,12 +38,16 @@ See [Getting Started](Getting_Started.md) for a full walkthrough.
 
 Adoption path: `wiki init` → `wiki check` → `wiki serve`, then add `lint`, `query`, `render`, and `build` as the wiki matures.
 
+Wiki CLI is intentionally batteries-included for semantic Markdown wikis: validation, formatting, querying, rendering, exporting, building, and local preview belong together. The boundary is not "minimal CLI only"; the boundary is "semantic wiki toolchain, not editor/app automation."
+
 ## What wiki is not
 
 - The **primary editor** or daily note-taking surface
 - A **replacement** for Obsidian, Logseq, or another wiki UI
 - A **note app clone**, CMS, or authenticated multi-user web product
 - An **auth layer** — local-first CLI and static publish; see deferred scope in [Wiki CLI templates](#ecosystem-templates) below
+- A vault automation CLI for daily notes, note append/read workflows, task lists, tags, plugin development, or Obsidian app control
+- A replacement for shell tools, Git, Pandoc, or editor-native commands
 
 Humans and agents keep writing where they already write. `wiki` makes that content **trustworthy** (SHACL, JSON Schema, and conventions), **searchable** (SPARQL + OWL-RL), and **publishable** (static HTML, JSON-LD, Turtle, optional read-only SPARQL over `wiki serve`).
 
@@ -58,11 +62,16 @@ Rather than owning your editor or data store, **Wiki** functions as a **read-onl
 
 | Layer                   | Role                                                                   | Examples                                                    |
 | ----------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------- |
-| Authoring surface       | Create and edit Markdown                                               | Obsidian, agent-driven LLM wiki, VS Code, any editor        |
+| Authoring surface       | Create, edit, search, and organize notes                               | Obsidian CLI, Obsidian, VS Code, shell                      |
 | Wiki CLI semantic layer | Compile wiki → RDF graph; check, lint, fmt; query; render; build/serve | `wiki check`, `wiki query`, `wiki build`                    |
-| Outputs                 | Deployable artifacts                                                   | GitHub Pages HTML, export files, `/api/sparql` when enabled |
+| Existing primitives     | History, sync, print/PDF, and generic text processing                  | Git, shell tools, Pandoc                                    |
+| Outputs                 | Deployable semantic artifacts                                          | GitHub Pages HTML, export files, `/api/sparql` when enabled |
 
 This separation is intentional: the strongest differentiator is the **machine layer** (SHACL, OWL-RL, SPARQL, typed HTML) that most note apps do not provide. **Wiki** avoids competing with editor-centric tools while making incremental adoption obvious.
+
+When an existing primitive already owns a workflow, Wiki CLI integrates rather than replaces it. Obsidian CLI owns Obsidian app/vault automation; Git owns history and collaboration; shell tools own generic file/process composition; Pandoc and document tools own non-semantic document conversion.
+
+`wiki link --fix-broken` supports link hygiene for publishable wikis. `wiki link --apply` is optional wiki-gardening: useful when desired, but not required for validation, publishing, or Obsidian compatibility.
 
 ## Interop-first workflows
 
@@ -118,7 +127,7 @@ Do not use these in new prose: `sparql-service-template` (→ `wiki-yasgui-templ
 
 - **Check** — SHACL and JSON Schema integrity, route safety, layout frontmatter ([Wiki Subcommand check](Wiki_Subcommand_check.md))
 - **Lint** — broken links, filename pattern, and heading conventions ([Wiki Subcommand lint](Wiki_Subcommand_lint.md))
-- **Link** — suggest missing wikilinks and repair broken internal links ([Wiki Subcommand link](Wiki_Subcommand_link.md))
+- **Link** — repair broken internal links and optionally insert suggested links as wiki-gardening ([Wiki Subcommand link](Wiki_Subcommand_link.md))
 - **Fmt** — mdformat for markdown ([Wiki Subcommand fmt](Wiki_Subcommand_fmt.md))
 - **Query** — SPARQL with OWL-RL and optional `--pretty` Rich tables ([Wiki Subcommand query](Wiki_Subcommand_query.md), [Graph Cache](Graph_Cache.md))
 - **Render** — live tables from inline SPARQL ([Wiki Subcommand render](Wiki_Subcommand_render.md))


### PR DESCRIPTION
## Summary
- document Wiki CLI's one-stop semantic Markdown toolchain boundary in AGENTS.md and Wiki_CLI.md
- clarify when to use Obsidian CLI versus Wiki CLI
- reframe wiki link --apply as optional wiki-gardening rather than required publishing flow

Related to #104.

## Validation
- wiki -c docs/wiki.yml fmt --check
- wiki -c docs/wiki.yml lint --strict
- wiki -c docs/wiki.yml check --strict
- wiki -c docs/wiki.yml render --check