### PR TITLE
fix: support root deployment by dropping base_url path

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -361,7 +361,7 @@ def build(output_dir: Path) -> None:
     config = Config.load(config_path)
     site = build_site(config)
 
-    base_url = config.site.base_url or "/wiki"
+    base_url = config.site.base_url if config.site.base_url is not None else "/wiki"
     url_style = config.site.url_style or "dir"
     base_path = base_url.strip("/")
 

--- a/docs/wiki.yml
+++ b/docs/wiki.yml
@@ -36,7 +36,7 @@ graph:
 site:
   layout: layouts/wikipedia.html
   # URL prefix for built and served pages.
-  base_url: /wiki
+  base_url: ""
   # dir → slug/index.html; file → slug.html
   url_style: dir
 

--- a/src/wiki/init_scaffold.py
+++ b/src/wiki/init_scaffold.py
@@ -98,7 +98,7 @@ def detect_origin_repo(cwd: Path) -> str | None:
 # Init options for this repository's docs/ wiki (parity with docs/wiki.yml).
 DOCS_WIKI_INIT_OPTIONS = InitOptions(
     graph_context_wiki="https://wazootech.github.io/wiki/",
-    site_base_url="/wiki",
+    site_base_url="",
     site_url_style=DEFAULT_URL_STYLE,
     graph_content_predicate="schema:articleBody",
     link_style="standard",

--- a/src/wiki/templates/wiki.yml
+++ b/src/wiki/templates/wiki.yml
@@ -70,7 +70,7 @@ site:
   # layout: custom.html  # layout unset → packaged minimal index layout (see Wiki Configuration → Page layout).
 {% endif %}
   # URL prefix for built and served pages.
-  base_url: {{ site_base_url }}
+  base_url: {{ '""' if site_base_url == "" else site_base_url }}
   # dir → slug/index.html; file → slug.html
   url_style: {{ site_url_style }}
 


### PR DESCRIPTION
Drops base_url in docs/wiki.yml to support root-level deployment at wiki.wazoo.dev, and fixes the docs/build.py fallback logic to prevent overriding an empty base URL string to /wiki.