### PR TITLE
feat: wiki.yml + wiki.lock source resolution (Phase 1 of #148)

### DIFF
--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -660,6 +660,55 @@ def fmt(wiki: Wiki, files: tuple[Path, ...], check: bool, verbose: bool) -> None
         click.echo(f"Format complete. Reformatted {report.formatted_count} files.")
 
 
+@main.group()
+def source() -> None:
+    """Manage external data sources (fetch, lock, status)."""
+
+
+@source.command("update")
+@click.pass_obj
+def source_update(wiki: Wiki) -> None:
+    """Fetch and lock all declared sources."""
+    from .sources import update as update_sources
+
+    try:
+        lockfile = update_sources(wiki.config)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    count = len(lockfile.sources)
+    click.echo(f"Locked {count} source{'s' if count != 1 else ''}.")
+    for name, locked in lockfile.sources.items():
+        click.echo(f"  {name}: {locked.resolved_ref[:12]} ({locked.fetched_at})")
+
+
+@source.command("status")
+@click.pass_obj
+def source_status(wiki: Wiki) -> None:
+    """Show the current status of each declared source."""
+    from .sources import status as source_status_fn
+
+    results = source_status_fn(wiki.config)
+    if not results:
+        click.echo("No sources declared.")
+        return
+
+    for entry in results:
+        ref = entry["declared_ref"] or "HEAD (default)"
+        locked = entry["locked_ref"] or "-"
+        state = "locked" if entry["is_pinned"] else "unlocked"
+        if entry["is_dirty"]:
+            state = "dirty (run wiki source update)"
+        elif not entry["cached"]:
+            state = "not cached (run wiki source update)"
+        click.echo(f"{entry['name']} ({entry['type']})")
+        click.echo(f"  url:    {entry['url']}")
+        click.echo(f"  ref:    {ref}")
+        click.echo(f"  locked: {locked}")
+        click.echo(f"  state:  {state}")
+        click.echo()
+
+
 @main.command()
 @click.option("-c", "--check", "check_only", is_flag=True, help="Check for updates without upgrading.")
 @click.option("-y", "--yes", "auto_yes", is_flag=True, help="Skip confirmation prompt and upgrade immediately.")

--- a/src/wiki/schemas/__init__.py
+++ b/src/wiki/schemas/__init__.py
@@ -24,6 +24,7 @@ from .reports import (
 )
 from .rules import CheckConfig, LintConfig, Severity, coerce_severity
 from .site import TocItem, VirtualPage, WikiSite
+from .sources import LOCKFILE_FILENAME, LOCKFILE_VERSION, LockedSource, Lockfile, SourceConfig
 from .wiki_config import (
     Config,
     FmtConfig,
@@ -59,6 +60,10 @@ __all__ = [
     "LinkConfig",
     "LinkOpportunity",
     "LintConfig",
+    "LOCKFILE_FILENAME",
+    "LOCKFILE_VERSION",
+    "LockedSource",
+    "Lockfile",
     "PageLayoutContext",
     "METADATA_VIEWS",
     "MetadataView",
@@ -67,6 +72,7 @@ __all__ = [
     "Severity",
     "SiteConfig",
     "SiteLayoutContext",
+    "SourceConfig",
     "SparqlServiceConfig",
     "TocItem",
     "WikiConfig",

--- a/src/wiki/schemas/sources.py
+++ b/src/wiki/schemas/sources.py
@@ -1,0 +1,72 @@
+"""Pydantic models for wiki source declarations and lockfiles."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+LOCKFILE_VERSION = 1
+LOCKFILE_FILENAME = "wiki.lock"
+
+
+class SourceConfig(BaseModel):
+    """A single external source declared in wiki.yml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: Literal["git"]
+    url: str
+    ref: str | None = None
+    path: str | None = None
+    description: str | None = None
+
+
+class LockedSource(BaseModel):
+    """A pinned source entry in wiki.lock."""
+
+    url: str
+    resolved_ref: str = ""
+    ref: str | None = None
+    path: str | None = None
+    content_hash: str | None = None
+    fetched_at: str = ""
+
+
+class Lockfile(BaseModel):
+    """Machine-authored lockfile recording pinned source state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = LOCKFILE_VERSION
+    sources: dict[str, LockedSource] = Field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path) -> Lockfile:
+        import json
+
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return cls.model_validate(data)
+        except Exception:
+            return cls()
+
+    def save(self, path: Path) -> None:
+        import json
+
+        path.write_text(
+            json.dumps(
+                self.model_dump(mode="json"),
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+    def timestamp(self) -> str:
+        return datetime.now(timezone.utc).isoformat()

--- a/src/wiki/schemas/wiki_config.py
+++ b/src/wiki/schemas/wiki_config.py
@@ -23,6 +23,7 @@ from pydantic import (
 
 from ..context import Context
 from .rules import CheckConfig, LintConfig
+from .sources import SourceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ _BLOCK_LABELS = {
     "link": "link",
     "check": "check",
     "lint": "lint",
+    "sources": "sources",
     "sparql_service": "sparql_service",
 }
 
@@ -393,9 +395,38 @@ class Config(BaseModel):
     link: LinkConfig = Field(default_factory=LinkConfig)
     check: CheckConfig = Field(default_factory=CheckConfig)
     lint: LintConfig = Field(default_factory=LintConfig)
+    sources: list[SourceConfig] = Field(default_factory=list)
     fmt: FmtConfig | dict[str, Any] | str | Path | None = None
     sparql_service: SparqlServiceConfig = Field(default_factory=SparqlServiceConfig)
     config_root: Path = Field(default_factory=Path.cwd)
+
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _validate_sources(cls, value: object) -> list[SourceConfig]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            seen: set[str] = set()
+            for item in value:
+                if isinstance(item, dict) and "name" in item:
+                    name = item["name"]
+                    if name in seen:
+                        raise ValueError(f"Duplicate source name: {name!r}")
+                    seen.add(name)
+            return [SourceConfig(**item) if isinstance(item, dict) else item for item in value]
+        if isinstance(value, dict):
+            seen = set()
+            result = []
+            for name, source_def in value.items():
+                if name in seen:
+                    raise ValueError(f"Duplicate source name: {name!r}")
+                seen.add(name)
+                if isinstance(source_def, dict):
+                    result.append(SourceConfig(name=name, **source_def))
+                else:
+                    result.append(SourceConfig(name=name))
+            return result
+        raise ValueError("sources must be a list or mapping")
 
     @field_validator("fmt", mode="before")
     @classmethod

--- a/src/wiki/session.py
+++ b/src/wiki/session.py
@@ -42,6 +42,7 @@ from .schemas import (
     RenderReport,
     ScaffoldResult,
 )
+from .sources import resolve as resolve_sources
 
 _RAW_FORMATS = frozenset({"turtle", "xml", "n3", "nt", "trig", "nquads"})
 
@@ -88,6 +89,12 @@ class Wiki:
                 Path(entry) if Path(entry).is_absolute() else config.config_root / entry
                 for entry in wiki_inputs
             ]
+        resolved = resolve_sources(config)
+        if resolved:
+            existing = set(config.wiki.inputs)
+            for path in resolved:
+                if path not in existing:
+                    config.wiki.inputs.append(path)
         return cls(config)
 
     def with_runtime(

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -1,0 +1,256 @@
+"""External source resolution and lockfile management.
+
+Treats external data sources like a package manager: wiki.yml declares the
+desired sources, wiki.lock records the exact resolved state for reproducible
+builds, and wiki source update refreshes and re-locks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .config import Config
+from .schemas.sources import LOCKFILE_FILENAME, Lockfile, LockedSource, SourceConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _lockfile_path(config: Config) -> Path:
+    return config.config_root / LOCKFILE_FILENAME
+
+
+def _source_cache_dir(config: Config, source_name: str) -> Path:
+    return config.config_root / ".wiki" / "sources" / source_name
+
+
+def _load_lockfile(config: Config) -> Lockfile:
+    return Lockfile.load(_lockfile_path(config))
+
+
+def _save_lockfile(config: Config, lockfile: Lockfile) -> None:
+    lockfile.save(_lockfile_path(config))
+
+
+def _git_hash_object(ref: str, repo_path: Path) -> str:
+    """Resolve a git ref to a full SHA-256 commit hash."""
+    result = subprocess.run(
+        ["git", "rev-parse", ref],
+        capture_output=True,
+        text=True,
+        cwd=repo_path,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to resolve git ref {ref!r}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def _git_fetch(source: SourceConfig, cache_dir: Path) -> Path:
+    """Clone or fetch a git source into the local cache."""
+    repo_dir = cache_dir / "repo"
+    if repo_dir.exists():
+        try:
+            result = subprocess.run(
+                ["git", "fetch", "--tags", "--force", "origin"],
+                capture_output=True,
+                text=True,
+                cwd=repo_dir,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to fetch {source.url}: {result.stderr.strip()}"
+                )
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to fetch {source.url}: {exc}"
+            ) from exc
+    else:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", source.url, str(repo_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            shutil.rmtree(cache_dir, ignore_errors=True)
+            raise RuntimeError(
+                f"Failed to clone {source.url}: {result.stderr.strip()}"
+            )
+    return repo_dir
+
+
+def _git_checkout(ref: str, repo_dir: Path) -> None:
+    """Checkout a specific ref in the repo."""
+    result = subprocess.run(
+        ["git", "checkout", ref, "--"],
+        capture_output=True,
+        text=True,
+        cwd=repo_dir,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to checkout {ref!r}: {result.stderr.strip()}"
+        )
+
+
+def _git_resolve_head(repo_dir: Path) -> str:
+    """Resolve HEAD to a commit SHA."""
+    return _git_hash_object("HEAD", repo_dir)
+
+
+def _compute_content_hash(repo_dir: Path) -> str:
+    """Compute a SHA-256 hash of all tracked files in the repo."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        cwd=repo_dir,
+    )
+    if result.returncode != 0:
+        return ""
+    files = result.stdout.split("\0") if result.stdout else []
+    hasher = hashlib.sha256()
+    for file_path in sorted(f for f in files if f):
+        try:
+            content = (repo_dir / file_path).read_bytes()
+            hasher.update(file_path.encode("utf-8"))
+            hasher.update(b"\0")
+            hasher.update(content)
+            hasher.update(b"\0")
+        except OSError:
+            continue
+    return hasher.hexdigest()
+
+
+def _resolve_source_path(source: SourceConfig, repo_dir: Path) -> Path:
+    """Return the local path for a source's content."""
+    base = repo_dir
+    if source.path:
+        base = repo_dir / source.path
+    if not base.exists():
+        raise RuntimeError(
+            f"Source {source.name!r}: path {source.path!r} does not exist in the repository"
+        )
+    return base.resolve()
+
+
+def resolve(config: Config) -> list[Path]:
+    """Resolve all external sources to local paths using the lockfile.
+
+    Reads each source declaration from config, checks the lockfile for
+    cached state, and returns the resolved local paths. Does NOT fetch —
+    use ``update()`` to refresh sources first.
+    """
+    if not config.sources:
+        return []
+
+    lockfile = _load_lockfile(config)
+    resolved: list[Path] = []
+
+    for source in config.sources:
+        locked = lockfile.sources.get(source.name)
+        if locked is None:
+            logger.warning(
+                "Source %r is not locked. Run 'wiki source update' to fetch and lock it.",
+                source.name,
+            )
+            continue
+
+        cache_dir = _source_cache_dir(config, source.name)
+        repo_dir = cache_dir / "repo"
+        if not repo_dir.exists():
+            logger.warning(
+                "Source %r is not cached locally. Run 'wiki source update' to fetch it.",
+                source.name,
+            )
+            continue
+
+        resolved_path = _resolve_source_path(source, repo_dir)
+        resolved.append(resolved_path)
+
+    return resolved
+
+
+def update(config: Config) -> Lockfile:
+    """Fetch and lock all declared sources.
+
+    Clones or fetches each source, pins the resolved ref in wiki.lock,
+    and returns the updated Lockfile.
+    """
+    lockfile = _load_lockfile(config)
+
+    for source in config.sources:
+        logger.info("Updating source %r from %s", source.name, source.url)
+        cache_dir = _source_cache_dir(config, source.name)
+        repo_dir = _git_fetch(source, cache_dir)
+
+        ref_to_check = source.ref or "HEAD"
+        if ref_to_check != "HEAD":
+            _git_checkout(ref_to_check, repo_dir)
+
+        resolved_ref = _git_resolve_head(repo_dir)
+        content_hash = _compute_content_hash(repo_dir)
+
+        lockfile.sources[source.name] = LockedSource(
+            url=source.url,
+            resolved_ref=resolved_ref,
+            ref=source.ref,
+            path=source.path,
+            content_hash=content_hash,
+            fetched_at=lockfile.timestamp(),
+        )
+        logger.info(
+            "Locked source %r at %s (%s)",
+            source.name,
+            resolved_ref[:12],
+            content_hash[:12] + "..." if content_hash else "no hash",
+        )
+
+    _save_lockfile(config, lockfile)
+    return lockfile
+
+
+def status(config: Config) -> list[dict[str, Any]]:
+    """Return the current status of each source vs the lockfile.
+
+    Returns a list of dicts with keys: name, type, url, declared_ref,
+    locked_ref, locked_hash, cached, is_pinned, is_dirty.
+    """
+    lockfile = _load_lockfile(config)
+    results: list[dict[str, Any]] = []
+
+    for source in config.sources:
+        locked = lockfile.sources.get(source.name)
+        cache_dir = _source_cache_dir(config, source.name)
+        repo_dir = cache_dir / "repo"
+        cached = repo_dir.exists()
+
+        is_pinned = locked is not None
+        is_dirty = False
+        if cached and locked and locked.resolved_ref:
+            try:
+                head = _git_hash_object("HEAD", repo_dir)
+                is_dirty = head != locked.resolved_ref
+            except RuntimeError:
+                is_dirty = True
+
+        results.append({
+            "name": source.name,
+            "type": source.type,
+            "url": source.url,
+            "declared_ref": source.ref,
+            "locked_ref": locked.resolved_ref[:12] if locked and locked.resolved_ref else None,
+            "locked_hash": locked.content_hash[:12] + "..." if locked and locked.content_hash else None,
+            "cached": cached,
+            "is_pinned": is_pinned,
+            "is_dirty": is_dirty,
+        })
+
+    return results

--- a/src/wiki/templates/wiki.yml
+++ b/src/wiki/templates/wiki.yml
@@ -105,6 +105,18 @@ lint:
   # Wikilinks in body when link.style is standard.
   link_style: warning
 
+# External data sources (git repos with wiki pages / RDF data to merge).
+# After adding a source, run 'wiki source update' to clone and lock it.
+# sources:
+#   - name: shared-taxonomy
+#     type: git
+#     url: https://github.com/example/taxonomy.wiki.git
+#     ref: v1.2.0  # optional branch, tag, or commit
+#     path: wiki  # optional subdirectory within the repo
+#   - name: community-pages
+#     type: git
+#     url: https://github.com/example/community.wiki.git
+
 # Optional SPARQL HTTP endpoint on wiki serve (opt-in).
 # sparql_service:
 #   enabled: false

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,171 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from wiki.config import Config
+from wiki.schemas.sources import LOCKFILE_FILENAME, LockedSource, Lockfile, SourceConfig
+
+
+class TestSourceConfig(unittest.TestCase):
+    def test_minimal_source(self) -> None:
+        source = SourceConfig(name="test", type="git", url="https://example.com/repo.git")
+        self.assertEqual(source.name, "test")
+        self.assertEqual(source.type, "git")
+        self.assertEqual(source.url, "https://example.com/repo.git")
+        self.assertIsNone(source.ref)
+        self.assertIsNone(source.path)
+        self.assertIsNone(source.description)
+
+    def test_full_source(self) -> None:
+        source = SourceConfig(
+            name="test",
+            type="git",
+            url="https://example.com/repo.git",
+            ref="v1.0.0",
+            path="wiki",
+            description="My source",
+        )
+        self.assertEqual(source.ref, "v1.0.0")
+        self.assertEqual(source.path, "wiki")
+        self.assertEqual(source.description, "My source")
+
+    def test_rejects_extra_fields(self) -> None:
+        with self.assertRaises(ValueError):
+            SourceConfig(name="test", type="git", url="https://example.com/repo.git", unknown="bad")
+
+    def test_rejects_invalid_type(self) -> None:
+        with self.assertRaises(ValueError):
+            SourceConfig(name="test", type="http", url="https://example.com/repo.git")
+
+
+class TestLockfile(unittest.TestCase):
+    def test_empty_lockfile(self) -> None:
+        lf = Lockfile()
+        self.assertEqual(lf.version, 1)
+        self.assertEqual(lf.sources, {})
+
+    def test_load_non_existent(self) -> None:
+        lf = Lockfile.load(Path("/nonexistent/wiki.lock"))
+        self.assertEqual(lf.sources, {})
+
+    def test_save_and_load_roundtrip(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "wiki.lock"
+            lf = Lockfile(
+                sources={
+                    "test": LockedSource(
+                        url="https://example.com/repo.git",
+                        resolved_ref="abc123def456",
+                        ref="v1.0.0",
+                        content_hash="xyz789",
+                        fetched_at="2025-01-01T00:00:00+00:00",
+                    )
+                }
+            )
+            lf.save(lock_path)
+            self.assertTrue(lock_path.exists())
+
+            loaded = Lockfile.load(lock_path)
+            self.assertEqual(loaded.version, 1)
+            self.assertIn("test", loaded.sources)
+            self.assertEqual(loaded.sources["test"].url, "https://example.com/repo.git")
+            self.assertEqual(loaded.sources["test"].resolved_ref, "abc123def456")
+            self.assertEqual(loaded.sources["test"].ref, "v1.0.0")
+
+    def test_load_corrupted(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "wiki.lock"
+            lock_path.write_text("{invalid json", encoding="utf-8")
+            lf = Lockfile.load(lock_path)
+            self.assertEqual(lf.sources, {})
+
+
+class TestConfigSources(unittest.TestCase):
+    def test_sources_list_syntax(self) -> None:
+        config = Config(
+            config_root=Path("."),
+            sources=[
+                {"name": "src1", "type": "git", "url": "https://example.com/a.git"},
+                {"name": "src2", "type": "git", "url": "https://example.com/b.git"},
+            ],
+        )
+        self.assertEqual(len(config.sources), 2)
+        self.assertEqual(config.sources[0].name, "src1")
+        self.assertEqual(config.sources[1].name, "src2")
+
+    def test_sources_dict_syntax(self) -> None:
+        config = Config(
+            config_root=Path("."),
+            sources={
+                "src1": {"type": "git", "url": "https://example.com/a.git"},
+                "src2": {"type": "git", "url": "https://example.com/b.git"},
+            },
+        )
+        self.assertEqual(len(config.sources), 2)
+        names = {s.name for s in config.sources}
+        self.assertIn("src1", names)
+        self.assertIn("src2", names)
+
+    def test_sources_none(self) -> None:
+        config = Config(config_root=Path("."))
+        self.assertEqual(config.sources, [])
+
+    def test_sources_rejects_duplicate_names(self) -> None:
+        with self.assertRaises(ValueError):
+            Config(
+                config_root=Path("."),
+                sources=[
+                    {"name": "src1", "type": "git", "url": "https://example.com/a.git"},
+                    {"name": "src1", "type": "git", "url": "https://example.com/b.git"},
+                ],
+            )
+
+    def test_sources_loaded_from_yaml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            yaml_content = {
+                "wiki": {"inputs": "wiki"},
+                "sources": [
+                    {"name": "taxonomy", "type": "git", "url": "https://example.com/taxonomy.git", "ref": "v1.0"},
+                    {"name": "community", "type": "git", "url": "https://example.com/community.git"},
+                ],
+            }
+            (base_path / "wiki.yaml").write_text(yaml.dump(yaml_content), encoding="utf-8")
+            config = Config.load(base_path)
+            self.assertEqual(len(config.sources), 2)
+            self.assertEqual(config.sources[0].name, "taxonomy")
+            self.assertEqual(config.sources[0].ref, "v1.0")
+            self.assertEqual(config.sources[1].name, "community")
+
+    def test_sources_unknown_keys_rejected(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            (base_path / "wiki.yaml").write_text(
+                yaml.dump({
+                    "wiki": {"inputs": "wiki"},
+                    "sources": [{"name": "bad", "type": "git", "url": "https://x.com", "extra_key": True}],
+                }),
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                Config.load(base_path)
+
+    def test_sources_unknown_type_rejected(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            (base_path / "wiki.yaml").write_text(
+                yaml.dump({
+                    "wiki": {"inputs": "wiki"},
+                    "sources": [{"name": "bad", "type": "sparql", "url": "https://x.com/sparql"}],
+                }),
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                Config.load(base_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Phase 1 of the local source resolution architecture described in #148, laying the groundwork for #156's broader registry vision.

## Changes

### Config schema
- **src/wiki/schemas/sources.py** â€” New `SourceConfig` (git source declaration), `Lockfile`/`LockedSource` (wiki.lock machine-authored resolution file)
- **src/wiki/schemas/wiki_config.py** â€” Added `sources:` block to `_BLOCK_LABELS` and `Config` model with `extra=forbid` validation
- Supports both list-of-dicts and dict-of-dicts syntax in wiki.yml
- Unknown keys and unsupported types (e.g. `sparql`) are rejected at validation time

### Resolver
- **src/wiki/sources.py** â€” `resolve()`, `update()`, `status()` functions
- `resolve()` reads wiki.lock and returns resolved local paths for locked sources
- `update()` clones/fetches git sources, pins resolved refs in wiki.lock
- `status()` compares declared vs locked state per source
- Sources cached under `.wiki/sources/<name>/repo/`
- Resolved sources are appended to `wiki.inputs` automatically in `Wiki.load()`

### CLI
- `wiki source update` â€” Fetch and lock all declared sources
- `wiki source status` â€” Show declared vs locked state for each source
- `wiki init` scaffold â€” Updated with commented sources example

### Tests
- 15 new tests covering SourceConfig, Lockfile load/save roundtrip, config validation, YAML loading, duplicate rejection, and unknown key rejection

## Design decisions

- **Git repos only for v1** â€” clear versioning via SHAs, zero changes to document parsing pipeline
- **wiki.lock beside wiki.yml** â€” conventional, matches package.json/package-lock.json pattern
- **Explicit `wiki source update`** â€” no network on build/check, deterministic from lockfile
- **Same graph for v1** â€” resolved sources merge into same graph; named graphs for #156

## Related
- Closes phase 1 of #148
- Builds toward #156

## Usage

```yaml
# wiki.yml
sources:
  - name: shared-taxonomy
    type: git
    url: https://github.com/example/taxonomy.wiki.git
    ref: v1.2.0
```

```bash
wiki source update   # clone/fetch + create wiki.lock
wiki source status   # show locked vs declared state
wiki check           # uses locked sources via graph
```
