### PR TITLE
Add integration proposal workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration-template.yml
+++ b/.github/ISSUE_TEMPLATE/integration-template.yml
@@ -1,0 +1,218 @@
+name: Wiki integration template proposal
+description: Propose a new Wiki CLI ecosystem template or integration pattern.
+title: "Create wiki-<integration>-template for <use case>"
+labels:
+  - template
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to propose a new `wazootech/wiki-*-template` repository or integration pattern.
+
+        Good proposals make the boundary explicit: Wiki CLI owns the semantic Markdown source layer, validation, querying, export, and publishing. The integration should own a distinct downstream role such as an agent workflow, memory runtime, retrieval index, docs surface, domain model, or work-management bridge.
+
+  - type: input
+    id: integration
+    attributes:
+      label: Integration name
+      description: Name of the external tool, platform, domain, or workflow.
+      placeholder: Open SWE, Mempalace, Qdrant, Linear, healthcare, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: proposed_repo
+    attributes:
+      label: Proposed template repository
+      description: Use the `wiki-<integration>-template` naming pattern unless there is a strong reason not to.
+      placeholder: wazootech/wiki-open-swe-template
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Integration category
+      options:
+        - Agent workflow / coding agent
+        - Runtime memory / retrieval
+        - Static site / publishing surface
+        - Issue tracker / work management
+        - Domain-specific knowledgebase
+        - Ontology / linked data
+        - RAG / GraphRAG / search
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should this template demonstrate?
+      placeholder: |
+        Create `wazootech/wiki-...-template`: a template showing how ... integrates with Wiki CLI to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: Explain the user problem and why this belongs in the Wiki ecosystem.
+      placeholder: |
+        Wiki CLI already provides...
+        The integration provides...
+        Together, they help users avoid...
+    validations:
+      required: true
+
+  - type: textarea
+    id: boundary
+    attributes:
+      label: Boundary between Wiki CLI and the integration
+      description: Make the product boundary explicit. What does each system own?
+      placeholder: |
+        | Responsibility | Wiki CLI | Integration |
+        |---|---|---|
+        | Source of truth | Markdown Wiki corpus | Derived/runtime state |
+        | Validation | SHACL, JSON Schema, lint, fmt | ... |
+        | Retrieval | SPARQL / RDF graph | ... |
+        | Publishing | Static HTML / RDF exports | ... |
+    validations:
+      required: true
+
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Recommended architecture
+      description: Show the intended data/control flow.
+      placeholder: |
+        ```text
+        Wiki Markdown + wiki.yml
+          -> wiki fmt / lint / check / render
+          -> RDF / JSON-LD / static site / query output
+          -> integration-specific runtime or workflow
+          -> cited outputs / PRs / retrieval / reports
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: template_contents
+    attributes:
+      label: Template contents
+      description: List the files, pages, scripts, configs, fixtures, and examples the template should include.
+      placeholder: |
+        Suggested structure:
+
+        ```text
+        .
+        +-- README.md
+        +-- AGENTS.md
+        +-- wiki.yml
+        +-- docs/wiki/
+        +-- queries/
+        +-- scripts/
+        +-- .github/workflows/wiki.yml
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: wiki_corpus
+    attributes:
+      label: Wiki corpus examples
+      description: What starter pages, frontmatter, shapes, schemas, and SPARQL reports should be included?
+      placeholder: |
+        Include pages for:
+        - integration overview
+        - durable decisions
+        - runbooks / procedures
+        - provenance examples
+        - validation shapes
+        - rendered SPARQL reports
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation and CI
+      description: What deterministic checks should pass without private credentials?
+      value: |
+        ```bash
+        wiki -c wiki.yml fmt --check
+        wiki -c wiki.yml lint --strict
+        wiki -c wiki.yml check --strict
+        wiki -c wiki.yml render --check
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: readme_positioning
+    attributes:
+      label: README positioning
+      description: Explain when to use Wiki CLI alone, the integration alone, and both together.
+      placeholder: |
+        Use Wiki CLI alone for...
+        Use the integration alone for...
+        Use both together when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What should this template explicitly not do?
+      placeholder: |
+        - Do not make Wiki CLI depend on the integration.
+        - Do not make derived runtime state the source of truth.
+        - Do not require private credentials in CI.
+        - Do not duplicate existing template scope.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checklist for when the template is done.
+      placeholder: |
+        - [ ] New `wazootech/wiki-...-template` repository exists.
+        - [ ] README explains the Wiki CLI / integration boundary.
+        - [ ] Template includes a working Wiki corpus.
+        - [ ] `wiki fmt --check` passes.
+        - [ ] `wiki lint --strict` passes.
+        - [ ] `wiki check --strict` passes.
+        - [ ] `wiki render --check` passes or no render blocks are included.
+        - [ ] Example queries work against the included corpus.
+        - [ ] CI validates without private credentials.
+    validations:
+      required: true
+
+  - type: textarea
+    id: open_questions
+    attributes:
+      label: Open questions
+      description: What decisions are still unresolved?
+      placeholder: |
+        1. Should this be standalone or folded into an existing template?
+        2. What is the minimal local demo?
+        3. Which credentials or external services should be optional?
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related issues and references
+      description: Link related Wiki issues, templates, and primary external docs.
+      placeholder: |
+        - Related Wiki issue:
+        - Existing template:
+        - External docs:
+    validations:
+      required: false

--- a/docs/wiki/Wiki_Skills.md
+++ b/docs/wiki/Wiki_Skills.md
@@ -6,11 +6,11 @@ description: Procedural knowledge for coding agents — install, scaffold, impro
 
 # Wiki CLI Agent Skills
 
-[Procedural Knowledge](Procedural_Knowledge.md) for coding agents lives in the Wiki CLI repository under `skills/`. One consolidated **`wiki`** skill routes to focused workflow references. Skills are **not** wiki pages — do not add `skills/` to `wiki.inputs`.
+[Procedural Knowledge](Procedural_Knowledge.md) for coding agents lives in the Wiki CLI repository under `skills/`. The **`wiki`** skill routes operational workflows to focused references, and **`wiki-feedback`** handles integration proposal feedback. Skills are **not** wiki pages — do not add `skills/` to `wiki.inputs`.
 
 Onboarding workflows are **independent modules** with no required order. Each completes its job and stops unless the user asks for the next step in the same turn.
 
-Canonical skill file: [`skills/wiki/SKILL.md`](https://github.com/wazootech/wiki/blob/main/skills/wiki/SKILL.md).
+Canonical operational skill file: [`skills/wiki/SKILL.md`](https://github.com/wazootech/wiki/blob/main/skills/wiki/SKILL.md). Integration proposal feedback lives in [`skills/wiki-feedback/SKILL.md`](https://github.com/wazootech/wiki/blob/main/skills/wiki-feedback/SKILL.md).
 
 ## Install via skills.sh
 
@@ -26,6 +26,7 @@ Install agent skills with the [Skills CLI](https://github.com/vercel-labs/skills
 
 ```bash
 npx skills add wazootech/wiki@wiki -g -y
