### PR TITLE
fix: make npm publish depend on PyPI publish to avoid race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
 
   publish-npm:
     name: Publish npm
-    needs: verify
+    needs: [verify, publish-pypi]
     if: >-
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && !inputs.skip_npm)


### PR DESCRIPTION
The npm job runs \pip install wazootech-wiki==VERSION\ during its \Install dependencies\ step, but was running in parallel with the PyPI publish job. If npm finished first, pip couldn't find the new version yet.

Adding \publish-pypi\ to \
eeds:\ ensures npm waits for PyPI to finish before installing.