### PR TITLE
chore: remove stale DOCS_WIKI_INIT_OPTIONS and parity test

### DIFF
--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -478,7 +478,7 @@ Under `lint`, each rule is `error`, `warning`, or `off`:
 
 ## This repository
 
-`docs/wiki.yml` is the dogfood wiki config: the same structure, block order, and Init columns as `wiki init` ([`wiki.yml`](https://github.com/wazootech/wiki/blob/main/src/wiki/templates/wiki.yml)), plus dogfood overrides — `graph.context.wiki` for GitHub Pages and `graph.content_predicate: schema:articleBody` for SPARQL full-text.
+`docs/wiki.yml` is the dogfood wiki config for this repository. It follows the same block order as the packaged scaffold, but with project-specific overrides — `graph.context.wiki` for GitHub Pages and `graph.content_predicate: schema:articleBody` for SPARQL full-text.
 
 ## Related
 

--- a/src/wiki/init_scaffold.py
+++ b/src/wiki/init_scaffold.py
@@ -15,7 +15,6 @@ from .schemas import InitOptions, ScaffoldResult
 from .schemas.wiki_config import DEFAULT_WIKI_BASE, normalize_base_iri
 
 __all__ = [
-    "DOCS_WIKI_INIT_OPTIONS",
     "InitOptions",
     "load_packaged_official_layout",
     "render_wiki_yaml",
@@ -93,17 +92,6 @@ def detect_origin_repo(cwd: Path) -> str | None:
     except ValueError:
         return None
     return f"{owner}/{repo}"
-
-
-# Init options for this repository's docs/ wiki (parity with docs/wiki.yml).
-DOCS_WIKI_INIT_OPTIONS = InitOptions(
-    graph_context_wiki="https://wazootech.github.io/wiki/",
-    site_base_url="",
-    site_url_style=DEFAULT_URL_STYLE,
-    graph_content_predicate="schema:articleBody",
-    link_style="standard",
-    site_layout="layouts/wikipedia.html",
-)
 
 
 def resolve_init_options(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,10 +8,6 @@ from click.testing import CliRunner
 from layout_helpers import write_layout
 from wiki.cli import main
 from wiki.config import Config
-from wiki.init_scaffold import (
-    DOCS_WIKI_INIT_OPTIONS,
-    render_wiki_yaml,
-)
 from wiki.paths import page_output_path
 from wiki.schemas import AuditReport
 from wiki.session import Wiki
@@ -330,18 +326,6 @@ about: wiki:Alice_Theory
             self.assertIn("<title>Page - Wiki CLI</title>", html)
             built_logo = (output_dir / "wiki" / "assets" / "logo.svg").read_text(encoding="utf-8")
             self.assertIn("<text>A</text>", built_logo)
-
-
-    def test_docs_wiki_yml_matches_init_scaffold(self) -> None:
-        repo_root = Path(__file__).resolve().parent.parent
-        docs_yml = repo_root / "docs" / "wiki.yml"
-        expected = render_wiki_yaml(DOCS_WIKI_INIT_OPTIONS)
-        self.assertTrue(docs_yml.is_file(), f"docs/wiki.yml not found at {docs_yml}")
-        self.assertEqual(
-            docs_yml.read_text(encoding="utf-8"),
-            expected,
-            "docs/wiki.yml must match render_wiki_yaml(DOCS_WIKI_INIT_OPTIONS)",
-        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The init scaffold template and \docs/wiki.yml\ are intentionally different — the test enforcing exact parity was a false constraint.

- Removes \	est_docs_wiki_yml_matches_init_scaffold\ from \	est_build.py\
- Removes \DOCS_WIKI_INIT_OPTIONS\ constant from \init_scaffold.py\
- Updates \Wiki_Configuration.md\ to not claim structural parity