+npx skills add wazootech/wiki@wiki-feedback -g -y
 
 # List skills without installing
 npx skills add wazootech/wiki --list
@@ -45,7 +46,7 @@ Project-local copies under `.agents/skills/` do not update automatically. Avoid 
 
 ## Workflows and routing
 
-The single **`wiki`** skill routes to four workflow references:
+The **`wiki`** skill routes operational workflows to focused references:
 
 | Intent                         | Reference                           | Stop when                        |
 | ------------------------------ | ----------------------------------- | -------------------------------- |
@@ -55,6 +56,8 @@ The single **`wiki`** skill routes to four workflow references:
 | GitHub Pages / CI deploy       | `skills/wiki/references/deploy.md`  | Workflow + URLs summarized       |
 
 Read one reference per turn unless the user explicitly asked for a multi-step flow (for example install → create → deploy).
+
+The **`wiki-feedback`** skill handles ecosystem feedback and integration proposals. Use it when comparing an external tool with Wiki CLI, drafting a `wiki-*-template` issue, or turning an integration idea into a repeatable GitHub issue. It reviews existing `template` issues first, preserves the boundary between Wiki CLI and downstream integrations, and recommends `.github/ISSUE_TEMPLATE/integration-template.yml` for final filing.
 
 ## Scripts
 
