### PR TITLE
fix: adjust deployment copy and upload paths for empty base URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,14 +62,14 @@ jobs:
 
       - name: Copy API docs into site output
         run: |
-          mkdir -p _site/wiki/assets/api
-          cp -r docs/assets/api/python _site/wiki/assets/api/
-          cp -r docs/assets/api/ts _site/wiki/assets/api/
+          mkdir -p _site/assets/api
+          cp -r docs/assets/api/python _site/assets/api/
+          cp -r docs/assets/api/ts _site/assets/api/
 
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "_site/wiki"
+          path: "_site"
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/wiki/Deploying_to_GitHub_Pages.md
+++ b/docs/wiki/Deploying_to_GitHub_Pages.md
@@ -11,9 +11,9 @@ This repository publishes `docs/wiki/` using `docs/wiki.yml`. The workflow lives
 ## Pipeline
 
 1. `uv sync` — install dependencies
-1. `wiki -c docs/wiki.yml check --strict -v` — SHACL, JSON Schema, routes, layout
-1. `wiki -c docs/wiki.yml build --output-dir _site --site-base-url /wiki` — static HTML
-1. Upload `_site/wiki` as the Pages artifact
+1. `uv run wiki -c docs/wiki.yml check --strict -v` — SHACL, JSON Schema, routes, layout
+1. `uv run python docs/build.py --output-dir _site` — static HTML
+1. Upload `_site` as the Pages artifact
 1. `deploy-pages` — publish
 
 Enable **GitHub Pages → Build and deployment → GitHub Actions** in repository settings.


### PR DESCRIPTION
Adjusts .github/workflows/deploy.yml and docs/wiki/Deploying_to_GitHub_Pages.md to copy API docs to _site/assets/api and upload _site directly, aligning with root-level custom domain deployments.