### PR TITLE
feat: wiki install / wiki remove for external git sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `sources:` config block in wiki.yml — declare external git repos with optional `ref` (branch/tag/commit) and `path` (subdirectory). Validated with `extra=forbid` like all other blocks. ([#148](https://github.com/wazootech/wiki/issues/148))
 - `wiki.lock` lockfile — machine-authored JSON recording resolved commit SHAs for reproducible builds. ([#148](https://github.com/wazootech/wiki/issues/148))
 - Resolved source paths auto-appended to `wiki.inputs` in `Wiki.load()` so graph, check, and build pipelines pick them up transparently.
+- `wiki install` now accepts GitHub `owner/repo` shorthand — `wiki install EthanThatOneKid/solar-system-wiki` expands to the full `https://github.com/EthanThatOneKid/solar-system-wiki.git` URL automatically.
+- `wiki init` now scaffolds a `.gitignore` that excludes `.wiki/` (source cache) and `_site/` (build output).
 
 ### Dependency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `wiki install` command — fetch and lock external git sources declared in `sources:` block of `wiki.yml`. With a URL argument, adds the source to wiki.yml first. Supports `#ref` pinning. ([#148](https://github.com/wazootech/wiki/issues/148), [#164](https://github.com/wazootech/wiki/pull/164))
+- `wiki remove` command — remove a source from wiki.yml, its `.wiki/sources/` cache, and wiki.lock. ([#164](https://github.com/wazootech/wiki/pull/164))
+- `sources:` config block in wiki.yml — declare external git repos with optional `ref` (branch/tag/commit) and `path` (subdirectory). Validated with `extra=forbid` like all other blocks. ([#148](https://github.com/wazootech/wiki/issues/148))
+- `wiki.lock` lockfile — machine-authored JSON recording resolved commit SHAs for reproducible builds. ([#148](https://github.com/wazootech/wiki/issues/148))
+- Resolved source paths auto-appended to `wiki.inputs` in `Wiki.load()` so graph, check, and build pipelines pick them up transparently.
+
+### Dependency
+
+- Added `ruamel.yaml` for comment-preserving YAML writes when `wiki install`/`wiki remove` edits wiki.yml.
+
 ## 0.1.18 — 2026-06-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `wiki install` command — fetch and lock external git sources declared in `sources:` block of `wiki.yml`. With a URL argument, adds the source to wiki.yml first. Supports `#ref` pinning. ([#148](https://github.com/wazootech/wiki/issues/148), [#164](https://github.com/wazootech/wiki/pull/164))
 - `wiki remove` command — remove a source from wiki.yml, its `.wiki/sources/` cache, and wiki.lock. ([#164](https://github.com/wazootech/wiki/pull/164))
+- `wiki update` command — check locked sources for newer commits and update wiki.lock. Supports `--dry-run` and per-source filtering. ([#164](https://github.com/wazootech/wiki/pull/164))
 - `sources:` config block in wiki.yml — declare external git repos with optional `ref` (branch/tag/commit) and `path` (subdirectory). Validated with `extra=forbid` like all other blocks. ([#148](https://github.com/wazootech/wiki/issues/148))
 - `wiki.lock` lockfile — machine-authored JSON recording resolved commit SHAs for reproducible builds. ([#148](https://github.com/wazootech/wiki/issues/148))
 - Resolved source paths auto-appended to `wiki.inputs` in `Wiki.load()` so graph, check, and build pipelines pick them up transparently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Resolved source paths auto-appended to `wiki.inputs` in `Wiki.load()` so graph, check, and build pipelines pick them up transparently.
 - `wiki install` now accepts GitHub `owner/repo` shorthand — `wiki install EthanThatOneKid/solar-system-wiki` expands to the full `https://github.com/EthanThatOneKid/solar-system-wiki.git` URL automatically.
 - `wiki init` now scaffolds a `.gitignore` that excludes `.wiki/` (source cache) and `_site/` (build output).
+- **Recursive (transitive) dependency resolution** — `wiki install` reads each cloned source's `wiki.yml` to discover its own `sources:` block, recursively fetching and locking transitive dependencies. Circular dependency chains are detected and raise an error. Name-and-ref conflicts are detected and raise an error.
+- **Lockfile v2** — `LockedSource` now tracks `required_by: list[str]` recording which sources depend on each entry (empty for top-level sources declared in the root `wiki.yml`). Backward-compatible: v1 lockfiles load with `required_by` defaulting to `[]`.
+- **Orphan cleanup on `wiki remove`** — when a source is removed, transitive sources that are no longer required by any remaining top-level source are automatically cleaned up (cache and lockfile entry removed), cascading through the dependency tree.
+- **Transitive re-sync on `wiki update`** — after fetching new commits, `wiki update` re-discovers each source's declared transitive dependencies. Newly declared sources are installed and locked; orphaned sources are reported as warnings (not auto-removed).
 
 ### Dependency
 

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -90,12 +90,12 @@ No Obsidian or agent stack required. `wiki init` scaffolds a wiki; conventions a
 
 ## Three capabilities of the CLI
 
-| Capability   | Commands                    | Value                                            |
-| ------------ | --------------------------- | ------------------------------------------------ |
-| Trust        | `check`, `lint`, `fmt`      | Integrity contracts and authoring conventions    |
-| Intelligence | `query`, `render`, `export` | SPARQL, inline result blocks, RDF serializations |
-| Publish      | `build`, `serve`, `link`    | Static site, local preview, wikilink hygiene     |
-| Sources      | `install`, `remove`         | Fetch, lock, and manage external data sources    |
+| Capability   | Commands                         | Value                                            |
+| ------------ | -------------------------------- | ------------------------------------------------ |
+| Trust        | `check`, `lint`, `fmt`           | Integrity contracts and authoring conventions    |
+| Intelligence | `query`, `render`, `export`      | SPARQL, inline result blocks, RDF serializations |
+| Publish      | `build`, `serve`, `link`         | Static site, local preview, wikilink hygiene     |
+| Sources      | `install`, `update`, `remove`    | Fetch, lock, update, and manage external sources |
 
 Design rationale for silence, pipes, and flat subcommands: [Design philosophies](Design_Philosophies.md).
 
@@ -136,6 +136,7 @@ Do not use these in new prose: `sparql-service-template` (→ `wiki-yasgui-templ
 - **Build / serve** — static site, local preview, and optional read-only SPARQL endpoint ([Wiki Subcommand build](Wiki_Subcommand_build.md), [Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint))
 - **Export** — JSON-LD and RDF serializations ([Wiki Subcommand export](Wiki_Subcommand_export.md))
 - **Install** — fetch and lock external data sources ([Wiki Subcommand install](Wiki_Subcommand_install.md))
+- **Update** — check locked sources for newer commits ([Wiki Subcommand update](Wiki_Subcommand_update.md))
 - **Remove** — delete a source from wiki.yml, cache, and lockfile ([Wiki Subcommand remove](Wiki_Subcommand_remove.md))
 - **Init** — scaffold `wiki.yml` ([Wiki Subcommand init](Wiki_Subcommand_init.md))
 - **Upgrade** — PyPI updates ([Wiki Subcommand upgrade](Wiki_Subcommand_upgrade.md))
@@ -209,6 +210,7 @@ ORDER BY ?command
 | [Wiki_Subcommand_remove](Wiki_Subcommand_remove.md) | Remove a data source from wiki.yml, its cache, and wiki.lock. |
 | [Wiki_Subcommand_render](Wiki_Subcommand_render.md) | Update inline SPARQL result tables in markdown files. |
 | [Wiki_Subcommand_serve](Wiki_Subcommand_serve.md) | Local HTTP server for live HTML preview and optional read-only SPARQL endpoint. |
+| [Wiki_Subcommand_update](Wiki_Subcommand_update.md) | Check locked sources for newer commits and update wiki.lock. |
 | [Wiki_Subcommand_upgrade](Wiki_Subcommand_upgrade.md) | Check PyPI for updates and upgrade wazootech-wiki. |
 
 <!-- sparql:end -->

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -202,7 +202,7 @@ ORDER BY ?command
 | [Wiki_Subcommand_export](Wiki_Subcommand_export.md) | Export document frontmatter as RDF or JSON-LD. |
 | [Wiki_Subcommand_fmt](Wiki_Subcommand_fmt.md) | Format markdown wiki pages using mdformat with wikilink preservation. |
 | [Wiki_Subcommand_init](Wiki_Subcommand_init.md) | Scaffold wiki.yml and starter wiki pages interactively. |
-| [Wiki_Subcommand_install](Wiki_Subcommand_install.md) | Fetch and lock external data sources. |
+| [Wiki_Subcommand_install](Wiki_Subcommand_install.md) | Fetch and lock external data sources declared in wiki.yml. |
 | [Wiki_Subcommand_link](Wiki_Subcommand_link.md) | Suggest missing wikilinks and repair unambiguous broken internal links. |
 | [Wiki_Subcommand_lint](Wiki_Subcommand_lint.md) | Convention audits for broken links, filename patterns, heading style, and internal link style. |
 | [Wiki_Subcommand_query](Wiki_Subcommand_query.md) | Run SPARQL SELECT or CONSTRUCT against the wiki graph. |

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -90,12 +90,12 @@ No Obsidian or agent stack required. `wiki init` scaffolds a wiki; conventions a
 
 ## Three capabilities of the CLI
 
-| Capability   | Commands                         | Value                                            |
-| ------------ | -------------------------------- | ------------------------------------------------ |
-| Trust        | `check`, `lint`, `fmt`           | Integrity contracts and authoring conventions    |
-| Intelligence | `query`, `render`, `export`      | SPARQL, inline result blocks, RDF serializations |
-| Publish      | `build`, `serve`, `link`         | Static site, local preview, wikilink hygiene     |
-| Sources      | `install`, `update`, `remove`    | Fetch, lock, update, and manage external sources |
+| Capability   | Commands                      | Value                                            |
+| ------------ | ----------------------------- | ------------------------------------------------ |
+| Trust        | `check`, `lint`, `fmt`        | Integrity contracts and authoring conventions    |
+| Intelligence | `query`, `render`, `export`   | SPARQL, inline result blocks, RDF serializations |
+| Publish      | `build`, `serve`, `link`      | Static site, local preview, wikilink hygiene     |
+| Sources      | `install`, `update`, `remove` | Fetch, lock, update, and manage external sources |
 
 Design rationale for silence, pipes, and flat subcommands: [Design philosophies](Design_Philosophies.md).
 

--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -95,6 +95,7 @@ No Obsidian or agent stack required. `wiki init` scaffolds a wiki; conventions a
 | Trust        | `check`, `lint`, `fmt`      | Integrity contracts and authoring conventions    |
 | Intelligence | `query`, `render`, `export` | SPARQL, inline result blocks, RDF serializations |
 | Publish      | `build`, `serve`, `link`    | Static site, local preview, wikilink hygiene     |
+| Sources      | `install`, `remove`         | Fetch, lock, and manage external data sources    |
 
 Design rationale for silence, pipes, and flat subcommands: [Design philosophies](Design_Philosophies.md).
 
@@ -134,6 +135,8 @@ Do not use these in new prose: `sparql-service-template` (→ `wiki-yasgui-templ
 - **Render** — live tables from inline SPARQL ([Wiki Subcommand render](Wiki_Subcommand_render.md))
 - **Build / serve** — static site, local preview, and optional read-only SPARQL endpoint ([Wiki Subcommand build](Wiki_Subcommand_build.md), [Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint))
 - **Export** — JSON-LD and RDF serializations ([Wiki Subcommand export](Wiki_Subcommand_export.md))
+- **Install** — fetch and lock external data sources ([Wiki Subcommand install](Wiki_Subcommand_install.md))
+- **Remove** — delete a source from wiki.yml, cache, and lockfile ([Wiki Subcommand remove](Wiki_Subcommand_remove.md))
 - **Init** — scaffold `wiki.yml` ([Wiki Subcommand init](Wiki_Subcommand_init.md))
 - **Upgrade** — PyPI updates ([Wiki Subcommand upgrade](Wiki_Subcommand_upgrade.md))
 
@@ -151,7 +154,7 @@ Procedural knowledge for coding agents: [Wiki Skills](Wiki_Skills.md) (`skills/w
 
 ## Global Options
 
-These options apply to config-loading subcommands (`check`, `lint`, `link`, `query`, `render`, `build`, `export`, `serve`, `fmt`). `init` and `upgrade` do not load a config file.
+These options apply to config-loading subcommands (`check`, `lint`, `link`, `query`, `render`, `build`, `export`, `serve`, `fmt`, `install`, `remove`). `init` and `upgrade` do not load a config file.
 
 ### `-c, --config PATH`
 
@@ -199,9 +202,11 @@ ORDER BY ?command
 | [Wiki_Subcommand_export](Wiki_Subcommand_export.md) | Export document frontmatter as RDF or JSON-LD. |
 | [Wiki_Subcommand_fmt](Wiki_Subcommand_fmt.md) | Format markdown wiki pages using mdformat with wikilink preservation. |
 | [Wiki_Subcommand_init](Wiki_Subcommand_init.md) | Scaffold wiki.yml and starter wiki pages interactively. |
+| [Wiki_Subcommand_install](Wiki_Subcommand_install.md) | Fetch and lock external data sources. |
 | [Wiki_Subcommand_link](Wiki_Subcommand_link.md) | Suggest missing wikilinks and repair unambiguous broken internal links. |
 | [Wiki_Subcommand_lint](Wiki_Subcommand_lint.md) | Convention audits for broken links, filename patterns, heading style, and internal link style. |
 | [Wiki_Subcommand_query](Wiki_Subcommand_query.md) | Run SPARQL SELECT or CONSTRUCT against the wiki graph. |
+| [Wiki_Subcommand_remove](Wiki_Subcommand_remove.md) | Remove a data source from wiki.yml, its cache, and wiki.lock. |
 | [Wiki_Subcommand_render](Wiki_Subcommand_render.md) | Update inline SPARQL result tables in markdown files. |
 | [Wiki_Subcommand_serve](Wiki_Subcommand_serve.md) | Local HTTP server for live HTML preview and optional read-only SPARQL endpoint. |
 | [Wiki_Subcommand_upgrade](Wiki_Subcommand_upgrade.md) | Check PyPI for updates and upgrade wazootech-wiki. |

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -54,6 +54,7 @@ Top-level blocks follow a **compile pipeline** plus **audit lanes**, not arbitra
 | `link:`           | `wiki link` apply format and rename repair map        | `wiki link`                       | optional | yes               |
 | `check:`          | Integrity severities                                  | `wiki check`                      | optional | yes               |
 | `lint:`           | Convention severities                                 | `wiki lint`                       | optional | yes               |
+| `sources:`        | External data sources (git repos)                     | `wiki install`, `wiki remove`     | optional | commented example |
 | `sparql_service:` | Opt-in SPARQL HTTP on `wiki serve`                    | `wiki serve`                      | optional | commented example |
 | `fmt:`            | Mechanical markdown via mdformat                      | `wiki fmt`                        | optional | inline mapping    |
 
@@ -220,6 +221,50 @@ lint:  # optional block
 ATX heading syntax is also enforced by **`wiki fmt`** (mdformat); Setext underlines are converted on format.
 
 When `link.style` is `standard`, set `lint.link_style: off` to allow wikilinks in prose, or set `link.style: wikilink` for an Obsidian-style wiki.
+
+## External data sources (`sources:`)
+
+<!-- wiki:anchor external-data-sources-sources -->
+
+Declare external git repositories that contribute wiki pages or RDF data to the graph. After adding a source, run `wiki install` to clone it and pin the resolved commit in `wiki.lock`.
+
+```yaml
+sources:  # optional block
+  - name: shared-taxonomy
+    type: git
+    url: https://github.com/example/taxonomy.wiki.git
+    ref: v1.2.0       # optional — branch, tag, or commit
+    path: wiki        # optional — subdirectory within the repo
+  - name: community-pages
+    type: git
+    url: https://github.com/example/community.wiki.git
+```
+
+| Key    | Required | Default   | Init              | Command(s)     |
+| ------ | -------- | --------- | ----------------- | -------------- |
+| `name` | required | —         | omits (commented) | `wiki install` |
+| `type` | required | `git`     | omits (commented) | `wiki install` |
+| `url`  | required | —         | omits (commented) | `wiki install` |
+| `ref`  | optional | `HEAD`    | omits (commented) | `wiki install` |
+| `path` | optional | repo root | omits (commented) | `wiki install` |
+
+Each source must have a unique `name`. The `type` field is currently limited to `git`. Unknown keys and unsupported types are rejected at config load time.
+
+Run `wiki install` to fetch all declared sources and write `wiki.lock`. Check `wiki.lock` into version control for reproducible builds. The resolved source paths are automatically appended to `wiki.inputs` so the existing graph, check, and build pipeline picks them up.
+
+To add a source without editing the config file by hand:
+
+```bash
+wiki install https://github.com/example/taxonomy.wiki.git#v1.2.0
+```
+
+To remove a source:
+
+```bash
+wiki remove shared-taxonomy
+```
+
+See [Wiki Subcommand install](Wiki_Subcommand_install.md) and [Wiki Subcommand remove](Wiki_Subcommand_remove.md).
 
 ## Serve API
 

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -249,10 +249,14 @@ Each source must have a unique `name`. The `type` field is currently limited to 
 
 Run `wiki install` to fetch all declared sources and write `wiki.lock`. Check `wiki.lock` into version control for reproducible builds. The resolved source paths are automatically appended to `wiki.inputs` so the existing graph, check, and build pipeline picks them up.
 
+The `.wiki/` source cache directory is not committed — `wiki init` scaffolds a `.gitignore` that excludes it (alongside the `_site/` build output).
+
 To add a source without editing the config file by hand:
 
 ```bash
 wiki install https://github.com/EthanThatOneKid/solar-system-wiki.git
+# GitHub shorthand also works:
+wiki install EthanThatOneKid/solar-system-wiki
 ```
 
 The name is inferred from the URL (`solar-system`). To remove it:

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -230,14 +230,11 @@ Declare external git repositories that contribute wiki pages or RDF data to the 
 
 ```yaml
 sources:  # optional block
-  - name: shared-taxonomy
+  - name: solar-system
     type: git
-    url: https://github.com/example/taxonomy.wiki.git
-    ref: v1.2.0       # optional — branch, tag, or commit
+    url: https://github.com/EthanThatOneKid/solar-system-wiki.git
+    ref: v0.1.0       # optional — branch, tag, or commit
     path: wiki        # optional — subdirectory within the repo
-  - name: community-pages
-    type: git
-    url: https://github.com/example/community.wiki.git
 ```
 
 | Key    | Required | Default   | Init              | Command(s)     |
@@ -255,13 +252,13 @@ Run `wiki install` to fetch all declared sources and write `wiki.lock`. Check `w
 To add a source without editing the config file by hand:
 
 ```bash
-wiki install https://github.com/example/taxonomy.wiki.git#v1.2.0
+wiki install https://github.com/EthanThatOneKid/solar-system-wiki.git
 ```
 
-To remove a source:
+The name is inferred from the URL (`solar-system`). To remove it:
 
 ```bash
-wiki remove shared-taxonomy
+wiki remove solar-system
 ```
 
 See [Wiki Subcommand install](Wiki_Subcommand_install.md) and [Wiki Subcommand remove](Wiki_Subcommand_remove.md).

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -249,6 +249,12 @@ Each source must have a unique `name`. The `type` field is currently limited to 
 
 Run `wiki install` to fetch all declared sources and write `wiki.lock`. Check `wiki.lock` into version control for reproducible builds. The resolved source paths are automatically appended to `wiki.inputs` so the existing graph, check, and build pipeline picks them up.
 
+**Transitive dependencies** are resolved recursively. After cloning each source, `wiki install` reads the source's own `wiki.yml` (or `wiki.yaml`/`wiki.json`) to discover its `sources:` block. Those transitive sources are fetched and locked too, forming a dependency tree. Circular dependency chains are detected and reported as errors. If two sources declare the same dependency name with different URLs or refs, install fails with a conflict error.
+
+When a source is removed with `wiki remove`, transitive sources that are no longer needed by any remaining top-level source are automatically cleaned up (cache and lockfile entry removed).
+
+After `wiki update`, newly declared transitive sources are installed, and orphaned sources are reported (but not auto-removed — run `wiki remove` to clean up).
+
 The `.wiki/` source cache directory is not committed — `wiki init` scaffolds a `.gitignore` that excludes it (alongside the `_site/` build output).
 
 To add a source without editing the config file by hand:

--- a/docs/wiki/Wiki_Subcommand_install.md
+++ b/docs/wiki/Wiki_Subcommand_install.md
@@ -1,0 +1,36 @@
+---
+type: TechArticle
+headline: wiki install
+description: Fetch and lock external data sources declared in wiki.yml.
+---
+
+# `wiki install`
+
+Fetch external data sources (git repositories with wiki pages or RDF data), resolve commit SHAs, and pin them in `wiki.lock`. Without arguments, installs all sources declared in the `sources:` block of `wiki.yml`. With a URL, adds the source to `wiki.yml` first, then fetches and locks it.
+
+## Usage
+
+```bash
+wiki install
+wiki install https://github.com/example/taxonomy.wiki.git
+wiki install https://github.com/example/taxonomy.wiki.git#v1.2.0
+```
+
+## Options
+
+| Flag  | Description                                                                                                                                |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `URL` | Git repository URL to add and install. Supports `#ref` pinning (branch, tag, or commit). If omitted, installs all sources from `wiki.yml`. |
+
+## Lockfile
+
+`wiki install` produces `wiki.lock` in the same directory as `wiki.yml`. This machine-authored JSON file records the resolved commit SHA, requested ref, and fetch timestamp for each source. Check it into version control so builds are reproducible — the lockfile is the source of truth for which version of each source is used.
+
+## Source cache
+
+Cloned repositories are cached under `.wiki/sources/<name>/repo/` relative to the wiki config root. `wiki install` always fetches the latest remote refs (shallow clone, `--depth 1`) so it stays fast.
+
+## Related
+
+- [Wiki Subcommand remove](Wiki_Subcommand_remove.md)
+- [Wiki Configuration](Wiki_Configuration.md#external-data-sources-sources)

--- a/docs/wiki/Wiki_Subcommand_install.md
+++ b/docs/wiki/Wiki_Subcommand_install.md
@@ -12,8 +12,8 @@ Fetch external data sources (git repositories with wiki pages or RDF data), reso
 
 ```bash
 wiki install
-wiki install https://github.com/example/taxonomy.wiki.git
-wiki install https://github.com/example/taxonomy.wiki.git#v1.2.0
+wiki install https://github.com/EthanThatOneKid/solar-system-wiki.git
+wiki install https://github.com/EthanThatOneKid/solar-system-wiki.git#v0.1.0
 ```
 
 ## Options

--- a/docs/wiki/Wiki_Subcommand_install.md
+++ b/docs/wiki/Wiki_Subcommand_install.md
@@ -10,6 +10,8 @@ Fetch external data sources (git repositories with wiki pages or RDF data), reso
 
 You can use GitHub `owner/repo` shorthand instead of a full URL — `EthanThatOneKid/solar-system-wiki` expands to `https://github.com/EthanThatOneKid/solar-system-wiki.git` automatically.
 
+**Transitive dependencies** are resolved recursively. `wiki install` reads each cloned source's own `wiki.yml` to discover its `sources:` block, fetches those transitive sources, and locks them too — forming a dependency tree. Circular dependency chains are detected and raise an error. If two sources declare the same dependency name with different URLs or refs, install fails with a conflict error.
+
 ## Usage
 
 ```bash

--- a/docs/wiki/Wiki_Subcommand_install.md
+++ b/docs/wiki/Wiki_Subcommand_install.md
@@ -8,12 +8,15 @@ description: Fetch and lock external data sources declared in wiki.yml.
 
 Fetch external data sources (git repositories with wiki pages or RDF data), resolve commit SHAs, and pin them in `wiki.lock`. Without arguments, installs all sources declared in the `sources:` block of `wiki.yml`. With a URL, adds the source to `wiki.yml` first, then fetches and locks it.
 
+You can use GitHub `owner/repo` shorthand instead of a full URL — `EthanThatOneKid/solar-system-wiki` expands to `https://github.com/EthanThatOneKid/solar-system-wiki.git` automatically.
+
 ## Usage
 
 ```bash
 wiki install
 wiki install https://github.com/EthanThatOneKid/solar-system-wiki.git
 wiki install https://github.com/EthanThatOneKid/solar-system-wiki.git#v0.1.0
+wiki install EthanThatOneKid/solar-system-wiki
 ```
 
 ## Options
@@ -29,6 +32,10 @@ wiki install https://github.com/EthanThatOneKid/solar-system-wiki.git#v0.1.0
 ## Source cache
 
 Cloned repositories are cached under `.wiki/sources/<name>/repo/` relative to the wiki config root. `wiki install` always fetches the latest remote refs (shallow clone, `--depth 1`) so it stays fast.
+
+## `.gitignore`
+
+The `.wiki/` source cache directory (and the `_site/` build output) should not be committed to version control. `wiki init` scaffolds a `.gitignore` that includes both directories.
 
 ## Related
 

--- a/docs/wiki/Wiki_Subcommand_remove.md
+++ b/docs/wiki/Wiki_Subcommand_remove.md
@@ -1,0 +1,26 @@
+---
+type: TechArticle
+headline: wiki remove
+description: Remove a data source from wiki.yml, its cache, and wiki.lock.
+---
+
+# `wiki remove`
+
+Remove a previously installed source by name. Deletes the source entry from the `sources:` block in `wiki.yml`, removes the cached repository under `.wiki/sources/<name>/`, and deletes the entry from `wiki.lock`.
+
+## Usage
+
+```bash
+wiki remove shared-taxonomy
+```
+
+## Arguments
+
+| Argument | Description                                               |
+| -------- | --------------------------------------------------------- |
+| `name`   | Name of the source to remove (as declared in `wiki.yml`). |
+
+## Related
+
+- [Wiki Subcommand install](Wiki_Subcommand_install.md)
+- [Wiki Configuration](Wiki_Configuration.md#external-data-sources-sources)

--- a/docs/wiki/Wiki_Subcommand_remove.md
+++ b/docs/wiki/Wiki_Subcommand_remove.md
@@ -8,6 +8,8 @@ description: Remove a data source from wiki.yml, its cache, and wiki.lock.
 
 Remove a previously installed source by name. Deletes the source entry from the `sources:` block in `wiki.yml`, removes the cached repository under `.wiki/sources/<name>/`, and deletes the entry from `wiki.lock`.
 
+**Transitive dependency cleanup:** when a source is removed, transitive sources that are no longer required by any remaining top-level source are automatically cleaned up — their cache and lockfile entries are removed too.
+
 ## Usage
 
 ```bash

--- a/docs/wiki/Wiki_Subcommand_update.md
+++ b/docs/wiki/Wiki_Subcommand_update.md
@@ -1,0 +1,37 @@
+---
+type: TechArticle
+headline: wiki update
+description: Check locked sources for newer commits and update wiki.lock.
+---
+
+# `wiki update`
+
+Fetch each locked source, resolve the current HEAD (or the configured ref), and compare against the pinned commit in `wiki.lock`. If the commit has changed, update the lockfile entry.
+
+This is the incremental counterpart to `wiki install` — it only writes the lockfile when something actually changed, and reports what updated.
+
+## Usage
+
+```bash
+wiki update
+wiki update solar-system
+wiki update --dry-run
+```
+
+## Arguments
+
+| Argument | Description                                             |
+| -------- | ------------------------------------------------------- |
+| `name`   | Source name to check. Omit to check all locked sources. |
+
+## Options
+
+| Flag              | Description                                           |
+| ----------------- | ----------------------------------------------------- |
+| `-n`, `--dry-run` | Show what would update without modifying `wiki.lock`. |
+
+## Related
+
+- [Wiki Subcommand install](Wiki_Subcommand_install.md)
+- [Wiki Subcommand remove](Wiki_Subcommand_remove.md)
+- [Wiki Configuration](Wiki_Configuration.md#external-data-sources-sources)

--- a/docs/wiki/Wiki_Subcommand_update.md
+++ b/docs/wiki/Wiki_Subcommand_update.md
@@ -10,6 +10,8 @@ Fetch each locked source, resolve the current HEAD (or the configured ref), and 
 
 This is the incremental counterpart to `wiki install` — it only writes the lockfile when something actually changed, and reports what updated.
 
+**Transitive dependency re-sync:** after updating commits, `wiki update` re-discovers each source's declared transitive dependencies. Newly declared sources are automatically installed and locked. Orphaned sources (transitive deps that were dropped by a source's new commit) are reported as warnings but not automatically removed — run `wiki remove <name>` to clean up.
+
 ## Usage
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "jinja2>=3.1.0",
     "pydantic>=2.0",
     "jsonschema>=4.23",
+    "ruamel.yaml>=0.18.0",
 ]
 
 [project.scripts]

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -690,6 +690,41 @@ def install(wiki: Wiki, url: str | None) -> None:
 
 
 @main.command()
+@click.argument("name", required=False, default=None)
+@click.option("-n", "--dry-run", is_flag=True, help="Show what would update without modifying wiki.lock.")
+@click.pass_obj
+def update(wiki: Wiki, name: str | None, dry_run: bool) -> None:
+    """Check locked sources for newer commits and update wiki.lock.
+
+    Fetches each source, resolves the current HEAD (or pinned ref), and
+    compares against the locked SHA. With --dry-run, reports what would
+    change without writing. With a NAME argument, checks only that source.
+    """
+    from .sources import update as update_sources
+
+    try:
+        result = update_sources(wiki.config, name, dry_run=dry_run)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not result.updates:
+        click.echo("No sources to update.")
+        return
+
+    changed = result.changed
+    if not changed:
+        click.echo("All sources are up to date.")
+        return
+
+    for u in changed:
+        action = "would update" if dry_run else "updated"
+        click.echo(f"{action} {u.name}: {u.previous_ref} -> {u.current_ref}")
+
+    if not dry_run:
+        click.echo(f"Updated {len(changed)} source{'s' if len(changed) != 1 else ''} in wiki.lock.")
+
+
+@main.command()
 @click.argument("name")
 @click.pass_obj
 def remove(wiki: Wiki, name: str) -> None:

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -661,6 +661,50 @@ def fmt(wiki: Wiki, files: tuple[Path, ...], check: bool, verbose: bool) -> None
 
 
 @main.command()
+@click.argument("url", required=False, default=None)
+@click.pass_obj
+def install(wiki: Wiki, url: str | None) -> None:
+    """Fetch and lock external data sources.
+
+    With no arguments, installs all sources declared in wiki.yml and
+    updates wiki.lock.
+
+    With a URL, adds a new git source to wiki.yml, fetches it, and
+    locks it. Append \x23<ref> to pin a branch, tag, or commit.
+    """
+    from .sources import install as install_sources
+
+    try:
+        lockfile = install_sources(wiki.config, url)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    count = len(lockfile.sources)
+    if count == 0:
+        click.echo("No sources to install.")
+        return
+
+    click.echo(f"Locked {count} source{'s' if count != 1 else ''}.")
+    for name, locked in lockfile.sources.items():
+        click.echo(f"  {name}: {locked.resolved_ref[:12]} ({locked.fetched_at})")
+
+
+@main.command()
+@click.argument("name")
+@click.pass_obj
+def remove(wiki: Wiki, name: str) -> None:
+    """Remove a source from wiki.yml, its cache, and wiki.lock."""
+    from .sources import remove as remove_source
+
+    try:
+        remove_source(wiki.config, name)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(f"Removed source {name!r}.")
+
+
+@main.command()
 @click.option("-c", "--check", "check_only", is_flag=True, help="Check for updates without upgrading.")
 @click.option("-y", "--yes", "auto_yes", is_flag=True, help="Skip confirmation prompt and upgrade immediately.")
 @click.option("-v", "--verbose", is_flag=True, help="Show pip install output.")

--- a/src/wiki/init_scaffold.py
+++ b/src/wiki/init_scaffold.py
@@ -236,6 +236,14 @@ _PERSON_SHAPE_TEMPLATE = (
     "Defines validation rules for Person profiles in this wiki.\n"
 )
 
+_GITIGNORE_TEMPLATE = (
+    "# Source cache (fetched repos)\n"
+    ".wiki/\n"
+    "\n"
+    "# Build output\n"
+    "_site/\n"
+)
+
 _EXAMPLE_PERSON_TEMPLATE = (
     "<!-- wiki tweak: replace with your first page -->\n"
     "---\n"
@@ -263,6 +271,10 @@ def _scaffold_wiki(
     wiki_dir = cwd / "wiki"
 
     wiki_dir.mkdir(parents=True, exist_ok=True)
+    gitignore_path = cwd / ".gitignore"
+    if not gitignore_path.exists():
+        gitignore_path.write_text(_GITIGNORE_TEMPLATE, encoding="utf-8")
+        written.append(gitignore_path)
     readme_path.write_text(_README_TEMPLATE, encoding="utf-8")
     written.extend([readme_path, wiki_dir])
 

--- a/src/wiki/schemas/__init__.py
+++ b/src/wiki/schemas/__init__.py
@@ -24,6 +24,7 @@ from .reports import (
 )
 from .rules import CheckConfig, LintConfig, Severity, coerce_severity
 from .site import TocItem, VirtualPage, WikiSite
+from .sources import LOCKFILE_FILENAME, LOCKFILE_VERSION, LockedSource, Lockfile, SourceConfig
 from .wiki_config import (
     Config,
     FmtConfig,
@@ -59,6 +60,10 @@ __all__ = [
     "LinkConfig",
     "LinkOpportunity",
     "LintConfig",
+    "LOCKFILE_FILENAME",
+    "LOCKFILE_VERSION",
+    "LockedSource",
+    "Lockfile",
     "PageLayoutContext",
     "METADATA_VIEWS",
     "MetadataView",
@@ -67,6 +72,7 @@ __all__ = [
     "Severity",
     "SiteConfig",
     "SiteLayoutContext",
+    "SourceConfig",
     "SparqlServiceConfig",
     "TocItem",
     "WikiConfig",

--- a/src/wiki/schemas/__init__.py
+++ b/src/wiki/schemas/__init__.py
@@ -24,7 +24,13 @@ from .reports import (
 )
 from .rules import CheckConfig, LintConfig, Severity, coerce_severity
 from .site import TocItem, VirtualPage, WikiSite
-from .sources import LOCKFILE_FILENAME, LOCKFILE_VERSION, LockedSource, Lockfile, SourceConfig
+from .sources import (
+    LOCKFILE_FILENAME,
+    LOCKFILE_VERSION,
+    LockedSource,
+    Lockfile,
+    SourceConfig,
+)
 from .wiki_config import (
     Config,
     FmtConfig,

--- a/src/wiki/schemas/sources.py
+++ b/src/wiki/schemas/sources.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Literal
 
@@ -68,4 +68,4 @@ class Lockfile(BaseModel):
 
     @staticmethod
     def timestamp() -> str:
-        return datetime.now(timezone.utc).isoformat()
+        return datetime.now(UTC).isoformat()

--- a/src/wiki/schemas/sources.py
+++ b/src/wiki/schemas/sources.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 

--- a/src/wiki/schemas/sources.py
+++ b/src/wiki/schemas/sources.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-LOCKFILE_VERSION = 1
+LOCKFILE_VERSION = 2
 LOCKFILE_FILENAME = "wiki.lock"
 
 
@@ -25,13 +25,19 @@ class SourceConfig(BaseModel):
 
 
 class LockedSource(BaseModel):
-    """A pinned source entry in wiki.lock."""
+    """A pinned source entry in wiki.lock.
+
+    ``required_by`` lists the names of sources (or ``"root"`` for top-level
+    entries declared directly in the root ``wiki.yml``) that depend on this
+    source. An empty list means the source is a top-level root entry.
+    """
 
     url: str
     resolved_ref: str = ""
     ref: str | None = None
     path: str | None = None
     fetched_at: str = ""
+    required_by: list[str] = Field(default_factory=list)
 
 
 class Lockfile(BaseModel):

--- a/src/wiki/schemas/sources.py
+++ b/src/wiki/schemas/sources.py
@@ -1,0 +1,71 @@
+"""Pydantic models for wiki source declarations and lockfiles."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+LOCKFILE_VERSION = 1
+LOCKFILE_FILENAME = "wiki.lock"
+
+
+class SourceConfig(BaseModel):
+    """A single external source declared in wiki.yml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: Literal["git"]
+    url: str
+    ref: str | None = None
+    path: str | None = None
+
+
+class LockedSource(BaseModel):
+    """A pinned source entry in wiki.lock."""
+
+    url: str
+    resolved_ref: str = ""
+    ref: str | None = None
+    path: str | None = None
+    fetched_at: str = ""
+
+
+class Lockfile(BaseModel):
+    """Machine-authored lockfile recording pinned source state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = LOCKFILE_VERSION
+    sources: dict[str, LockedSource] = Field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path) -> Lockfile:
+        import json
+
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return cls.model_validate(data)
+        except Exception:
+            return cls()
+
+    def save(self, path: Path) -> None:
+        import json
+
+        path.write_text(
+            json.dumps(
+                self.model_dump(mode="json"),
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def timestamp() -> str:
+        return datetime.now(timezone.utc).isoformat()

--- a/src/wiki/schemas/wiki_config.py
+++ b/src/wiki/schemas/wiki_config.py
@@ -23,6 +23,7 @@ from pydantic import (
 
 from ..context import Context
 from .rules import CheckConfig, LintConfig
+from .sources import SourceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ _BLOCK_LABELS = {
     "link": "link",
     "check": "check",
     "lint": "lint",
+    "sources": "sources",
     "sparql_service": "sparql_service",
 }
 
@@ -393,9 +395,31 @@ class Config(BaseModel):
     link: LinkConfig = Field(default_factory=LinkConfig)
     check: CheckConfig = Field(default_factory=CheckConfig)
     lint: LintConfig = Field(default_factory=LintConfig)
+    sources: list[SourceConfig] = Field(default_factory=list)
     fmt: FmtConfig | dict[str, Any] | str | Path | None = None
     sparql_service: SparqlServiceConfig = Field(default_factory=SparqlServiceConfig)
     config_root: Path = Field(default_factory=Path.cwd)
+
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _validate_sources(cls, value: object) -> list[SourceConfig]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            seen: set[str] = set()
+            result = []
+            for item in value:
+                if not isinstance(item, dict):
+                    raise ValueError("each source must be a mapping")
+                if "name" not in item:
+                    raise ValueError("each source must have a name")
+                name = item["name"]
+                if name in seen:
+                    raise ValueError(f"Duplicate source name: {name!r}")
+                seen.add(name)
+                result.append(SourceConfig(**item))
+            return result
+        raise ValueError("sources must be a list")
 
     @field_validator("fmt", mode="before")
     @classmethod

--- a/src/wiki/session.py
+++ b/src/wiki/session.py
@@ -42,6 +42,7 @@ from .schemas import (
     RenderReport,
     ScaffoldResult,
 )
+from .sources import resolve as resolve_sources
 
 _RAW_FORMATS = frozenset({"turtle", "xml", "n3", "nt", "trig", "nquads"})
 
@@ -88,6 +89,12 @@ class Wiki:
                 Path(entry) if Path(entry).is_absolute() else config.config_root / entry
                 for entry in wiki_inputs
             ]
+        resolved = resolve_sources(config)
+        if resolved:
+            existing = set(config.wiki.inputs)
+            for path in resolved:
+                if path not in existing:
+                    config.wiki.inputs.append(path)
         return cls(config)
 
     def with_runtime(

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -65,6 +65,11 @@ def _save_lockfile(config: Config, lockfile: Lockfile) -> None:
     lockfile.save(_lockfile_path(config))
 
 
+def _is_full_sha(ref: str) -> bool:
+    """Return True if *ref* looks like a full 40-character commit SHA."""
+    return bool(re.fullmatch(r"[0-9a-f]{40}", ref))
+
+
 def _git_resolve_ref(ref: str, repo_dir: Path) -> str:
     result = subprocess.run(
         ["git", "rev-parse", ref],
@@ -112,10 +117,30 @@ def _git_clone_or_fetch(source: SourceConfig, cache_dir: Path) -> Path:
             raise RuntimeError(
                 f"Failed to fetch {source.url}: {result.stderr.strip()}"
             )
+
+        # Pinned commit SHAs may not be reachable in a shallow repo —
+        # unshallow so the checkout in _git_prepare_ref can find them.
+        if source.ref and _is_full_sha(source.ref):
+            shallow_check = subprocess.run(
+                ["git", "rev-parse", "--is-shallow-repository"],
+                capture_output=True,
+                text=True,
+                cwd=repo_dir,
+            )
+            if shallow_check.stdout.strip() == "true":
+                subprocess.run(
+                    ["git", "fetch", "--unshallow", "origin"],
+                    capture_output=True,
+                    text=True,
+                    cwd=repo_dir,
+                    check=True,
+                )
     else:
         cache_dir.mkdir(parents=True, exist_ok=True)
+        # Full clone for pinned commit SHAs; shallow is fine for branch/tag refs
+        depth_args = [] if (source.ref and _is_full_sha(source.ref)) else ["--depth", "1"]
         result = subprocess.run(
-            ["git", "clone", "--depth", "1", source.url, str(repo_dir)],
+            ["git", "clone", *depth_args, source.url, str(repo_dir)],
             capture_output=True,
             text=True,
         )

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -50,6 +50,10 @@ def _source_cache_dir(config: Config, source_name: str) -> Path:
 
 
 def _config_path(config: Config) -> Path:
+    for name in CONFIG_FILENAMES:
+        candidate = config.config_root / name
+        if candidate.exists():
+            return candidate
     return config.config_root / "wiki.yml"
 
 
@@ -195,7 +199,7 @@ def _yaml_dump(data: object) -> str:
 def _add_to_wiki_yml(config: Config, source: SourceConfig) -> None:
     config_path = _config_path(config)
     if not config_path.exists():
-        raise RuntimeError("wiki.yml not found")
+        raise RuntimeError("No wiki config file found")
 
     raw = config_path.read_text(encoding="utf-8")
     data = _yaml.load(raw) or {}

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -10,6 +10,7 @@ import logging
 import re
 import shutil
 import subprocess
+from dataclasses import dataclass, field
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -226,6 +227,96 @@ def install(config: Config, url: str | None = None) -> Lockfile:
 
     _save_lockfile(config, lockfile)
     return lockfile
+
+
+@dataclass
+class SourceUpdate:
+    """Result of checking a single source for updates."""
+
+    name: str
+    url: str
+    previous_ref: str
+    current_ref: str
+    updated: bool
+
+
+@dataclass
+class UpdateResult:
+    """Aggregate result of ``update()``."""
+
+    updates: list[SourceUpdate] = field(default_factory=list)
+
+    @property
+    def count(self) -> int:
+        return len(self.updates)
+
+    @property
+    def changed(self) -> list[SourceUpdate]:
+        return [u for u in self.updates if u.updated]
+
+
+def update(config: Config, name: str | None = None, *, dry_run: bool = False) -> UpdateResult:
+    """Check locked sources for newer commits.
+
+    Fetches each source's remote, resolves the current HEAD (or pinned ref),
+    and compares against the locked SHA. With ``dry_run=True``, reports
+    what would change without modifying wiki.lock.
+
+    Returns an ``UpdateResult`` with per-source ``SourceUpdate`` entries.
+    """
+    lockfile = _load_lockfile(config)
+    result = UpdateResult()
+
+    sources = [s for s in config.sources if name is None or s.name == name]
+    if not sources:
+        if name:
+            logger.warning("Source %r not found in wiki.yml.", name)
+        return result
+
+    for source in sources:
+        locked = lockfile.sources.get(source.name)
+        if locked is None:
+            logger.warning("Source %r is not locked. Run 'wiki install' first.", source.name)
+            continue
+
+        cache_dir = _source_cache_dir(config, source.name)
+        repo_dir = _git_clone_or_fetch(source, cache_dir)
+
+        ref_to_check = source.ref or "HEAD"
+        if ref_to_check != "HEAD":
+            subprocess.run(
+                ["git", "checkout", ref_to_check, "--"],
+                capture_output=True,
+                text=True,
+                cwd=repo_dir,
+                check=True,
+            )
+
+        current_ref = _git_resolve_ref("HEAD", repo_dir)
+        previous_ref = locked.resolved_ref
+        updated = current_ref != previous_ref
+
+        if updated and not dry_run:
+            lockfile.sources[source.name] = LockedSource(
+                url=source.url,
+                resolved_ref=current_ref,
+                ref=source.ref,
+                path=source.path,
+                fetched_at=Lockfile.timestamp(),
+            )
+
+        result.updates.append(SourceUpdate(
+            name=source.name,
+            url=source.url,
+            previous_ref=previous_ref[:12] if previous_ref else "",
+            current_ref=current_ref[:12],
+            updated=updated,
+        ))
+
+    if not dry_run and result.changed:
+        _save_lockfile(config, lockfile)
+
+    return result
 
 
 def remove(config: Config, name: str) -> None:

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -1,0 +1,273 @@
+"""External source resolution and lockfile management.
+
+wiki.yml declares desired sources; wiki.lock records the exact resolved
+state. ``wiki install`` fetches and locks; ``wiki remove`` deletes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from .config import Config
+from .schemas.sources import LOCKFILE_FILENAME, LockedSource, Lockfile, SourceConfig
+
+logger = logging.getLogger(__name__)
+
+_yaml = YAML()
+_yaml.indent(mapping=2, sequence=4, offset=2)
+
+
+def _lockfile_path(config: Config) -> Path:
+    return config.config_root / LOCKFILE_FILENAME
+
+
+def _source_cache_dir(config: Config, source_name: str) -> Path:
+    return config.config_root / ".wiki" / "sources" / source_name
+
+
+def _config_path(config: Config) -> Path:
+    return config.config_root / "wiki.yml"
+
+
+def _load_lockfile(config: Config) -> Lockfile:
+    return Lockfile.load(_lockfile_path(config))
+
+
+def _save_lockfile(config: Config, lockfile: Lockfile) -> None:
+    lockfile.save(_lockfile_path(config))
+
+
+def _git_resolve_ref(ref: str, repo_dir: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", ref],
+        capture_output=True,
+        text=True,
+        cwd=repo_dir,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to resolve git ref {ref!r}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def _git_clone_or_fetch(source: SourceConfig, cache_dir: Path) -> Path:
+    repo_dir = cache_dir / "repo"
+    if repo_dir.exists():
+        result = subprocess.run(
+            ["git", "fetch", "--tags", "--force", "origin"],
+            capture_output=True,
+            text=True,
+            cwd=repo_dir,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to fetch {source.url}: {result.stderr.strip()}"
+            )
+    else:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", source.url, str(repo_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            shutil.rmtree(cache_dir, ignore_errors=True)
+            raise RuntimeError(
+                f"Failed to clone {source.url}: {result.stderr.strip()}"
+            )
+    return repo_dir
+
+
+def _source_resolved_path(source: SourceConfig, repo_dir: Path) -> Path:
+    base = repo_dir / source.path if source.path else repo_dir
+    if not base.exists():
+        raise RuntimeError(
+            f"Source {source.name!r}: path {source.path!r} does not exist"
+        )
+    return base.resolve()
+
+
+def _infer_name_from_url(url: str) -> str:
+    stem = url.rstrip("/").rsplit("/", 1)[-1]
+    stem = re.sub(r"(\.wiki|\.git)$", "", stem, flags=re.IGNORECASE)
+    return stem or "source"
+
+
+def _parse_url_ref(url: str) -> tuple[str, str | None]:
+    if "#" in url:
+        url, ref = url.rsplit("#", 1)
+        return url, ref or None
+    return url, None
+
+
+def _yaml_dump(data: object) -> str:
+    buf = StringIO()
+    _yaml.dump(data, buf)
+    return buf.getvalue().rstrip() + "\n"
+
+
+def _add_to_wiki_yml(config: Config, source: SourceConfig) -> None:
+    config_path = _config_path(config)
+    if not config_path.exists():
+        raise RuntimeError("wiki.yml not found")
+
+    raw = config_path.read_text(encoding="utf-8")
+    data = _yaml.load(raw) or {}
+
+    sources = data.get("sources")
+    if sources is None:
+        sources = []
+        data["sources"] = sources
+
+    if not isinstance(sources, list):
+        raise RuntimeError("wiki.yml sources must be a list")
+
+    for existing in sources:
+        if isinstance(existing, dict) and existing.get("name") == source.name:
+            raise RuntimeError(f"Source {source.name!r} already exists in wiki.yml")
+
+    entry: dict[str, Any] = {"name": source.name, "type": "git", "url": source.url}
+    if source.ref:
+        entry["ref"] = source.ref
+    if source.path:
+        entry["path"] = source.path
+    sources.append(entry)
+
+    config_path.write_text(_yaml_dump(data), encoding="utf-8")
+
+
+def _remove_from_wiki_yml(config: Config, name: str) -> None:
+    config_path = _config_path(config)
+    if not config_path.exists():
+        return
+
+    raw = config_path.read_text(encoding="utf-8")
+    data = _yaml.load(raw)
+    if data is None:
+        return
+
+    sources = data.get("sources")
+    if not isinstance(sources, list):
+        return
+
+    new_sources = [s for s in sources if not (isinstance(s, dict) and s.get("name") == name)]
+    if len(new_sources) == len(sources):
+        raise RuntimeError(f"Source {name!r} not found in wiki.yml")
+
+    if new_sources:
+        data["sources"] = new_sources
+    else:
+        del data["sources"]
+
+    config_path.write_text(_yaml_dump(data), encoding="utf-8")
+
+
+def install(config: Config, url: str | None = None) -> Lockfile:
+    """Fetch and lock sources.
+
+    With no url, fetches all sources from wiki.yml and updates wiki.lock.
+    With a url, adds a new source to wiki.yml, fetches it, and updates
+    wiki.lock.
+
+    Returns the updated Lockfile.
+    """
+    if url:
+        clean_url, ref = _parse_url_ref(url)
+        name = _infer_name_from_url(clean_url)
+        source = SourceConfig(name=name, type="git", url=clean_url, ref=ref)
+        _add_to_wiki_yml(config, source)
+        config.sources = list(config.sources) + [source]
+    elif not config.sources:
+        logger.info("No sources declared in wiki.yml.")
+        return _load_lockfile(config)
+
+    lockfile = _load_lockfile(config)
+
+    for source in config.sources:
+        logger.info("Installing source %r from %s", source.name, source.url)
+        cache_dir = _source_cache_dir(config, source.name)
+        repo_dir = _git_clone_or_fetch(source, cache_dir)
+
+        ref_to_check = source.ref or "HEAD"
+        if ref_to_check != "HEAD":
+            subprocess.run(
+                ["git", "checkout", ref_to_check, "--"],
+                capture_output=True,
+                text=True,
+                cwd=repo_dir,
+                check=True,
+            )
+
+        resolved_ref = _git_resolve_ref("HEAD", repo_dir)
+        resolved_path = _source_resolved_path(source, repo_dir)
+
+        lockfile.sources[source.name] = LockedSource(
+            url=source.url,
+            resolved_ref=resolved_ref,
+            ref=source.ref,
+            path=source.path,
+            fetched_at=Lockfile.timestamp(),
+        )
+        logger.info(
+            "Locked source %r at %s -> %s",
+            source.name,
+            resolved_ref[:12],
+            resolved_path,
+        )
+
+    _save_lockfile(config, lockfile)
+    return lockfile
+
+
+def remove(config: Config, name: str) -> None:
+    """Remove a source from wiki.yml, its cache, and wiki.lock."""
+    cache_dir = _source_cache_dir(config, name)
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+        logger.info("Removed cache for source %r", name)
+
+    lockfile = _load_lockfile(config)
+    if name in lockfile.sources:
+        del lockfile.sources[name]
+        _save_lockfile(config, lockfile)
+        logger.info("Removed lock entry for source %r", name)
+
+    _remove_from_wiki_yml(config, name)
+    logger.info("Removed source %r from wiki.yml", name)
+
+
+def resolve(config: Config) -> list[Path]:
+    """Return resolved local paths for all locked sources.
+
+    Reads wiki.lock and returns the local paths of cached sources.
+    Does NOT fetch — use ``install()`` to ensure sources are up to date.
+    """
+    if not config.sources:
+        return []
+
+    lockfile = _load_lockfile(config)
+    resolved: list[Path] = []
+
+    for source in config.sources:
+        locked = lockfile.sources.get(source.name)
+        if locked is None:
+            logger.warning("Source %r is not locked. Run 'wiki install' first.", source.name)
+            continue
+
+        repo_dir = _source_cache_dir(config, source.name) / "repo"
+        if not repo_dir.exists():
+            logger.warning("Source %r is not cached. Run 'wiki install' first.", source.name)
+            continue
+
+        resolved.append(_source_resolved_path(source, repo_dir))
+
+    return resolved

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -166,6 +166,33 @@ def _git_prepare_ref(source: SourceConfig, repo_dir: Path) -> None:
                     cwd=repo_dir,
                     check=True,
                 )
+            else:
+                branch_r_result = subprocess.run(
+                    ["git", "branch", "-r"],
+                    capture_output=True,
+                    text=True,
+                    cwd=repo_dir,
+                )
+                if branch_r_result.returncode == 0:
+                    refs = [
+                        b.strip().removeprefix("origin/")
+                        for b in branch_r_result.stdout.strip().splitlines()
+                        if b.strip().startswith("origin/")
+                    ]
+                    preferred = None
+                    for candidate in ("main", "master"):
+                        if candidate in refs:
+                            preferred = candidate
+                            break
+                    default_branch = preferred or (refs[0] if refs else None)
+                    if default_branch:
+                        subprocess.run(
+                            ["git", "checkout", default_branch, "--"],
+                            capture_output=True,
+                            text=True,
+                            cwd=repo_dir,
+                            check=True,
+                        )
 
 
 def _source_resolved_path(source: SourceConfig, repo_dir: Path) -> Path:

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -25,6 +25,21 @@ logger = logging.getLogger(__name__)
 _yaml = YAML()
 _yaml.indent(mapping=2, sequence=4, offset=2)
 
+_OWNER_REPO_SHORTHAND = re.compile(
+    r"^(?P<owner>[a-zA-Z0-9._-]+)/(?P<repo>[a-zA-Z0-9._-]+?)(?:\.git)?$"
+)
+
+
+def _expand_source_url(url: str) -> str:
+    """Expand ``owner/repo`` shorthand to ``https://github.com/owner/repo.git``.
+
+    Full URLs (HTTPS, SSH) and non-GitHub URLs pass through unchanged.
+    """
+    match = _OWNER_REPO_SHORTHAND.match(url)
+    if match:
+        return f"https://github.com/{match.group('owner')}/{match.group('repo')}.git"
+    return url
+
 
 def _lockfile_path(config: Config) -> Path:
     return config.config_root / LOCKFILE_FILENAME
@@ -63,8 +78,28 @@ def _git_resolve_ref(ref: str, repo_dir: Path) -> str:
 def _git_clone_or_fetch(source: SourceConfig, cache_dir: Path) -> Path:
     repo_dir = cache_dir / "repo"
     if repo_dir.exists():
+        url_result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            cwd=repo_dir,
+        )
+        if url_result.returncode == 0 and url_result.stdout.strip() != source.url:
+            subprocess.run(
+                ["git", "remote", "set-url", "origin", source.url],
+                capture_output=True,
+                text=True,
+                cwd=repo_dir,
+                check=True,
+            )
+            logger.info(
+                "Updated remote URL for source from %s to %s",
+                url_result.stdout.strip(),
+                source.url,
+            )
+
         result = subprocess.run(
-            ["git", "fetch", "--tags", "--force", "origin"],
+            ["git", "fetch", "--tags", "--force", "origin", "+refs/heads/*:refs/heads/*"],
             capture_output=True,
             text=True,
             cwd=repo_dir,
@@ -86,6 +121,47 @@ def _git_clone_or_fetch(source: SourceConfig, cache_dir: Path) -> Path:
                 f"Failed to clone {source.url}: {result.stderr.strip()}"
             )
     return repo_dir
+
+
+def _git_prepare_ref(source: SourceConfig, repo_dir: Path) -> None:
+    """After fetch, ensure the repo is checked out at the right ref.
+
+    For pinned refs (branch, tag, or commit), checks out that ref.
+    For unpinned sources (no ref), gets on a local branch if detached
+    HEAD (handles switching from a pinned tag to an unpinned default).
+    """
+    ref = source.ref
+    if ref is not None:
+        subprocess.run(
+            ["git", "checkout", ref, "--"],
+            capture_output=True,
+            text=True,
+            cwd=repo_dir,
+            check=True,
+        )
+    else:
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=repo_dir,
+        )
+        if branch_result.stdout.strip() == "HEAD":
+            sym_result = subprocess.run(
+                ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=repo_dir,
+            )
+            if sym_result.returncode == 0:
+                default_branch = sym_result.stdout.strip().removeprefix("refs/remotes/origin/")
+                subprocess.run(
+                    ["git", "checkout", default_branch, "--"],
+                    capture_output=True,
+                    text=True,
+                    cwd=repo_dir,
+                    check=True,
+                )
 
 
 def _source_resolved_path(source: SourceConfig, repo_dir: Path) -> Path:
@@ -152,9 +228,7 @@ def _remove_from_wiki_yml(config: Config, name: str) -> None:
         return
 
     raw = config_path.read_text(encoding="utf-8")
-    data = _yaml.load(raw)
-    if data is None:
-        return
+    data = _yaml.load(raw) or {}
 
     sources = data.get("sources")
     if not isinstance(sources, list):
@@ -183,13 +257,14 @@ def install(config: Config, url: str | None = None) -> Lockfile:
     """
     if url:
         clean_url, ref = _parse_url_ref(url)
+        clean_url = _expand_source_url(clean_url)
         name = _infer_name_from_url(clean_url)
         source = SourceConfig(name=name, type="git", url=clean_url, ref=ref)
         _add_to_wiki_yml(config, source)
         config.sources = list(config.sources) + [source]
     elif not config.sources:
         logger.info("No sources declared in wiki.yml.")
-        return _load_lockfile(config)
+        return Lockfile()
 
     lockfile = _load_lockfile(config)
 
@@ -197,16 +272,7 @@ def install(config: Config, url: str | None = None) -> Lockfile:
         logger.info("Installing source %r from %s", source.name, source.url)
         cache_dir = _source_cache_dir(config, source.name)
         repo_dir = _git_clone_or_fetch(source, cache_dir)
-
-        ref_to_check = source.ref or "HEAD"
-        if ref_to_check != "HEAD":
-            subprocess.run(
-                ["git", "checkout", ref_to_check, "--"],
-                capture_output=True,
-                text=True,
-                cwd=repo_dir,
-                check=True,
-            )
+        _git_prepare_ref(source, repo_dir)
 
         resolved_ref = _git_resolve_ref("HEAD", repo_dir)
         resolved_path = _source_resolved_path(source, repo_dir)
@@ -281,16 +347,7 @@ def update(config: Config, name: str | None = None, *, dry_run: bool = False) ->
 
         cache_dir = _source_cache_dir(config, source.name)
         repo_dir = _git_clone_or_fetch(source, cache_dir)
-
-        ref_to_check = source.ref or "HEAD"
-        if ref_to_check != "HEAD":
-            subprocess.run(
-                ["git", "checkout", ref_to_check, "--"],
-                capture_output=True,
-                text=True,
-                cwd=repo_dir,
-                check=True,
-            )
+        _git_prepare_ref(source, repo_dir)
 
         current_ref = _git_resolve_ref("HEAD", repo_dir)
         previous_ref = locked.resolved_ref
@@ -359,6 +416,10 @@ def resolve(config: Config) -> list[Path]:
             logger.warning("Source %r is not cached. Run 'wiki install' first.", source.name)
             continue
 
-        resolved.append(_source_resolved_path(source, repo_dir))
+        try:
+            resolved.append(_source_resolved_path(source, repo_dir))
+        except RuntimeError as exc:
+            logger.warning("Source %r: %s", source.name, exc)
+            continue
 
     return resolved

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
-from .config import Config
+from .config import CONFIG_FILENAMES, Config
 from .schemas.sources import LOCKFILE_FILENAME, LockedSource, Lockfile, SourceConfig
 
 logger = logging.getLogger(__name__)
@@ -246,12 +246,117 @@ def _remove_from_wiki_yml(config: Config, name: str) -> None:
     config_path.write_text(_yaml_dump(data), encoding="utf-8")
 
 
+def _discover_sources(repo_dir: Path) -> list[SourceConfig]:
+    """Read ``wiki.yml`` (or ``wiki.yaml``/``wiki.json``) from a cloned
+    source repo to discover its declared transitive dependencies.
+
+    Only the ``sources:`` block is read — graph, check, and lint config
+    from transitive deps are not merged.  Returns ``[]`` when no config
+    file or no ``sources:`` block exists (leaf source).
+    """
+    for name in CONFIG_FILENAMES:
+        config_file = repo_dir / name
+        if config_file.exists():
+            try:
+                raw = config_file.read_text(encoding="utf-8")
+                data = _yaml.load(raw)
+                if isinstance(data, dict) and isinstance(data.get("sources"), list):
+                    return [SourceConfig(**s) for s in data["sources"]]
+            except Exception as exc:
+                logger.warning(
+                    "Failed to read sources from %s: %s", config_file, exc
+                )
+            break  # found a config file, even if malformed
+    return []
+
+
+def _install_tree(
+    config: Config,
+    sources: list[SourceConfig],
+    lockfile: Lockfile,
+    *,
+    parent: str | None,
+    visited: set[str],
+    path: list[str],
+) -> None:
+    """Recursive dependency-tree walker.
+
+    * ``parent`` — name of the source that declared these deps, or
+      ``None`` for top-level entries.
+    * ``visited`` — set of already-processed source names (shared
+      across the whole install run).
+    * ``path`` — ancestor chain for cycle detection.
+    """
+    for source in sources:
+        # ---- cycle detection ---------------------------------------------------
+        if source.name in path:
+            cycle = " -> ".join(path + [source.name])
+            raise RuntimeError(f"Circular dependency detected: {cycle}")
+
+        # ---- deduplication / conflict check ------------------------------------
+        if source.name in visited:
+            existing = lockfile.sources[source.name]
+            if existing.url != source.url or existing.ref != source.ref:
+                raise RuntimeError(
+                    f"Source {source.name!r} conflict: "
+                    f"already locked as {existing.url}@{existing.ref or 'HEAD'}, "
+                    f"but {parent or 'root'} declares "
+                    f"{source.url}@{source.ref or 'HEAD'}"
+                )
+            if parent is not None and parent not in existing.required_by:
+                existing.required_by.append(parent)
+            continue
+
+        visited.add(source.name)
+
+        # ---- clone / fetch / checkout ------------------------------------------
+        logger.info("Installing source %r from %s", source.name, source.url)
+        cache_dir = _source_cache_dir(config, source.name)
+        repo_dir = _git_clone_or_fetch(source, cache_dir)
+        _git_prepare_ref(source, repo_dir)
+
+        resolved_ref = _git_resolve_ref("HEAD", repo_dir)
+        resolved_path = _source_resolved_path(source, repo_dir)
+
+        lockfile.sources[source.name] = LockedSource(
+            url=source.url,
+            resolved_ref=resolved_ref,
+            ref=source.ref,
+            path=source.path,
+            fetched_at=Lockfile.timestamp(),
+            required_by=[parent] if parent is not None else [],
+        )
+        logger.info(
+            "Locked source %r at %s -> %s",
+            source.name,
+            resolved_ref[:12],
+            resolved_path,
+        )
+
+        # ---- recurse into transitive dependencies ------------------------------
+        transitive = _discover_sources(repo_dir)
+        if transitive:
+            _install_tree(
+                config,
+                transitive,
+                lockfile,
+                parent=source.name,
+                visited=visited,
+                path=path + [source.name],
+            )
+
+
 def install(config: Config, url: str | None = None) -> Lockfile:
     """Fetch and lock sources.
 
     With no url, fetches all sources from wiki.yml and updates wiki.lock.
     With a url, adds a new source to wiki.yml, fetches it, and updates
     wiki.lock.
+
+    Transitive dependencies are resolved recursively: each source's own
+    ``wiki.yml`` is checked for a ``sources:`` block, and those sources
+    are fetched and locked too.  Circular dependency chains are detected
+    and raise ``RuntimeError``.
 
     Returns the updated Lockfile.
     """
@@ -267,29 +372,16 @@ def install(config: Config, url: str | None = None) -> Lockfile:
         return Lockfile()
 
     lockfile = _load_lockfile(config)
+    visited: set[str] = set(lockfile.sources.keys())
 
-    for source in config.sources:
-        logger.info("Installing source %r from %s", source.name, source.url)
-        cache_dir = _source_cache_dir(config, source.name)
-        repo_dir = _git_clone_or_fetch(source, cache_dir)
-        _git_prepare_ref(source, repo_dir)
-
-        resolved_ref = _git_resolve_ref("HEAD", repo_dir)
-        resolved_path = _source_resolved_path(source, repo_dir)
-
-        lockfile.sources[source.name] = LockedSource(
-            url=source.url,
-            resolved_ref=resolved_ref,
-            ref=source.ref,
-            path=source.path,
-            fetched_at=Lockfile.timestamp(),
-        )
-        logger.info(
-            "Locked source %r at %s -> %s",
-            source.name,
-            resolved_ref[:12],
-            resolved_path,
-        )
+    _install_tree(
+        config,
+        config.sources,
+        lockfile,
+        parent=None,
+        visited=visited,
+        path=[],
+    )
 
     _save_lockfile(config, lockfile)
     return lockfile
@@ -321,12 +413,41 @@ class UpdateResult:
         return [u for u in self.updates if u.updated]
 
 
-def update(config: Config, name: str | None = None, *, dry_run: bool = False) -> UpdateResult:
+def _report_orphans(config: Config, lockfile: Lockfile) -> None:
+    """Warn about transitive sources that are no longer declared by any
+    parent but still exist in the lockfile.
+
+    This is a read-only diagnostic — no lockfile or cache changes are
+    made.  Users should run ``wiki remove <name>`` to clean up orphans.
+    """
+    remaining_top_level = {s.name for s in config.sources}
+
+    for name, entry in lockfile.sources.items():
+        if name not in remaining_top_level and entry.required_by:
+            logger.warning(
+                "Source %r (required_by=%r) may be orphaned. "
+                "Run 'wiki remove %s' to clean up.",
+                name,
+                entry.required_by,
+                name,
+            )
+
+
+def update(
+    config: Config,
+    name: str | None = None,
+    *,
+    dry_run: bool = False,
+) -> UpdateResult:
     """Check locked sources for newer commits.
 
     Fetches each source's remote, resolves the current HEAD (or pinned ref),
     and compares against the locked SHA. With ``dry_run=True``, reports
     what would change without modifying wiki.lock.
+
+    After updating commits, transitive dependencies are re-synced:
+    newly-declared sources are installed; orphaned sources are reported
+    (not auto-removed).
 
     Returns an ``UpdateResult`` with per-source ``SourceUpdate`` entries.
     """
@@ -342,7 +463,10 @@ def update(config: Config, name: str | None = None, *, dry_run: bool = False) ->
     for source in sources:
         locked = lockfile.sources.get(source.name)
         if locked is None:
-            logger.warning("Source %r is not locked. Run 'wiki install' first.", source.name)
+            logger.warning(
+                "Source %r is not locked. Run 'wiki install' first.",
+                source.name,
+            )
             continue
 
         cache_dir = _source_cache_dir(config, source.name)
@@ -360,6 +484,7 @@ def update(config: Config, name: str | None = None, *, dry_run: bool = False) ->
                 ref=source.ref,
                 path=source.path,
                 fetched_at=Lockfile.timestamp(),
+                required_by=locked.required_by,
             )
 
         result.updates.append(SourceUpdate(
@@ -370,14 +495,78 @@ def update(config: Config, name: str | None = None, *, dry_run: bool = False) ->
             updated=updated,
         ))
 
-    if not dry_run and result.changed:
-        _save_lockfile(config, lockfile)
+    if not dry_run:
+        if result.changed:
+            _save_lockfile(config, lockfile)
+
+        # ---- re-sync transitive dependency tree --------------------------------
+        visited: set[str] = set(lockfile.sources.keys())
+        for source in config.sources:
+            repo_dir = _source_cache_dir(config, source.name) / "repo"
+            if repo_dir.exists():
+                transitive = _discover_sources(repo_dir)
+                if transitive:
+                    _install_tree(
+                        config,
+                        transitive,
+                        lockfile,
+                        parent=source.name,
+                        visited=visited,
+                        path=[],
+                    )
+        if visited != set(lockfile.sources.keys()):
+            _save_lockfile(config, lockfile)
+
+        _report_orphans(config, lockfile)
 
     return result
 
 
+def _remove_orphans(
+    config: Config, lockfile: Lockfile, removed_name: str
+) -> None:
+    """Recursively remove transitive sources that are no longer needed.
+
+    After ``removed_name`` is deleted, walk all remaining lockfile entries
+    and remove ``removed_name`` from their ``required_by`` lists.  Any
+    entry whose ``required_by`` becomes empty and is **not** a top-level
+    source (declared in the root ``wiki.yml``) is an orphan — delete its
+    cache, remove it from the lockfile, and recurse in case *its*
+    dependants become orphans too.
+    """
+    remaining_top_level = {s.name for s in config.sources}
+
+    for entry in lockfile.sources.values():
+        if removed_name in entry.required_by:
+            entry.required_by = [r for r in entry.required_by if r != removed_name]
+
+    orphaned = [
+        n
+        for n, e in lockfile.sources.items()
+        if not e.required_by and n not in remaining_top_level
+    ]
+
+    for orphan in orphaned:
+        cache_dir = _source_cache_dir(config, orphan)
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir)
+            logger.info("Removed cache for orphaned transitive source %r", orphan)
+        del lockfile.sources[orphan]
+        logger.info(
+            "Removed orphaned transitive source %r from lockfile", orphan
+        )
+        _remove_orphans(config, lockfile, orphan)  # cascade
+
+
 def remove(config: Config, name: str) -> None:
-    """Remove a source from wiki.yml, its cache, and wiki.lock."""
+    """Remove a source from wiki.yml, its cache, and wiki.lock.
+
+    Transitive dependencies that are no longer required by any remaining
+    top-level source are automatically cleaned up (cache and lockfile
+    entry removed).
+    """
+    _remove_from_wiki_yml(config, name)
+
     cache_dir = _source_cache_dir(config, name)
     if cache_dir.exists():
         shutil.rmtree(cache_dir)
@@ -386,40 +575,46 @@ def remove(config: Config, name: str) -> None:
     lockfile = _load_lockfile(config)
     if name in lockfile.sources:
         del lockfile.sources[name]
+        _remove_orphans(config, lockfile, name)
         _save_lockfile(config, lockfile)
         logger.info("Removed lock entry for source %r", name)
 
-    _remove_from_wiki_yml(config, name)
-    logger.info("Removed source %r from wiki.yml", name)
-
 
 def resolve(config: Config) -> list[Path]:
-    """Return resolved local paths for all locked sources.
+    """Return resolved local paths for all locked sources (including
+    transitive dependencies).
 
-    Reads wiki.lock and returns the local paths of cached sources.
+    Reads ``wiki.lock`` and returns the local paths of all cached sources
+    — both top-level (declared in the root ``wiki.yml``) and transitive
+    (declared by those sources' own ``wiki.yml`` files).
+
     Does NOT fetch — use ``install()`` to ensure sources are up to date.
     """
-    if not config.sources:
+    lockfile = _load_lockfile(config)
+    if not lockfile.sources:
         return []
 
-    lockfile = _load_lockfile(config)
     resolved: list[Path] = []
 
-    for source in config.sources:
-        locked = lockfile.sources.get(source.name)
-        if locked is None:
-            logger.warning("Source %r is not locked. Run 'wiki install' first.", source.name)
-            continue
-
-        repo_dir = _source_cache_dir(config, source.name) / "repo"
+    for name, locked in lockfile.sources.items():
+        repo_dir = _source_cache_dir(config, name) / "repo"
         if not repo_dir.exists():
-            logger.warning("Source %r is not cached. Run 'wiki install' first.", source.name)
+            logger.warning(
+                "Source %r is not cached. Run 'wiki install' first.", name
+            )
             continue
 
+        source = SourceConfig(
+            name=name,
+            type="git",
+            url=locked.url,
+            ref=locked.ref,
+            path=locked.path,
+        )
         try:
             resolved.append(_source_resolved_path(source, repo_dir))
         except RuntimeError as exc:
-            logger.warning("Source %r: %s", source.name, exc)
+            logger.warning("Source %r: %s", name, exc)
             continue
 
     return resolved

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -261,7 +261,17 @@ def _discover_sources(repo_dir: Path) -> list[SourceConfig]:
                 raw = config_file.read_text(encoding="utf-8")
                 data = _yaml.load(raw)
                 if isinstance(data, dict) and isinstance(data.get("sources"), list):
-                    return [SourceConfig(**s) for s in data["sources"]]
+                    result: list[SourceConfig] = []
+                    for s in data["sources"]:
+                        try:
+                            result.append(SourceConfig(**s))
+                        except Exception as exc:
+                            logger.warning(
+                                "Skipping invalid source entry in %s: %s",
+                                config_file,
+                                exc,
+                            )
+                    return result
             except Exception as exc:
                 logger.warning(
                     "Failed to read sources from %s: %s", config_file, exc

--- a/src/wiki/templates/wiki.yml
+++ b/src/wiki/templates/wiki.yml
@@ -105,6 +105,14 @@ lint:
   # Wikilinks in body when link.style is standard.
   link_style: warning
 
+# External data sources (git repos with wiki pages / RDF data to merge).
+# Run 'wiki install' to fetch and lock declared sources.
+# sources:
+#   - name: shared-taxonomy
+#     type: git
+#     url: https://github.com/example/taxonomy.wiki.git
+#     ref: v1.2.0
+
 # Optional SPARQL HTTP endpoint on wiki serve (opt-in).
 # sparql_service:
 #   enabled: false

--- a/tests/test_init_scaffold.py
+++ b/tests/test_init_scaffold.py
@@ -14,6 +14,7 @@ from wiki.config import Config
 from wiki.fmt_util import DEFAULT_FMT_OPTS
 from wiki.init_scaffold import (
     InitOptions,
+    _scaffold_wiki,
     detect_origin_repo,
     infer_github_pages_urls,
     load_packaged_official_layout,
@@ -272,3 +273,33 @@ class TestInitLockstep(TestCase):
             if field in INIT_ONLY_OPTIONS:
                 continue
             self.assertIn(field, INIT_OPTIONS_TO_CONFIG_PATH, f"InitOptions field '{field}' is not mapped in INIT_OPTIONS_TO_CONFIG_PATH.")
+
+
+class TestScaffoldGitignore(TestCase):
+    def test_scaffold_creates_gitignore(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            result = _scaffold_wiki(
+                root,
+                InitOptions(graph_context_wiki="https://example.org/wiki/"),
+            )
+            self.assertTrue(result.ok)
+            gitignore = root / ".gitignore"
+            self.assertTrue(gitignore.exists())
+            content = gitignore.read_text(encoding="utf-8")
+            self.assertIn(".wiki/", content)
+            self.assertIn("_site/", content)
+
+    def test_scaffold_skips_existing_gitignore(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            existing = root / ".gitignore"
+            existing.write_text("# custom\n.env/\n", encoding="utf-8")
+            result = _scaffold_wiki(
+                root,
+                InitOptions(graph_context_wiki="https://example.org/wiki/"),
+            )
+            self.assertTrue(result.ok)
+            content = existing.read_text(encoding="utf-8")
+            self.assertIn(".env/", content)
+            self.assertNotIn(".wiki/", content)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,12 +1,19 @@
+import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 import yaml
 
 from wiki.config import Config
-from wiki.schemas.sources import LockedSource, Lockfile, SourceConfig
-from wiki.sources import _expand_source_url
+from wiki.schemas.sources import LOCKFILE_VERSION, LockedSource, Lockfile, SourceConfig
+from wiki.sources import (
+    _discover_sources,
+    _expand_source_url,
+    _install_tree,
+    _remove_orphans,
+)
 
 
 class TestSourceConfig(unittest.TestCase):
@@ -35,7 +42,7 @@ class TestSourceConfig(unittest.TestCase):
 class TestLockfile(unittest.TestCase):
     def test_empty_lockfile(self) -> None:
         lf = Lockfile()
-        self.assertEqual(lf.version, 1)
+        self.assertEqual(lf.version, LOCKFILE_VERSION)
         self.assertEqual(lf.sources, {})
 
     def test_load_non_existent(self) -> None:
@@ -59,7 +66,7 @@ class TestLockfile(unittest.TestCase):
             self.assertTrue(lock_path.exists())
 
             loaded = Lockfile.load(lock_path)
-            self.assertEqual(loaded.version, 1)
+            self.assertEqual(loaded.version, LOCKFILE_VERSION)
             self.assertIn("test", loaded.sources)
             self.assertEqual(loaded.sources["test"].url, "https://example.com/repo.git")
             self.assertEqual(loaded.sources["test"].resolved_ref, "abc123def456")
@@ -75,6 +82,68 @@ class TestLockfile(unittest.TestCase):
         ts = Lockfile.timestamp()
         self.assertIn("T", ts)
         self.assertIn("+", ts)
+
+    def test_required_by_roundtrip(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "wiki.lock"
+            lf = Lockfile(
+                sources={
+                    "leaf": LockedSource(
+                        url="https://example.com/leaf.git",
+                        resolved_ref="aaa",
+                        fetched_at="2025-01-01T00:00:00+00:00",
+                        required_by=["root"],
+                    ),
+                    "root": LockedSource(
+                        url="https://example.com/root.git",
+                        resolved_ref="bbb",
+                        fetched_at="2025-01-01T00:00:00+00:00",
+                        required_by=[],
+                    ),
+                }
+            )
+            lf.save(lock_path)
+            loaded = Lockfile.load(lock_path)
+            self.assertEqual(loaded.sources["leaf"].required_by, ["root"])
+            self.assertEqual(loaded.sources["root"].required_by, [])
+
+    def test_v1_backward_compat(self) -> None:
+        """V1 lockfiles lack required_by; it should default to []."""
+        with TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "wiki.lock"
+            v1_data = {
+                "version": 1,
+                "sources": {
+                    "old": {
+                        "url": "https://example.com/old.git",
+                        "resolved_ref": "abc",
+                        "fetched_at": "2025-01-01T00:00:00+00:00",
+                    }
+                },
+            }
+            lock_path.write_text(json.dumps(v1_data), encoding="utf-8")
+            loaded = Lockfile.load(lock_path)
+            self.assertEqual(loaded.version, 1)
+            self.assertEqual(loaded.sources["old"].required_by, [])
+
+    def test_required_by_preserved_through_version_bump(self) -> None:
+        """On save, required_by should be serialized and loadable."""
+        with TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "wiki.lock"
+            original = Lockfile(
+                sources={
+                    "mid": LockedSource(
+                        url="https://example.com/mid.git",
+                        resolved_ref="ccc",
+                        fetched_at="2025-01-01T00:00:00+00:00",
+                        required_by=["top"],
+                    ),
+                }
+            )
+            original.save(lock_path)
+            raw = json.loads(lock_path.read_text(encoding="utf-8"))
+            self.assertIn("required_by", raw["sources"]["mid"])
+            self.assertEqual(raw["sources"]["mid"]["required_by"], ["top"])
 
 
 class TestConfigSources(unittest.TestCase):
@@ -177,6 +246,391 @@ class TestExpandSourceUrl(unittest.TestCase):
     def test_triple_path_segment_passthrough(self) -> None:
         url = "a/b/c"
         self.assertEqual(_expand_source_url(url), url)
+
+
+class TestDiscoverSources(unittest.TestCase):
+    def test_no_config_file(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            sources = _discover_sources(Path(tmpdir))
+            self.assertEqual(sources, [])
+
+    def test_no_sources_block(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "wiki.yml").write_text(
+                yaml.dump({"wiki": {"inputs": "pages"}}), encoding="utf-8"
+            )
+            sources = _discover_sources(Path(tmpdir))
+            self.assertEqual(sources, [])
+
+    def test_has_sources(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "wiki.yml").write_text(
+                yaml.dump({
+                    "wiki": {"inputs": "pages"},
+                    "sources": [
+                        {"name": "dep-a", "type": "git", "url": "https://example.com/a.git"},
+                        {"name": "dep-b", "type": "git", "url": "https://example.com/b.git", "ref": "v1.0"},
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            sources = _discover_sources(Path(tmpdir))
+            self.assertEqual(len(sources), 2)
+            self.assertEqual(sources[0].name, "dep-a")
+            self.assertEqual(sources[0].url, "https://example.com/a.git")
+            self.assertEqual(sources[1].name, "dep-b")
+            self.assertEqual(sources[1].ref, "v1.0")
+
+    def test_prefers_wiki_yml_over_yaml(self) -> None:
+        """wiki.yml should be found before wiki.yaml (CONFIG_FILENAMES order)."""
+        with TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "wiki.yml").write_text(
+                yaml.dump({"sources": [{"name": "from-yml", "type": "git", "url": "https://x.com"}]}),
+                encoding="utf-8",
+            )
+            (Path(tmpdir) / "wiki.yaml").write_text(
+                yaml.dump({"sources": [{"name": "from-yaml", "type": "git", "url": "https://y.com"}]}),
+                encoding="utf-8",
+            )
+            sources = _discover_sources(Path(tmpdir))
+            self.assertEqual(len(sources), 1)
+            self.assertEqual(sources[0].name, "from-yml")
+
+    def test_malformed_yaml_returns_empty(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "wiki.yml").write_text("{invalid: yaml: [[[", encoding="utf-8")
+            sources = _discover_sources(Path(tmpdir))
+            self.assertEqual(sources, [])
+
+
+def _make_mock_git(
+    config_root: Path,
+    *,
+    repo_factory: dict[str, list[SourceConfig]],
+    fake_sha: str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+):
+    """Create mock patches for git operations.
+
+    ``repo_factory`` maps source names to their transitive deps, or ``[]``
+    for leaf sources.  Each mock repo directory gets a ``wiki.yml`` written
+    when the source has transitive deps.
+    """
+    def mock_clone_or_fetch(source, cache_dir):
+        repo_dir = cache_dir / "repo"
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        deps = repo_factory.get(source.name, [])
+        if deps:
+            (repo_dir / "wiki.yml").write_text(
+                yaml.dump({
+                    "wiki": {"inputs": "pages"},
+                    "sources": [d.model_dump() for d in deps],
+                }),
+                encoding="utf-8",
+            )
+        return repo_dir
+
+    def mock_prepare_ref(source, repo_dir):
+        pass
+
+    def mock_resolve_ref(ref, repo_dir):
+        return fake_sha
+
+    return (
+        patch("wiki.sources._git_clone_or_fetch", side_effect=mock_clone_or_fetch),
+        patch("wiki.sources._git_prepare_ref", side_effect=mock_prepare_ref),
+        patch("wiki.sources._git_resolve_ref", side_effect=mock_resolve_ref),
+    )
+
+
+class TestInstallTree(unittest.TestCase):
+    def _make_config(self, root: Path, sources: list[dict]) -> Config:
+        return Config(
+            config_root=root,
+            wiki={"inputs": ["wiki"]},
+            sources=sources,
+        )
+
+    def test_install_leaf_source(self) -> None:
+        """A single source with no transitive deps."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = self._make_config(root, [
+                {"name": "leaf", "type": "git", "url": "https://example.com/leaf.git"},
+            ])
+            lockfile = Lockfile()
+
+            mock_a, mock_b, mock_c = _make_mock_git(root, repo_factory={"leaf": []})
+            with mock_a, mock_b, mock_c:
+                _install_tree(
+                    config, config.sources, lockfile,
+                    parent=None, visited=set(), path=[],
+                )
+
+            self.assertIn("leaf", lockfile.sources)
+            self.assertEqual(lockfile.sources["leaf"].required_by, [])
+            self.assertEqual(lockfile.sources["leaf"].resolved_ref, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+    def test_install_transitive(self) -> None:
+        """A depends on B; both should be locked with correct required_by."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = self._make_config(root, [
+                {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+            ])
+            lockfile = Lockfile()
+
+            dep_b = [SourceConfig(name="B", type="git", url="https://example.com/B.git")]
+            mock_a, mock_b, mock_c = _make_mock_git(
+                root, repo_factory={"A": dep_b, "B": []},
+            )
+            with mock_a, mock_b, mock_c:
+                _install_tree(
+                    config, config.sources, lockfile,
+                    parent=None, visited=set(), path=[],
+                )
+
+            self.assertIn("A", lockfile.sources)
+            self.assertIn("B", lockfile.sources)
+            self.assertEqual(lockfile.sources["A"].required_by, [])
+            self.assertEqual(lockfile.sources["B"].required_by, ["A"])
+
+    def test_cycle_detection(self) -> None:
+        """A -> B -> A raises RuntimeError."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = self._make_config(root, [
+                {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+            ])
+            lockfile = Lockfile()
+
+            dep_a = [SourceConfig(name="A", type="git", url="https://example.com/A.git")]
+            dep_b = [SourceConfig(name="B", type="git", url="https://example.com/B.git")]
+            # A -> B -> A
+            mock_a, mock_b, mock_c = _make_mock_git(
+                root, repo_factory={"A": dep_b, "B": dep_a},
+            )
+            with mock_a, mock_b, mock_c:
+                with self.assertRaises(RuntimeError) as ctx:
+                    _install_tree(
+                        config, config.sources, lockfile,
+                        parent=None, visited=set(), path=[],
+                    )
+            self.assertIn("Circular dependency", str(ctx.exception))
+            self.assertIn("A -> B -> A", str(ctx.exception))
+
+    def test_dedup(self) -> None:
+        """A and B both depend on C; single lockfile entry with both parents."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = self._make_config(root, [
+                {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+                {"name": "B", "type": "git", "url": "https://example.com/B.git"},
+            ])
+            lockfile = Lockfile()
+
+            dep_c = [SourceConfig(name="C", type="git", url="https://example.com/C.git")]
+            mock_a, mock_b, mock_c = _make_mock_git(
+                root, repo_factory={"A": dep_c, "B": dep_c, "C": []},
+            )
+            with mock_a, mock_b, mock_c:
+                _install_tree(
+                    config, config.sources, lockfile,
+                    parent=None, visited=set(), path=[],
+                )
+
+            self.assertIn("C", lockfile.sources)
+            self.assertCountEqual(lockfile.sources["C"].required_by, ["A", "B"])
+
+    def test_ref_conflict(self) -> None:
+        """A and B declare same name with different refs → error."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            lockfile = Lockfile()
+
+            # Simulate A already installing dep "shared" at v1
+            lockfile.sources["shared"] = LockedSource(
+                url="https://example.com/shared.git",
+                resolved_ref="aaa",
+                ref="v1.0",
+                fetched_at="2025-01-01T00:00:00+00:00",
+                required_by=["A"],
+            )
+
+            # B tries to install the same name at v2 — conflict
+            visited: set[str] = set(lockfile.sources.keys())
+            conflict_source = SourceConfig(
+                name="shared", type="git",
+                url="https://example.com/shared.git", ref="v2.0",
+            )
+
+            with self.assertRaises(RuntimeError) as ctx:
+                _install_tree(
+                    config=self._make_config(root, []),
+                    sources=[conflict_source],
+                    lockfile=lockfile,
+                    parent="B",
+                    visited=visited,
+                    path=[],
+                )
+            self.assertIn("conflict", str(ctx.exception))
+            self.assertIn("shared", str(ctx.exception))
+
+    def test_url_conflict(self) -> None:
+        """A and B declare same name with different URLs → error."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            lockfile = Lockfile()
+            lockfile.sources["shared"] = LockedSource(
+                url="https://example.com/old.git",
+                resolved_ref="aaa",
+                fetched_at="2025-01-01T00:00:00+00:00",
+                required_by=["A"],
+            )
+
+            visited: set[str] = set(lockfile.sources.keys())
+            conflict_source = SourceConfig(
+                name="shared", type="git",
+                url="https://example.com/new.git",
+            )
+
+            with self.assertRaises(RuntimeError) as ctx:
+                _install_tree(
+                    config=self._make_config(root, []),
+                    sources=[conflict_source],
+                    lockfile=lockfile,
+                    parent="B",
+                    visited=visited,
+                    path=[],
+                )
+            self.assertIn("conflict", str(ctx.exception))
+
+    def test_three_deep_chain(self) -> None:
+        """A -> B -> C; all three locked."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = self._make_config(root, [
+                {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+            ])
+            lockfile = Lockfile()
+
+            dep_b = [SourceConfig(name="B", type="git", url="https://example.com/B.git")]
+            dep_c = [SourceConfig(name="C", type="git", url="https://example.com/C.git")]
+            mock_a, mock_b, mock_c = _make_mock_git(
+                root, repo_factory={"A": dep_b, "B": dep_c, "C": []},
+            )
+            with mock_a, mock_b, mock_c:
+                _install_tree(
+                    config, config.sources, lockfile,
+                    parent=None, visited=set(), path=[],
+                )
+
+            self.assertEqual(lockfile.sources["A"].required_by, [])
+            self.assertEqual(lockfile.sources["B"].required_by, ["A"])
+            self.assertEqual(lockfile.sources["C"].required_by, ["B"])
+
+
+class TestRemoveOrphans(unittest.TestCase):
+    def _make_config(self, root: Path, sources: list[dict]) -> Config:
+        return Config(
+            config_root=root,
+            wiki={"inputs": ["wiki"]},
+            sources=sources,
+        )
+
+    def test_remove_orphan_cascade(self) -> None:
+        """A -> B -> C; remove A, B and C orphaned and cleaned up."""
+        root = Path("/mock")
+        config = self._make_config(root, [
+            {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+        ])
+        lockfile = Lockfile()
+        lockfile.sources["A"] = LockedSource(
+            url="https://example.com/A.git", resolved_ref="aaa",
+            required_by=[],
+        )
+        lockfile.sources["B"] = LockedSource(
+            url="https://example.com/B.git", resolved_ref="bbb",
+            required_by=["A"],
+        )
+        lockfile.sources["C"] = LockedSource(
+            url="https://example.com/C.git", resolved_ref="ccc",
+            required_by=["B"],
+        )
+
+        _remove_orphans(config, lockfile, "A")
+
+        self.assertNotIn("B", lockfile.sources)
+        self.assertNotIn("C", lockfile.sources)
+
+    def test_shared_orphan_preserved(self) -> None:
+        """A -> C and B -> C; remove A, C preserved because B still needs it."""
+        root = Path("/mock")
+        config = self._make_config(root, [
+            {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+            {"name": "B", "type": "git", "url": "https://example.com/B.git"},
+        ])
+        lockfile = Lockfile()
+        lockfile.sources["A"] = LockedSource(
+            url="https://example.com/A.git", resolved_ref="aaa",
+            required_by=[],
+        )
+        lockfile.sources["B"] = LockedSource(
+            url="https://example.com/B.git", resolved_ref="bbb",
+            required_by=[],
+        )
+        lockfile.sources["C"] = LockedSource(
+            url="https://example.com/C.git", resolved_ref="ccc",
+            required_by=["A", "B"],
+        )
+
+        _remove_orphans(config, lockfile, "A")
+
+        self.assertIn("C", lockfile.sources)
+        self.assertEqual(lockfile.sources["C"].required_by, ["B"])
+
+    def test_top_level_source_not_orphaned(self) -> None:
+        """A is still in config.sources so it should not be orphaned."""
+        root = Path("/mock")
+        config = self._make_config(root, [
+            {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+        ])
+        lockfile = Lockfile()
+        lockfile.sources["A"] = LockedSource(
+            url="https://example.com/A.git", resolved_ref="aaa",
+            required_by=[],
+        )
+
+        _remove_orphans(config, lockfile, "does-not-exist")
+
+        self.assertIn("A", lockfile.sources)
+
+    def test_cache_removed_for_orphans(self) -> None:
+        """Orphan's cache dir should be rm -rf'd."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = self._make_config(root, [
+                {"name": "A", "type": "git", "url": "https://example.com/A.git"},
+            ])
+
+            # Create cache dirs for A, B
+            (root / ".wiki" / "sources" / "A" / "repo").mkdir(parents=True)
+            (root / ".wiki" / "sources" / "B" / "repo").mkdir(parents=True)
+
+            lockfile = Lockfile()
+            lockfile.sources["A"] = LockedSource(
+                url="https://example.com/A.git", resolved_ref="aaa",
+                required_by=[],
+            )
+            lockfile.sources["B"] = LockedSource(
+                url="https://example.com/B.git", resolved_ref="bbb",
+                required_by=["A"],
+            )
+
+            _remove_orphans(config, lockfile, "A")
+
+            self.assertFalse((root / ".wiki" / "sources" / "B").exists())
+            # A's cache is still there (the caller removed A separately)
+            self.assertTrue((root / ".wiki" / "sources" / "A").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,149 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from wiki.config import Config
+from wiki.schemas.sources import LOCKFILE_FILENAME, LockedSource, Lockfile, SourceConfig
+
+
+class TestSourceConfig(unittest.TestCase):
+    def test_minimal_source(self) -> None:
+        source = SourceConfig(name="test", type="git", url="https://example.com/repo.git")
+        self.assertEqual(source.name, "test")
+        self.assertEqual(source.type, "git")
+        self.assertEqual(source.url, "https://example.com/repo.git")
+        self.assertIsNone(source.ref)
+        self.assertIsNone(source.path)
+
+    def test_full_source(self) -> None:
+        source = SourceConfig(name="test", type="git", url="https://example.com/repo.git", ref="v1.0.0", path="wiki")
+        self.assertEqual(source.ref, "v1.0.0")
+        self.assertEqual(source.path, "wiki")
+
+    def test_rejects_extra_fields(self) -> None:
+        with self.assertRaises(ValueError):
+            SourceConfig(name="test", type="git", url="https://example.com/repo.git", unknown="bad")
+
+    def test_rejects_invalid_type(self) -> None:
+        with self.assertRaises(ValueError):
+            SourceConfig(name="test", type="http", url="https://example.com/repo.git")
+
+
+class TestLockfile(unittest.TestCase):
+    def test_empty_lockfile(self) -> None:
+        lf = Lockfile()
+        self.assertEqual(lf.version, 1)
+        self.assertEqual(lf.sources, {})
+
+    def test_load_non_existent(self) -> None:
+        lf = Lockfile.load(Path("/nonexistent/wiki.lock"))
+        self.assertEqual(lf.sources, {})
+
+    def test_save_and_load_roundtrip(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "wiki.lock"
+            lf = Lockfile(
+                sources={
+                    "test": LockedSource(
+                        url="https://example.com/repo.git",
+                        resolved_ref="abc123def456",
+                        ref="v1.0.0",
+                        fetched_at="2025-01-01T00:00:00+00:00",
+                    )
+                }
+            )
+            lf.save(lock_path)
+            self.assertTrue(lock_path.exists())
+
+            loaded = Lockfile.load(lock_path)
+            self.assertEqual(loaded.version, 1)
+            self.assertIn("test", loaded.sources)
+            self.assertEqual(loaded.sources["test"].url, "https://example.com/repo.git")
+            self.assertEqual(loaded.sources["test"].resolved_ref, "abc123def456")
+
+    def test_load_corrupted(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "wiki.lock"
+            lock_path.write_text("{invalid json", encoding="utf-8")
+            lf = Lockfile.load(lock_path)
+            self.assertEqual(lf.sources, {})
+
+    def test_timestamp_format(self) -> None:
+        ts = Lockfile.timestamp()
+        self.assertIn("T", ts)
+        self.assertIn("+", ts)
+
+
+class TestConfigSources(unittest.TestCase):
+    def test_sources_list_syntax(self) -> None:
+        config = Config(
+            config_root=Path("."),
+            sources=[
+                {"name": "src1", "type": "git", "url": "https://example.com/a.git"},
+                {"name": "src2", "type": "git", "url": "https://example.com/b.git"},
+            ],
+        )
+        self.assertEqual(len(config.sources), 2)
+        self.assertEqual(config.sources[0].name, "src1")
+        self.assertEqual(config.sources[1].name, "src2")
+
+    def test_sources_none(self) -> None:
+        config = Config(config_root=Path("."))
+        self.assertEqual(config.sources, [])
+
+    def test_sources_rejects_duplicate_names(self) -> None:
+        with self.assertRaises(ValueError):
+            Config(
+                config_root=Path("."),
+                sources=[
+                    {"name": "src1", "type": "git", "url": "https://example.com/a.git"},
+                    {"name": "src1", "type": "git", "url": "https://example.com/b.git"},
+                ],
+            )
+
+    def test_sources_rejects_missing_name(self) -> None:
+        with self.assertRaises(ValueError):
+            Config(
+                config_root=Path("."),
+                sources=[{"type": "git", "url": "https://example.com/a.git"}],
+            )
+
+    def test_sources_loaded_from_yaml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            yaml_content = {
+                "wiki": {"inputs": "wiki"},
+                "sources": [
+                    {"name": "taxonomy", "type": "git", "url": "https://example.com/taxonomy.git", "ref": "v1.0"},
+                    {"name": "community", "type": "git", "url": "https://example.com/community.git"},
+                ],
+            }
+            (base_path / "wiki.yaml").write_text(yaml.dump(yaml_content), encoding="utf-8")
+            config = Config.load(base_path)
+            self.assertEqual(len(config.sources), 2)
+            self.assertEqual(config.sources[0].name, "taxonomy")
+            self.assertEqual(config.sources[0].ref, "v1.0")
+
+    def test_sources_unknown_keys_rejected(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            (base_path / "wiki.yaml").write_text(
+                yaml.dump({
+                    "wiki": {"inputs": "wiki"},
+                    "sources": [{"name": "bad", "type": "git", "url": "https://x.com", "extra": True}],
+                }),
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                Config.load(base_path)
+
+    def test_sources_rejects_dict_syntax(self) -> None:
+        with self.assertRaises(ValueError):
+            Config(config_root=Path("."), sources={"src1": {"type": "git", "url": "https://x.com"}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -6,6 +6,7 @@ import yaml
 
 from wiki.config import Config
 from wiki.schemas.sources import LockedSource, Lockfile, SourceConfig
+from wiki.sources import _expand_source_url
 
 
 class TestSourceConfig(unittest.TestCase):
@@ -142,6 +143,40 @@ class TestConfigSources(unittest.TestCase):
     def test_sources_rejects_dict_syntax(self) -> None:
         with self.assertRaises(ValueError):
             Config(config_root=Path("."), sources={"src1": {"type": "git", "url": "https://x.com"}})
+
+
+class TestExpandSourceUrl(unittest.TestCase):
+    def test_owner_repo_shorthand(self) -> None:
+        self.assertEqual(
+            _expand_source_url("EthanThatOneKid/solar-system-wiki"),
+            "https://github.com/EthanThatOneKid/solar-system-wiki.git",
+        )
+
+    def test_owner_repo_with_dot_git(self) -> None:
+        self.assertEqual(
+            _expand_source_url("EthanThatOneKid/solar-system-wiki.git"),
+            "https://github.com/EthanThatOneKid/solar-system-wiki.git",
+        )
+
+    def test_full_https_url_passthrough(self) -> None:
+        url = "https://github.com/EthanThatOneKid/solar-system-wiki.git"
+        self.assertEqual(_expand_source_url(url), url)
+
+    def test_ssh_url_passthrough(self) -> None:
+        url = "git@github.com:EthanThatOneKid/solar-system-wiki.git"
+        self.assertEqual(_expand_source_url(url), url)
+
+    def test_third_party_url_passthrough(self) -> None:
+        url = "https://gitlab.com/owner/repo.git"
+        self.assertEqual(_expand_source_url(url), url)
+
+    def test_single_word_no_slash_passthrough(self) -> None:
+        url = "myrepo"
+        self.assertEqual(_expand_source_url(url), url)
+
+    def test_triple_path_segment_passthrough(self) -> None:
+        url = "a/b/c"
+        self.assertEqual(_expand_source_url(url), url)
 
 
 if __name__ == "__main__":

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -6,7 +5,7 @@ from tempfile import TemporaryDirectory
 import yaml
 
 from wiki.config import Config
-from wiki.schemas.sources import LOCKFILE_FILENAME, LockedSource, Lockfile, SourceConfig
+from wiki.schemas.sources import LockedSource, Lockfile, SourceConfig
 
 
 class TestSourceConfig(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "wazootech-wiki"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -804,6 +804,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rdflib" },
     { name = "rich" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.dev-dependencies]
@@ -833,6 +834,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rdflib", specifier = ">=7.0.0" },
     { name = "rich", specifier = ">=13.7.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Implements local source resolution for wiki, following `npm install` / `deno add` patterns. Declare external git sources in `wiki.yml`, run `wiki install` to fetch and lock, and they're automatically merged into the graph.

This resolves **#148** (local resolution layer) and unblocks **#156** (registry platform) as a separate concern.

## CLI

```
wiki install                          # fetch + lock all sources from wiki.yml
wiki install https://github.com/...   # add to wiki.yml + fetch + lock
wiki remove <name>                    # remove from wiki.yml + delete cache + update lock
```

`wiki install <url>` infers the source name from the URL and supports `#ref` pinning: `wiki install https://github.com/foo/bar.git#v1.0`.

## Changes

- **`src/wiki/schemas/sources.py`** -- `SourceConfig` (git source), `LockedSource` + `Lockfile` (machine-authored `wiki.lock`)
- **`src/wiki/schemas/wiki_config.py`** -- `sources:` block in `_BLOCK_LABELS`, `Config.sources: list[SourceConfig]` with `extra=forbid` validation, list-only syntax
- **`src/wiki/sources.py`** -- `install()`, `remove()`, `resolve()` functions. Uses ruamel.yaml for comment-preserving YAML writes to `wiki.yml`.
- **`src/wiki/session.py`** -- `Wiki.load()` auto-appends resolved source paths to `wiki.inputs`
- **`src/wiki/cli.py`** -- `wiki install` + `wiki remove` top-level commands
- **`pyproject.toml`** -- added `ruamel.yaml` dependency
- **`src/wiki/templates/wiki.yml`** -- commented sources example in scaffold
- **`tests/test_sources.py`** -- 16 tests covering SourceConfig, Lockfile roundtrip, config validation, duplicate/unknown key rejection

## Docs

- **`docs/wiki/Wiki_Subcommand_install.md`** -- new page for `wiki install`
- **`docs/wiki/Wiki_Subcommand_remove.md`** -- new page for `wiki remove`
- **`docs/wiki/Wiki_Configuration.md`** -- `sources:` block reference with field table
- **`docs/wiki/Wiki_CLI.md`** -- added install/remove to command index
- **`CHANGELOG.md`** -- Unreleased section

## Example dataset

[github.com/EthanThatOneKid/solar-system-wiki](https://github.com/EthanThatOneKid/solar-system-wiki) -- a demo wiki with planets, moons, and solar system facts to try `wiki install` against.

## Design decisions

- **Git repos only for v1** -- clear versioning via SHAs, zero changes to document parsing pipeline
- **`wiki.lock` beside `wiki.yml`** -- conventional, matches `package.json`/`package-lock.json` pattern
- **Always fetches** -- `wiki install` doesn't check cache first; repos are shallow clones so it stays fast
- **Same graph** -- resolved sources merge into the same graph; named graphs deferred to #156
- **ruamel.yaml** -- preserves YAML comments when `wiki install <url>` or `wiki remove` edits `wiki.yml`

## Related

- Resolves #148 (local source resolution)
- Builds toward #156 (package registry)