@@ -110,6 +113,7 @@ skills/
   wiki/references/deploy.md
   wiki/references/workflow-template-uv.yml
   wiki/references/workflow-template-pip.yml
+  wiki-feedback/SKILL.md
 ```
 
 Human-oriented install and daily workflow: [Getting Started](Getting_Started.md).

--- a/skills/wiki-feedback/SKILL.md
+++ b/skills/wiki-feedback/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: wiki-feedback
+description: >-
+  Drafts and files repeatable Wiki CLI integration/template proposals. Use when the user asks
+  to evaluate a new integration, create a wiki-*-template issue, compare an external tool with
+  the Wiki toolchain, or turn integration feedback into a GitHub issue. Reviews existing
+  template issues first, identifies the integration category, preserves Wiki CLI's source-layer
+  boundary, and recommends the GitHub issue form for final filing.
+---
+
+# Wiki Feedback Skill
+
+Use this skill for Wiki CLI ecosystem feedback, especially new integration or template proposals.
+
+## Core rule
+
+Every integration proposal must make the boundary explicit:
+
+- Wiki CLI owns the semantic Markdown source layer: `wiki.yml`, documents, frontmatter, SHACL, JSON Schema, lint, fmt, SPARQL, RDF/JSON-LD export, render, build, and serve.
+- The integration owns a distinct role: runtime memory, retrieval, publishing surface, agent workflow, issue-tracker bridge, domain model, or downstream application.
+- Derived indexes, generated memories, PR comments, vector stores, and external runtimes are not the canonical Wiki corpus unless explicitly promoted into Wiki pages and validated.
+
+## Workflow
+
+1. Review existing open issues with label `template`.
+2. Classify the proposed integration:
+   - Agent workflow / coding agent
+   - Runtime memory / retrieval
+   - Static site / publishing surface
+   - Issue tracker / work management
+   - Domain-specific knowledgebase
+   - Ontology / linked data
+   - RAG / GraphRAG / search
+3. Identify nearby existing issues and avoid duplicate scope.
+4. Draft the proposal using `.github/ISSUE_TEMPLATE/integration-template.yml`.
+5. Recommend filing through the GitHub issue form when the user wants durable feedback.
+6. If asked to execute, create the issue with label `template`.
+
+## Proposal sections
+
+Use these sections when drafting by hand:
+
+1. Goal
+2. Why this matters
+3. Boundary between Wiki CLI and the integration
+4. Recommended architecture
+5. Template repository
+6. Template contents
+7. Wiki corpus examples
+8. Validation and CI
+9. README positioning
+10. Non-goals
+11. Acceptance criteria
+12. Open questions
+13. Related issues and references
+
+## Quality bar
+
+A good proposal:
+
+- states the proposed repo name as `wazootech/wiki-<integration>-template`;
+- explains what Wiki CLI owns and what the integration owns;
+- includes deterministic validation commands;
+- avoids requiring private credentials in CI;
+- includes provenance and citation expectations;
+- names related template issues;
+- cites primary external documentation;
+- explains whether the template is standalone or should fold into an existing template.
+
+## Default validation block
+
+```bash
+wiki -c wiki.yml fmt --check
+wiki -c wiki.yml lint --strict
+wiki -c wiki.yml check --strict
+wiki -c wiki.yml render --check
+```
+
+Use `docs/wiki.yml` instead of `wiki.yml` when the template follows this repository's dogfooding layout.
+
+## Filing guidance
+
+Prefer the GitHub issue form:
+
+`.github/ISSUE_TEMPLATE/integration-template.yml`
+
+If filing via `gh issue create`, preserve the same structure and apply the `template` label.


### PR DESCRIPTION
## Summary
- add a GitHub issue form for repeatable Wiki integration/template proposals
- add a wiki-feedback skill for drafting and filing integration proposals
- document the new skill on the Wiki Skills page

## Validation
- `wiki -c docs/wiki.yml fmt --check docs/wiki/Wiki_Skills.md`
- `wiki -c docs/wiki.yml lint --strict`
- `wiki -c docs/wiki.yml check --strict`
- `wiki -c docs/wiki.yml render --check`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/ISSUE_TEMPLATE/integration-template.yml').read_text())"`
