### PR TITLE
docs: add SPARQL examples to wiki render page

### DIFF
--- a/docs/wiki/Wiki_Subcommand_render.md
+++ b/docs/wiki/Wiki_Subcommand_render.md
@@ -37,7 +37,123 @@ wiki render --cache
 
 ## Block format
 
-See [Style Guide](Style_Guide.md) for the `sparql:start` / `sparql:end` wrapper and fenced `sparql` code block. Close the start comment before the fence to show the query in built HTML; leave it open and close after the fence (`<!-- sparql:start` … `-->`) to hide the query from published pages while `wiki render` still updates the table.
+See [Style Guide](Style_Guide.md) for the `sparql:start` / `sparql:end` wrapper and fenced `sparql` code block. Close the start comment before the fence to show the query in built HTML. Leave it open and close after the fence to hide the query from published pages while `wiki render` still updates the table.
+
+## Examples
+
+### List all people (visible query)
+
+The default visible block style shows the query in published HTML so readers can see and learn from it.
+
+<!-- sparql:start -->
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <https://schema.org/>
+
+SELECT ?person ?givenName ?familyName WHERE {
+  ?person rdf:type schema:Person .
+  ?person schema:givenName ?givenName .
+  ?person schema:familyName ?familyName .
+}
+ORDER BY ?familyName
+```
+
+| person | givenName | familyName |
+| --- | --- | --- |
+| [Jeff_Kazzee](Jeff_Kazzee.md) | Jeff | Kazzee |
+| https://wiki.example.org/people/Alice_Smith | Alice | Smith |
+<!-- sparql:end -->
+
+### List all software applications (hidden query)
+
+The hidden query style keeps the SPARQL inside an HTML comment — invisible in published pages, but still executed by `wiki render`.
+
+<!-- sparql:start
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <https://schema.org/>
+
+SELECT ?app ?name ?version WHERE {
+  ?app rdf:type schema:SoftwareApplication .
+  ?app schema:name ?name .
+  OPTIONAL { ?app schema:softwareVersion ?version . }
+}
+ORDER BY ?name
+```
+-->
+| app | name | version |
+| --- | --- | --- |
+| [Linked_Markdown](Linked_Markdown.md) | Linked Markdown |  |
+| [Obsidian](Obsidian.md) | Obsidian |  |
+| [Vivary](Vivary.md) | Vivary | 0.1.0 |
+| [Wiki_CLI](Wiki_CLI.md) | Wiki CLI | 0.1.17 |
+<!-- sparql:end -->
+
+### More query patterns
+
+Paste one of these SPARQL queries into a `sparql:start` block on any wiki page and run `wiki render` to see results.
+
+**All TechArticles with headlines and descriptions:**
+
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <https://schema.org/>
+
+SELECT ?headline ?description WHERE {
+  ?doc rdf:type schema:TechArticle .
+  ?doc schema:headline ?headline .
+  OPTIONAL { ?doc schema:description ?description . }
+}
+ORDER BY ?headline
+```
+
+**Full-text search for pages that mention a term in their body:**
+
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <https://schema.org/>
+
+SELECT ?headline WHERE {
+  ?doc rdf:type schema:TechArticle .
+  ?doc schema:headline ?headline .
+  ?doc schema:articleBody ?body .
+  FILTER(CONTAINS(?body, &quot;your-search-term&quot;))
+}
+ORDER BY ?headline
+```
+
+**Backlinks to a target page via body text:**
+
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <https://schema.org/>
+
+SELECT ?headline WHERE {
+  ?doc rdf:type schema:TechArticle .
+  ?doc schema:headline ?headline .
+  ?doc schema:articleBody ?body .
+  FILTER(CONTAINS(?body, &quot;Target_Page&quot;))
+}
+ORDER BY ?headline
+```
+
+Replace `&quot;Target_Page&quot;` with a page filename (without `.md`) to find pages that link to it.
+
+**Recent changes by date (requires date frontmatter):**
+
+Add `dateCreated` or `dateModified` to your page frontmatter with a YAML date (e.g. `dateCreated: 2026-06-28`). The wiki graph automatically types these as `xsd:date`. Then query:
+
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <https://schema.org/>
+
+SELECT ?headline ?created WHERE {
+  ?doc rdf:type schema:TechArticle .
+  ?doc schema:headline ?headline .
+  ?doc schema:dateCreated ?created .
+}
+ORDER BY DESC(?created)
+```
 
 ## Related
 


### PR DESCRIPTION
Closes #152

Adds a new **## Examples** section to \Wiki_Subcommand_render.md\ with:

**Live SPARQL blocks** (updated by \wiki render\):
- **List all people** — visible query block demonstrating \schema:Person\ queries with \givenName\/\amilyName\
- **List all software applications** — hidden query block demonstrating \schema:SoftwareApplication\ with \OPTIONAL\ properties

**Documented query patterns** (copy-paste ready):
- All TechArticles with headlines and descriptions
- Full-text search via \CONTAINS(?body, ...)\ on \schema:articleBody\
- Backlinks to a target page via body text
- Recent changes by date (with instructions for adding \dateCreated\ to frontmatter)

### Verification
- \wiki fmt --check\ ✓
- \wiki lint --strict\ ✓
- \wiki check --strict\ ✓
- \wiki render --check\ ✓
- \uff check .\ ✓