### PR TITLE
fix: skip invalid source entries individually instead of dropping all

### DIFF
--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -261,7 +261,17 @@ def _discover_sources(repo_dir: Path) -> list[SourceConfig]:
                 raw = config_file.read_text(encoding="utf-8")
                 data = _yaml.load(raw)
                 if isinstance(data, dict) and isinstance(data.get("sources"), list):
-                    return [SourceConfig(**s) for s in data["sources"]]
+                    result: list[SourceConfig] = []
+                    for s in data["sources"]:
+                        try:
+                            result.append(SourceConfig(**s))
+                        except Exception as exc:
+                            logger.warning(
+                                "Skipping invalid source entry in %s: %s",
+                                config_file,
+                                exc,
+                            )
+                    return result
             except Exception as exc:
                 logger.warning(
                     "Failed to read sources from %s: %s", config_file, exc


### PR DESCRIPTION
Replaced the all-or-nothing list comprehension in _discover_sources with per-entry validation. Bad entries are warned and skipped; valid entries are preserved.

Review feedback: https://github.com/wazootech/wiki/pull/164#discussion_r3