### PR TITLE
fix: accept legacy link.style values markdown/obsidian as aliases for standard/wikilink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.18 — 2026-06-28
+
+### Fixed
+
+- `wiki upgrade` no longer fails when `wiki.yml` contains legacy `link.style: markdown` or `link.style: obsidian`. Old values are now accepted and automatically mapped to `standard` and `wikilink` respectively, with a deprecation warning. ([#134](https://github.com/wazootech/wiki/issues/134))
+
 ## 0.1.17 — 2026-06-28
 
 ### Added

--- a/src/wiki/schemas/init.py
+++ b/src/wiki/schemas/init.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 from pydantic import BaseModel, ConfigDict, field_validator
 
-_LINK_STYLES = frozenset({"standard", "wikilink"})
+logger = logging.getLogger(__name__)
+
+_LINK_STYLES = frozenset({"standard", "wikilink", "markdown", "obsidian"})
+_LEGACY_LINK_STYLE_MAP = {"markdown": "standard", "obsidian": "wikilink"}
 _VALID_URL_STYLES = frozenset({"dir", "file"})
 
 
@@ -40,6 +45,15 @@ class InitOptions(BaseModel):
         if not isinstance(value, str):
             raise ValueError(f"expected standard or wikilink, got {value!r}")
         normalized = value.strip().lower()
+        if normalized in _LEGACY_LINK_STYLE_MAP:
+            new_style = _LEGACY_LINK_STYLE_MAP[normalized]
+            logger.warning(
+                "link_style: '%s' is deprecated, use '%s' instead "
+                "(edit wiki.yml link.style and re-run)",
+                normalized,
+                new_style,
+            )
+            return new_style
         if normalized not in _LINK_STYLES:
             raise ValueError(f"expected standard or wikilink, got {value!r}")
         return normalized

--- a/src/wiki/schemas/wiki_config.py
+++ b/src/wiki/schemas/wiki_config.py
@@ -26,7 +26,8 @@ from .rules import CheckConfig, LintConfig
 
 logger = logging.getLogger(__name__)
 
-_LINK_STYLES = frozenset({"standard", "wikilink"})
+_LINK_STYLES = frozenset({"standard", "wikilink", "markdown", "obsidian"})
+_LEGACY_LINK_STYLE_MAP = {"markdown": "standard", "obsidian": "wikilink"}
 DEFAULT_LINK_STYLE = "standard"
 DEFAULT_BASE_URL = "/wiki"
 DEFAULT_URL_STYLE = "dir"
@@ -340,6 +341,15 @@ class LinkConfig(BaseModel):
         if not isinstance(value, str):
             raise ValueError(f"expected standard or wikilink, got {value!r}")
         normalized = value.strip().lower()
+        if normalized in _LEGACY_LINK_STYLE_MAP:
+            new_style = _LEGACY_LINK_STYLE_MAP[normalized]
+            logger.warning(
+                "link.style: '%s' is deprecated, use '%s' instead "
+                "(edit wiki.yml link.style and re-run)",
+                normalized,
+                new_style,
+            )
+            return new_style
         if normalized not in _LINK_STYLES:
             raise ValueError(f"expected standard or wikilink, got {value!r}")
         return normalized

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,13 +192,13 @@ class TestConfig(unittest.TestCase):
         config = Config(link={"style": "wikilink"})
         self.assertEqual(config.link.style, "wikilink")
 
-    def test_Config_rejects_legacy_markdown_link_style(self) -> None:
-        with self.assertRaises(ValidationError):
-            Config(link={"style": "markdown"})
+    def test_Config_accepts_legacy_markdown_link_style(self) -> None:
+        config = Config(link={"style": "markdown"})
+        self.assertEqual(config.link.style, "standard")
 
-    def test_Config_rejects_legacy_obsidian_link_style(self) -> None:
-        with self.assertRaises(ValidationError):
-            Config(link={"style": "obsidian"})
+    def test_Config_accepts_legacy_obsidian_link_style(self) -> None:
+        config = Config(link={"style": "obsidian"})
+        self.assertEqual(config.link.style, "wikilink")
 
     def test_Config_rejects_invalid_link_style(self) -> None:
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
## Summary

Fixes #134 — a catch-22 where \wiki upgrade\ (and any other \wiki\ command) failed at config load time if \wiki.yml\ contained the old \link.style\ values from before the 0.1.16 rename.

Legacy values are now accepted and automatically mapped to the current equivalents with a deprecation warning:

| Legacy | Maps to | 
|--------|---------|
| \link.style: markdown\ | \link.style: standard\ |
| \link.style: obsidian\ | \link.style: wikilink\ |

## Changes

- **\src/wiki/schemas/wiki_config.py\** — Added \markdown\/ \obsidian\ to \_LINK_STYLES\; added \_LEGACY_LINK_STYLE_MAP\; in \LinkConfig._validate_style\, map legacy values with a \logger.warning\ deprecation message
- **\src/wiki/schemas/init.py\** — Same treatment in \InitOptions._validate_link_style\
- **\	ests/test_config.py\** — Updated legacy tests from expecting rejection to asserting correct normalization (\markdown\ → \standard\, \obsidian\ → \wikilink\); \	est_Config_rejects_invalid_link_style\ remains unchanged for truly invalid values
- **\CHANGELOG.md\** — Added 0.1.18 entry

## Testing

All 474 existing tests pass.