### PR TITLE
fix: resolve datetime.datetime as xsd:dateTime instead of xsd:date

### DIFF
--- a/src/wiki/graph.py
+++ b/src/wiki/graph.py
@@ -113,7 +113,9 @@ def resolve_object(key: str, value: Any, graph: Graph, subject: URIRef, context:
         graph.add((subject, pred, Literal(value, datatype=XSD.boolean)))
     elif isinstance(value, (int, float)):
         graph.add((subject, pred, Literal(value)))
-    elif hasattr(value, "isoformat") and hasattr(value, "year"): # Check for datetime/date
+    elif hasattr(value, "hour"):
+        graph.add((subject, pred, Literal(value, datatype=XSD.dateTime)))
+    elif hasattr(value, "isoformat") and hasattr(value, "year"):
         graph.add((subject, pred, Literal(value, datatype=XSD.date)))
     elif value is not None:
         graph.add((subject, pred, Literal(str(value))))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -103,10 +103,14 @@ class TestRDFFrontmatter(unittest.TestCase):
         self.assertEqual(len(list(graph.objects(subject, nothing_pred))), 0)
 
         # 4. Datetime object mapping
-        from datetime import date
+        from datetime import date, datetime
         bday_pred = self.context.namespaces["schema"]["birthDate"]
         resolve_object("birthDate", date(1990, 1, 1), graph, subject, self.context)
         self.assertTrue((subject, bday_pred, Literal(date(1990, 1, 1), datatype=XSD.date)) in graph)
+
+        resolved_pred = self.context.namespaces["schema"]["resolvedAt"]
+        resolve_object("resolvedAt", datetime(2025, 6, 15, 14, 30, 0), graph, subject, self.context)
+        self.assertTrue((subject, resolved_pred, Literal(datetime(2025, 6, 15, 14, 30, 0), datatype=XSD.dateTime)) in graph)
 
         # 5. String with unregistered prefix (falls back to Literal)
         unreg_pred = self.context.namespaces["schema"]["unregistered"]


### PR DESCRIPTION
## Summary

Fixes a bug where `datetime.datetime` objects in frontmatter were serialized as `xsd:date`, silently dropping time/timezone components.

## Changes

- **`src/wiki/graph.py:116-119`** — Added `hasattr(value, "hour")` check before the date-only check. `datetime.datetime` serializes as `xsd:dateTime`, `datetime.date` remains `xsd:date`.
- **`tests/test_graph.py`** — Added test coverage for `datetime.datetime` with `xsd:dateTime`.

Closes #172
