### PR TITLE
feat: add --version flag to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `wiki --version` flag prints the installed version ([#132](https://github.com/wazootech/wiki/issues/132)).
 - **Library-first Python API** ([#112](https://github.com/wazootech/wiki/issues/112)) — `Wiki` session, typed `AuditReport` / `Issue` and operation result models, direct `Wiki.build`, `Wiki.init`, `Wiki.link`, `Wiki.render`, `Wiki.export`, and `Wiki.format` methods, curated `wiki.__all__`, and `py.typed`. See [Wiki Programmatic API](docs/wiki/Wiki_Programmatic_API.md).
 - Typed **layout context** models (`LayoutContext`) validated at `build_layout_context` with expanded layout slot contract tests ([#106](https://github.com/wazootech/wiki/issues/106)).
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import click
 
+from . import __version__
 from . import upgrade as upgrade_module
 from .cli_output import exit_audit_report, print_check_messages
 from .errors import BuildError, UpgradeError
@@ -34,6 +35,7 @@ def optional_files_argument(f):
 
 
 @click.group()
+@click.version_option(version=__version__, prog_name="wiki")
 @click.option(
     "--wiki-inputs",
     "wiki_inputs",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from urllib.request import urlopen
 import yaml
 from click.testing import CliRunner
 
+from wiki import __version__
 from wiki.cli import FILE_COMMANDS, main
 from wiki.config import Config
 from wiki.init_scaffold import (
@@ -44,6 +45,12 @@ name: Invalid Page
             self.assertEqual(result_strict.exit_code, 1)
             self.assertIn("Errors:", result_strict.output)
             self.assertIn("spaces are not allowed", result_strict.output)
+
+    def test_cli_version_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--version"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, f"wiki, version {__version__}\n")
 
     def test_cli_lint_reports_filename_pattern(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- `@click.version_option` on the root group so `wiki --version` prints `wiki, version <x>`, sourced from `wiki.__version__`
- CHANGELOG entry under Added

Closes #132

## Test plan

- [x] `wiki --version` prints the installed version, exits 0
- [x] new `test_cli_version_flag` passes
- [x] `ruff check .`