### PR TITLE
fix: resolve vector-tabs alignment and text-wrapping issues

### DIFF
--- a/docs/assets/wikipedia.css
+++ b/docs/assets/wikipedia.css
@@ -219,6 +219,7 @@ a:hover {
 .vector-tabs {
   display: flex;
   list-style: none;
+  align-items: flex-end;
 }
 
 .vector-tabs li {
@@ -239,6 +240,7 @@ a:hover {
   cursor: pointer;
   transition: all 0.15s ease;
   margin-bottom: -1px;
+  white-space: nowrap;
 }
 
 .vector-tabs li.selected a {


### PR DESCRIPTION
Sets lign-items: flex-end on .vector-tabs and white-space: nowrap on .vector-tabs a to prevent tabs from wrapping to two lines and floating away from the bottom border.