### PR TITLE
fix: only link-resolve CURIEs and URLs in infobox values

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -129,7 +129,11 @@ def _render_metadata_value_parts(value, page, site, base_url, url_style):
     if isinstance(value, (int, float)):
         text = str(value)
         return text, html_module.escape(text)
-    return _render_link_like(str(value), str(value), page, site, base_url, url_style)
+    text = str(value)
+    if is_external_link(text) or ":" in text:
+        return _render_link_like(text, text, page, site, base_url, url_style)
+    escaped = html_module.escape(text)
+    return text, escaped
 
 
 def _infobox_list_item_html(html: str) -> str:


### PR DESCRIPTION
**Problem:** \_render_metadata_value_parts\ passed every string value through \_render_link_like\, resolving it against wiki page routes. Plain text values like \givenName: Gregory\ or \softwareVersion: 0.1.17\ that coincidentally matched a page route were rendered as links.

**Fix:** Only attempt link resolution on strings that look like references — external URLs or values containing \:\ (CURIEs). Plain text values without a colon render as escaped plain text immediately.

**Test:** All 472 existing tests pass.