### PR TITLE
Add query-first wiki MCP server

### DIFF
--- a/docs/wiki/Wiki_CLI.md
+++ b/docs/wiki/Wiki_CLI.md
@@ -90,13 +90,13 @@ No Obsidian or agent stack required. `wiki init` scaffolds a wiki; conventions a
 
 ## Three capabilities of the CLI
 
-| Capability   | Commands                      | Value                                            |
-| ------------ | ----------------------------- | ------------------------------------------------ |
-| Trust        | `check`, `lint`, `fmt`        | Integrity contracts and authoring conventions    |
-| Intelligence | `query`, `render`, `export`   | SPARQL, inline result blocks, RDF serializations |
-| Publish      | `build`, `serve`, `link`      | Static site, local preview, wikilink hygiene     |
-| Sources      | `install`, `update`, `remove` | Fetch, lock, update, and manage external sources |
-| Provenance   | `graph list`                  | Inspect read-only named graph boundaries         |
+| Capability   | Commands                           | Value                                                              |
+| ------------ | ---------------------------------- | ------------------------------------------------------------------ |
+| Trust        | `check`, `lint`, `fmt`             | Integrity contracts and authoring conventions                      |
+| Intelligence | `query`, `mcp`, `render`, `export` | SPARQL, MCP graph access, inline result blocks, RDF serializations |
+| Publish      | `build`, `serve`, `link`           | Static site, local preview, wikilink hygiene                       |
+| Sources      | `install`, `update`, `remove`      | Fetch, lock, update, and manage external sources                   |
+| Provenance   | `graph list`                       | Inspect read-only named graph boundaries                           |
 
 Design rationale for silence, pipes, and flat subcommands: [Design philosophies](Design_Philosophies.md).
 
@@ -134,6 +134,7 @@ Do not use these in new prose: `sparql-service-template` (→ `wiki-yasgui-templ
 - **Fmt** — mdformat for markdown ([Wiki Subcommand fmt](Wiki_Subcommand_fmt.md))
 - **Query** — SPARQL with OWL-RL and optional `--pretty` Rich tables ([Wiki Subcommand query](Wiki_Subcommand_query.md), [Graph Cache](Graph_Cache.md))
 - **Graph list** — inspect root and source named graphs for SPARQL `GRAPH` provenance ([Wiki Subcommand graph](Wiki_Subcommand_graph.md))
+- **MCP** — read-only query-first MCP server for local agents ([Wiki Subcommand mcp](Wiki_Subcommand_mcp.md))
 - **Render** — live tables from inline SPARQL ([Wiki Subcommand render](Wiki_Subcommand_render.md))
 - **Build / serve** — static site, local preview, and optional read-only SPARQL endpoint ([Wiki Subcommand build](Wiki_Subcommand_build.md), [Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint))
 - **Export** — JSON-LD and RDF serializations ([Wiki Subcommand export](Wiki_Subcommand_export.md))
@@ -205,7 +206,7 @@ Procedural knowledge for coding agents: [Wiki Skills](Wiki_Skills.md) (`skills/w
 
 ## Global Options
 
-These options apply to config-loading subcommands (`check`, `lint`, `link`, `query`, `render`, `build`, `export`, `serve`, `fmt`, `install`, `remove`). `init` and `upgrade` do not load a config file.
+These options apply to config-loading subcommands (`check`, `lint`, `link`, `query`, `mcp`, `render`, `build`, `export`, `serve`, `fmt`, `install`, `remove`). `init` and `upgrade` do not load a config file.
 
 ### `-c, --config PATH`
 
@@ -257,6 +258,7 @@ ORDER BY ?command
 | [Wiki_Subcommand_install](Wiki_Subcommand_install.md) | Fetch and lock external data sources declared in wiki.yml. |
 | [Wiki_Subcommand_link](Wiki_Subcommand_link.md) | Suggest missing wikilinks and repair unambiguous broken internal links. |
 | [Wiki_Subcommand_lint](Wiki_Subcommand_lint.md) | Convention audits for broken links, filename patterns, heading style, and internal link style. |
+| [Wiki_Subcommand_mcp](Wiki_Subcommand_mcp.md) | Run a read-only MCP server for querying the wiki graph. |
 | [Wiki_Subcommand_query](Wiki_Subcommand_query.md) | Run SPARQL SELECT or CONSTRUCT against the wiki graph. |
 | [Wiki_Subcommand_remove](Wiki_Subcommand_remove.md) | Remove a data source from wiki.yml, its cache, and wiki.lock. |
 | [Wiki_Subcommand_render](Wiki_Subcommand_render.md) | Update inline SPARQL result tables in markdown files. |

--- a/docs/wiki/Wiki_Subcommand_mcp.md
+++ b/docs/wiki/Wiki_Subcommand_mcp.md
@@ -1,0 +1,143 @@
+---
+type: TechArticle
+headline: wiki mcp
+description: Run a read-only MCP server for querying the wiki graph.
+---
+
+# `wiki mcp`
+
+Start a local [Model Context Protocol](https://modelcontextprotocol.io/) server for the configured Wiki graph. The server is read-only and query-first: it exposes SPARQL execution and graph context for agents, not page editing, formatting, link repair, build, or filesystem automation.
+
+## Usage
+
+```bash
+wiki mcp
+wiki -c docs/wiki.yml mcp
+wiki --wiki-inputs docs/wiki mcp
+wiki mcp --mode stdio
+```
+
+`stdio` is the default and only transport in the first version.
+
+## Claude Code setup
+
+Register the local server with Claude Code:
+
+```bash
+claude mcp add wiki -- wiki -c docs/wiki.yml mcp
+```
+
+Generic stdio MCP clients should run the same command shape:
+
+```bash
+wiki -c docs/wiki.yml mcp
+```
+
+## Options
+
+| Flag     | Default | Description         |
+| -------- | ------- | ------------------- |
+| `--mode` | `stdio` | MCP transport mode. |
+
+## Tools
+
+### `query_sparql`
+
+Execute SPARQL against the compiled wiki graph.
+
+Parameters:
+
+```json
+{
+  "query": "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10",
+  "format": "json",
+  "inference": true,
+  "reload": false
+}
+```
+
+Allowed query forms: `SELECT`, `ASK`, `CONSTRUCT`, and `DESCRIBE`. SPARQL Update and unsupported query forms are rejected before execution.
+
+`format` reuses [Wiki Subcommand query](Wiki_Subcommand_query.md) names and aliases: `table`, `json`, `csv`, `tsv`, `turtle`, `n3`, and `markdown`. The MCP default is `json`.
+
+The tool returns a structured object:
+
+```json
+{
+  "format": "json",
+  "query_form": "SELECT",
+  "result": "..."
+}
+```
+
+### `describe_wiki`
+
+Return factual context for writing grounded SPARQL:
+
+- Wiki CLI version
+- Config path and inputs
+- Namespace bindings from the built graph
+- Graph stats for the default inferred graph
+- Observed vocabulary from the graph
+
+The vocabulary summary is intentionally load-bearing for agent use. It lists real classes and predicates so agents can avoid inventing predicates, getting empty results, and treating a bad query as missing data.
+
+Example shape:
+
+```json
+{
+  "version": "0.1.21",
+  "config": "docs/wiki.yml",
+  "inputs": ["docs/wiki"],
+  "namespaces": {
+    "schema": "https://schema.org/",
+    "wiki": "https://wiki.example.org/"
+  },
+  "graph": {
+    "triples": 1234,
+    "subjects": 120,
+    "predicates": 45,
+    "objects": 900,
+    "inference": true
+  },
+  "vocabulary": {
+    "classes": [
+      { "iri": "https://schema.org/Person", "curie": "schema:Person", "count": 12 }
+    ],
+    "predicates": [
+      { "iri": "https://schema.org/name", "curie": "schema:name", "count": 42 }
+    ]
+  }
+}
+```
+
+Vocabulary limits are intentionally compact: top 25 classes by `rdf:type` usage and top 50 predicates by triple count.
+
+## Resources
+
+| Resource            | MIME type          | Purpose                                                        |
+| ------------------- | ------------------ | -------------------------------------------------------------- |
+| `wiki://info`       | `application/json` | Version, config, inputs, graph settings, stats, and vocabulary |
+| `wiki://namespaces` | `application/json` | Prefix map for SPARQL authoring                                |
+| `wiki://graph.ttl`  | `text/turtle`      | Current inferred graph serialized as Turtle                    |
+
+## Safety model
+
+`wiki mcp` is read-only by default:
+
+- No wiki source mutation
+- No build output writes
+- No formatting changes
+- No link repair
+- No generic file read/write tools
+- No Obsidian automation
+- No SPARQL Update
+
+The command reuses the same in-process graph cache behavior as other Wiki CLI operations. `reload=true` on `query_sparql` rebuilds the in-memory graph before executing the query.
+
+## Related
+
+- [Wiki Subcommand query](Wiki_Subcommand_query.md)
+- [Wiki Subcommand serve](Wiki_Subcommand_serve.md#sparql-endpoint)
+- [Graph Cache](Graph_Cache.md)
+- [SPARQL](SPARQL.md)

--- a/docs/wiki/Wiki_Subcommand_mcp.md
+++ b/docs/wiki/Wiki_Subcommand_mcp.md
@@ -15,6 +15,7 @@ wiki mcp
 wiki -c docs/wiki.yml mcp
 wiki --wiki-inputs docs/wiki mcp
 wiki mcp --mode stdio
+wiki mcp --cache
 ```
 
 `stdio` is the default and only transport in the first version.
@@ -35,9 +36,10 @@ wiki -c docs/wiki.yml mcp
 
 ## Options
 
-| Flag     | Default | Description         |
-| -------- | ------- | ------------------- |
-| `--mode` | `stdio` | MCP transport mode. |
+| Flag      | Default | Description                                                  |
+| --------- | ------- | ------------------------------------------------------------ |
+| `--mode`  | `stdio` | MCP transport mode.                                          |
+| `--cache` | off     | Persist graph artifacts under `.wiki/cache` across launches. |
 
 ## Tools
 
@@ -133,7 +135,7 @@ Vocabulary limits are intentionally compact: top 25 classes by `rdf:type` usage 
 - No Obsidian automation
 - No SPARQL Update
 
-The command reuses the same in-process graph cache behavior as other Wiki CLI operations. `reload=true` on `query_sparql` rebuilds the in-memory graph before executing the query.
+The command reuses the same graph cache behavior as other Wiki CLI operations: in-process caching is always used within one running MCP server, and `--cache` enables filesystem persistence under `.wiki/cache` for faster reuse across MCP launches. `reload=true` on `query_sparql` rebuilds the in-memory graph before executing the query; with `--cache`, the rebuilt graph is also written back to the filesystem cache.
 
 ## Related
 

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -202,6 +202,8 @@ export interface ServeOptions {
 export interface McpOptions {
   /** MCP transport mode (default ``"stdio"``). */
   mode?: McpMode;
+  /** Persist graph under ``.wiki/cache`` across MCP launches. */
+  cache?: boolean;
   /** Working directory for the subprocess. */
   cwd?: string;
   /** Extra environment variables. */

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -6,6 +6,8 @@ export type UrlStyle = "dir" | "file";
 export type LinkStyle = "standard" | "wikilink";
 /** Output formats for SPARQL query results. */
 export type QueryFormat = "table" | "json" | "csv" | "tsv" | "turtle" | "n3" | "markdown";
+/** MCP server transport mode. */
+export type McpMode = "stdio";
 /** Output formats for RDF export. */
 export type ExportFormat = "dict" | "json-ld" | "turtle" | "xml" | "n3" | "nt" | "trig" | "nquads";
 /** JSON-LD serialization mode. */
@@ -196,6 +198,16 @@ export interface ServeOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+/** Options for ``Wiki.mcp()``. */
+export interface McpOptions {
+  /** MCP transport mode (default ``"stdio"``). */
+  mode?: McpMode;
+  /** Working directory for the subprocess. */
+  cwd?: string;
+  /** Extra environment variables. */
+  env?: NodeJS.ProcessEnv;
+}
+
 /** Runtime overrides applied to a Wiki session (immutable config copy). */
 export interface RuntimeOptions {
   /** Override ``site.base_url`` for this session. */
@@ -252,3 +264,5 @@ export interface PreflightResult {
 
 /** The child process returned by ``Wiki.serve()``. */
 export type ServeProcess = ChildProcess;
+/** The child process returned by ``Wiki.mcp()``. */
+export type McpProcess = ChildProcess;

--- a/npm/src/wiki.ts
+++ b/npm/src/wiki.ts
@@ -21,6 +21,7 @@ import type {
   InitOptions,
   LinkOptions,
   LintOptions,
+  McpOptions,
   PreflightOptions,
   PreflightResult,
   QueryOptions,
@@ -293,6 +294,20 @@ export class Wiki {
     pushFlag(args, "--site-url-style", options.urlStyle ?? this.runtime.urlStyle);
     pushFlag(args, "--watch", options.watch);
     return spawnWiki(this.args("serve", args), {
+      cwd: options.cwd ?? this.cwd,
+      env: { ...this.env, ...options.env },
+    });
+  }
+
+  /** Start a read-only MCP server for the wiki graph.
+   *
+   * @param options - MCP options (mode, cwd, env).
+   * @returns The spawned child process (not a Promise).
+   */
+  mcp(options: McpOptions = {}): ChildProcess {
+    const args: string[] = [];
+    pushFlag(args, "--mode", options.mode);
+    return spawnWiki(this.args("mcp", args), {
       cwd: options.cwd ?? this.cwd,
       env: { ...this.env, ...options.env },
     });

--- a/npm/src/wiki.ts
+++ b/npm/src/wiki.ts
@@ -301,12 +301,13 @@ export class Wiki {
 
   /** Start a read-only MCP server for the wiki graph.
    *
-   * @param options - MCP options (mode, cwd, env).
+   * @param options - MCP options (mode, cache, cwd, env).
    * @returns The spawned child process (not a Promise).
    */
   mcp(options: McpOptions = {}): ChildProcess {
     const args: string[] = [];
     pushFlag(args, "--mode", options.mode);
+    pushFlag(args, "--cache", options.cache);
     return spawnWiki(this.args("mcp", args), {
       cwd: options.cwd ?? this.cwd,
       env: { ...this.env, ...options.env },

--- a/npm/test-wiki-api.js
+++ b/npm/test-wiki-api.js
@@ -80,6 +80,16 @@ async function main() {
     'list',
   ]);
 
+  assert.deepStrictEqual(wiki.args('mcp', ['--mode', 'stdio']), [
+    '--wiki-inputs',
+    'docs/wiki',
+    '--config',
+    'docs/wiki.yml',
+    'mcp',
+    '--mode',
+    'stdio',
+  ]);
+
   const initWiki = new TestWiki();
   await initWiki.init({
     git: true,

--- a/npm/test-wiki-api.js
+++ b/npm/test-wiki-api.js
@@ -80,7 +80,7 @@ async function main() {
     'list',
   ]);
 
-  assert.deepStrictEqual(wiki.args('mcp', ['--mode', 'stdio']), [
+  assert.deepStrictEqual(wiki.args('mcp', ['--mode', 'stdio', '--cache']), [
     '--wiki-inputs',
     'docs/wiki',
     '--config',
@@ -88,6 +88,7 @@ async function main() {
     'mcp',
     '--mode',
     'stdio',
+    '--cache',
   ]);
 
   const initWiki = new TestWiki();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "jsonschema>=4.23",
     "ruamel.yaml>=0.18.0",
     "linked-markdown",
+    "mcp>=1.27,<2",
 ]
 
 [project.scripts]

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -274,13 +274,19 @@ def query(
     show_default=True,
     help="MCP transport mode.",
 )
+@click.option(
+    "--cache",
+    "disk_cache",
+    is_flag=True,
+    help="Persist graph under .wiki/cache for faster reuse across MCP launches.",
+)
 @click.pass_obj
-def mcp(wiki: Wiki, mode: str) -> None:
+def mcp(wiki: Wiki, mode: str, disk_cache: bool) -> None:
     """Start a read-only MCP server for the wiki graph."""
     from .mcp import run_mcp_server
 
     try:
-        run_mcp_server(wiki, mode=mode.lower())
+        run_mcp_server(wiki, mode=mode.lower(), disk_cache=disk_cache)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -267,6 +267,25 @@ def query(
 
 
 @main.command()
+@click.option(
+    "--mode",
+    type=click.Choice(["stdio"], case_sensitive=False),
+    default="stdio",
+    show_default=True,
+    help="MCP transport mode.",
+)
+@click.pass_obj
+def mcp(wiki: Wiki, mode: str) -> None:
+    """Start a read-only MCP server for the wiki graph."""
+    from .mcp import run_mcp_server
+
+    try:
+        run_mcp_server(wiki, mode=mode.lower())
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@main.command()
 @optional_files_argument
 @click.option("--no-inference", is_flag=True, help="Skip OWL-RL inference.")
 @click.option("--reload", is_flag=True, help="Rebuild the in-memory graph from wiki sources before rendering.")

--- a/src/wiki/mcp.py
+++ b/src/wiki/mcp.py
@@ -1,0 +1,189 @@
+"""Model Context Protocol server for query-first wiki graph access."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from rdflib import RDF, Graph, URIRef
+
+from . import __version__
+from .format import detect_query_form, is_sparql_update
+from .format_choice import FormatChoice
+from .graph import graph_stats
+from .session import Wiki
+
+QUERY_FORMATS = {"table", "json", "csv", "tsv", "turtle", "n3", "markdown"}
+ALLOWED_QUERY_FORMS = {"SELECT", "ASK", "CONSTRUCT", "DESCRIBE"}
+
+
+def _relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _display_path(path: Path | None, root: Path) -> str | None:
+    if path is None:
+        return None
+    return _relative_path(path, root)
+
+
+def _normalize_query_format(output_format: str | None) -> str:
+    raw = str(output_format or "json").strip()
+    if not raw:
+        return "json"
+    canonical = FormatChoice.FORMAT_ALIASES.get(raw.casefold(), raw.casefold())
+    if canonical not in QUERY_FORMATS:
+        raise ValueError(f"Unsupported query result format: {output_format}")
+    return canonical
+
+
+def _namespace_map(graph: Graph) -> dict[str, str]:
+    return {prefix: str(namespace) for prefix, namespace in graph.namespaces()}
+
+
+def _curie(graph: Graph, iri: URIRef) -> str | None:
+    normalized = graph.namespace_manager.normalizeUri(iri)
+    if normalized.startswith("<") and normalized.endswith(">"):
+        return None
+    return normalized
+
+
+def _vocabulary_entry(graph: Graph, iri: URIRef, count: int) -> dict[str, Any]:
+    entry: dict[str, Any] = {"iri": str(iri), "count": count}
+    compact = _curie(graph, iri)
+    if compact is not None:
+        entry["curie"] = compact
+    return entry
+
+
+def vocabulary_summary(graph: Graph, *, class_limit: int = 25, predicate_limit: int = 50) -> dict[str, list[dict[str, Any]]]:
+    """Return observed classes and predicates to help agents write grounded SPARQL."""
+    classes: Counter[URIRef] = Counter()
+    predicates: Counter[URIRef] = Counter()
+
+    for _, object_ in graph.subject_objects(RDF.type):
+        if isinstance(object_, URIRef):
+            classes[object_] += 1
+    for predicate in graph.predicates():
+        if isinstance(predicate, URIRef):
+            predicates[predicate] += 1
+
+    return {
+        "classes": [_vocabulary_entry(graph, iri, count) for iri, count in classes.most_common(class_limit)],
+        "predicates": [_vocabulary_entry(graph, iri, count) for iri, count in predicates.most_common(predicate_limit)],
+    }
+
+
+def describe_wiki(wiki: Wiki) -> dict[str, Any]:
+    """Return factual graph context for agents writing SPARQL queries."""
+    graph = wiki.graph(infer=True, reload=False)
+    config = wiki.config
+    root = config.config_root
+    return {
+        "version": __version__,
+        "config": _display_path(wiki.config_path, root),
+        "inputs": [_relative_path(path, root) for path in config.wiki.inputs],
+        "namespaces": _namespace_map(graph),
+        "graph": {
+            **graph_stats(graph),
+            "inference": True,
+        },
+        "vocabulary": vocabulary_summary(graph),
+    }
+
+
+def query_sparql(
+    wiki: Wiki,
+    query: str,
+    *,
+    format: str = "json",
+    inference: bool = True,
+    reload: bool = False,
+) -> dict[str, str]:
+    """Execute an allowlisted SPARQL query against the configured wiki graph."""
+    if is_sparql_update(query):
+        raise ValueError("SPARQL Update is not supported by wiki mcp.")
+    query_form = detect_query_form(query)
+    if query_form not in ALLOWED_QUERY_FORMS:
+        raise ValueError(f"Unsupported SPARQL query form: {query_form}")
+    output_format = _normalize_query_format(format)
+    result = wiki.query(
+        query,
+        format=output_format,
+        no_inference=not inference,
+        reload=reload,
+        cache=False,
+    )
+    return {
+        "format": output_format,
+        "query_form": query_form,
+        "result": result,
+    }
+
+
+def info_resource(wiki: Wiki) -> str:
+    """Return wiki info as an application/json resource body."""
+    return json.dumps(describe_wiki(wiki), indent=2, sort_keys=True)
+
+
+def namespaces_resource(wiki: Wiki) -> str:
+    """Return graph namespace bindings as an application/json resource body."""
+    graph = wiki.graph(infer=True, reload=False)
+    return json.dumps(_namespace_map(graph), indent=2, sort_keys=True)
+
+
+def graph_ttl_resource(wiki: Wiki) -> str:
+    """Return the inferred graph serialized as Turtle."""
+    graph = wiki.graph(infer=True, reload=False)
+    return graph.serialize(format="turtle")
+
+
+def create_mcp_server(wiki: Wiki):
+    """Create the FastMCP server. Imported lazily so tests can avoid protocol startup."""
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP("wiki")
+
+    @server.tool(name="query_sparql", structured_output=True)
+    def query_sparql_tool(
+        query: str,
+        format: str = "json",
+        inference: bool = True,
+        reload: bool = False,
+    ) -> dict[str, str]:
+        """Execute SPARQL SELECT, ASK, CONSTRUCT, or DESCRIBE against the wiki graph."""
+        return query_sparql(wiki, query, format=format, inference=inference, reload=reload)
+
+    @server.tool(name="describe_wiki", structured_output=True)
+    def describe_wiki_tool() -> dict[str, Any]:
+        """Return config, namespaces, graph stats, and observed vocabulary."""
+        return describe_wiki(wiki)
+
+    @server.resource("wiki://info", mime_type="application/json")
+    def wiki_info_resource() -> str:
+        """Version, config path, inputs, graph settings, stats, and vocabulary."""
+        return info_resource(wiki)
+
+    @server.resource("wiki://namespaces", mime_type="application/json")
+    def wiki_namespaces_resource() -> str:
+        """Prefix map for SPARQL authoring."""
+        return namespaces_resource(wiki)
+
+    @server.resource("wiki://graph.ttl", mime_type="text/turtle")
+    def wiki_graph_resource() -> str:
+        """Current inferred wiki graph serialized as Turtle."""
+        return graph_ttl_resource(wiki)
+
+    return server
+
+
+def run_mcp_server(wiki: Wiki, *, mode: str = "stdio") -> None:
+    """Run the MCP server over the requested transport."""
+    if mode != "stdio":
+        raise ValueError(f"Unsupported MCP mode: {mode}")
+    create_mcp_server(wiki).run(transport="stdio")

--- a/src/wiki/mcp.py
+++ b/src/wiki/mcp.py
@@ -79,9 +79,9 @@ def vocabulary_summary(graph: Graph, *, class_limit: int = 25, predicate_limit: 
     }
 
 
-def describe_wiki(wiki: Wiki) -> dict[str, Any]:
+def describe_wiki(wiki: Wiki, *, disk_cache: bool = False) -> dict[str, Any]:
     """Return factual graph context for agents writing SPARQL queries."""
-    graph = wiki.graph(infer=True, reload=False)
+    graph = wiki.graph(infer=True, reload=False, disk_cache=disk_cache)
     config = wiki.config
     root = config.config_root
     return {
@@ -104,6 +104,7 @@ def query_sparql(
     format: str = "json",
     inference: bool = True,
     reload: bool = False,
+    cache: bool = False,
 ) -> dict[str, str]:
     """Execute an allowlisted SPARQL query against the configured wiki graph."""
     if is_sparql_update(query):
@@ -117,7 +118,7 @@ def query_sparql(
         format=output_format,
         no_inference=not inference,
         reload=reload,
-        cache=False,
+        cache=cache,
     )
     return {
         "format": output_format,
@@ -126,24 +127,24 @@ def query_sparql(
     }
 
 
-def info_resource(wiki: Wiki) -> str:
+def info_resource(wiki: Wiki, *, disk_cache: bool = False) -> str:
     """Return wiki info as an application/json resource body."""
-    return json.dumps(describe_wiki(wiki), indent=2, sort_keys=True)
+    return json.dumps(describe_wiki(wiki, disk_cache=disk_cache), indent=2, sort_keys=True)
 
 
-def namespaces_resource(wiki: Wiki) -> str:
+def namespaces_resource(wiki: Wiki, *, disk_cache: bool = False) -> str:
     """Return graph namespace bindings as an application/json resource body."""
-    graph = wiki.graph(infer=True, reload=False)
+    graph = wiki.graph(infer=True, reload=False, disk_cache=disk_cache)
     return json.dumps(_namespace_map(graph), indent=2, sort_keys=True)
 
 
-def graph_ttl_resource(wiki: Wiki) -> str:
+def graph_ttl_resource(wiki: Wiki, *, disk_cache: bool = False) -> str:
     """Return the inferred graph serialized as Turtle."""
-    graph = wiki.graph(infer=True, reload=False)
+    graph = wiki.graph(infer=True, reload=False, disk_cache=disk_cache)
     return graph.serialize(format="turtle")
 
 
-def create_mcp_server(wiki: Wiki):
+def create_mcp_server(wiki: Wiki, *, disk_cache: bool = False):
     """Create the FastMCP server. Imported lazily so tests can avoid protocol startup."""
     from mcp.server.fastmcp import FastMCP
 
@@ -157,33 +158,33 @@ def create_mcp_server(wiki: Wiki):
         reload: bool = False,
     ) -> dict[str, str]:
         """Execute SPARQL SELECT, ASK, CONSTRUCT, or DESCRIBE against the wiki graph."""
-        return query_sparql(wiki, query, format=format, inference=inference, reload=reload)
+        return query_sparql(wiki, query, format=format, inference=inference, reload=reload, cache=disk_cache)
 
     @server.tool(name="describe_wiki", structured_output=True)
     def describe_wiki_tool() -> dict[str, Any]:
         """Return config, namespaces, graph stats, and observed vocabulary."""
-        return describe_wiki(wiki)
+        return describe_wiki(wiki, disk_cache=disk_cache)
 
     @server.resource("wiki://info", mime_type="application/json")
     def wiki_info_resource() -> str:
         """Version, config path, inputs, graph settings, stats, and vocabulary."""
-        return info_resource(wiki)
+        return info_resource(wiki, disk_cache=disk_cache)
 
     @server.resource("wiki://namespaces", mime_type="application/json")
     def wiki_namespaces_resource() -> str:
         """Prefix map for SPARQL authoring."""
-        return namespaces_resource(wiki)
+        return namespaces_resource(wiki, disk_cache=disk_cache)
 
     @server.resource("wiki://graph.ttl", mime_type="text/turtle")
     def wiki_graph_resource() -> str:
         """Current inferred wiki graph serialized as Turtle."""
-        return graph_ttl_resource(wiki)
+        return graph_ttl_resource(wiki, disk_cache=disk_cache)
 
     return server
 
 
-def run_mcp_server(wiki: Wiki, *, mode: str = "stdio") -> None:
+def run_mcp_server(wiki: Wiki, *, mode: str = "stdio", disk_cache: bool = False) -> None:
     """Run the MCP server over the requested transport."""
     if mode != "stdio":
         raise ValueError(f"Unsupported MCP mode: {mode}")
-    create_mcp_server(wiki).run(transport="stdio")
+    create_mcp_server(wiki, disk_cache=disk_cache).run(transport="stdio")

--- a/src/wiki/session.py
+++ b/src/wiki/session.py
@@ -10,7 +10,7 @@ from typing import Any
 from rdflib import Dataset, Graph
 
 from .audit import _merge_results, _run_check, _run_lint
-from .config import Config
+from .config import Config, find_config_path
 from .fmt_util import format_markdown
 from .format import process_rdf_format
 from .graph import (
@@ -75,8 +75,9 @@ def _resolve_runtime_config(
 class Wiki:
     """Loaded wiki configuration and graph session for library operations."""
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Config, config_path: Path | None = None) -> None:
         self.config = config
+        self.config_path = config_path
 
     @classmethod
     def load(
@@ -94,7 +95,9 @@ class Wiki:
         Returns:
             A new ``Wiki`` instance backed by the loaded config.
         """
-        config = Config.load(Path(config_path))
+        load_path = Path(config_path)
+        resolved_config_path = find_config_path(load_path)
+        config = Config.load(load_path)
         if wiki_inputs:
             config.wiki.inputs = [
                 Path(entry) if Path(entry).is_absolute() else config.config_root / entry
@@ -106,7 +109,7 @@ class Wiki:
             for path in resolved:
                 if path not in existing:
                     config.wiki.inputs.append(path)
-        return cls(config)
+        return cls(config, resolved_config_path)
 
     def with_runtime(
         self,
@@ -123,7 +126,7 @@ class Wiki:
         Returns:
             A new ``Wiki`` with a deep-copied config.
         """
-        return Wiki(_resolve_runtime_config(self.config, base_url=base_url, url_style=url_style))
+        return Wiki(_resolve_runtime_config(self.config, base_url=base_url, url_style=url_style), self.config_path)
 
     def graph(
         self,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,111 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from click.testing import CliRunner
+
+from wiki.cli import main
+from wiki.mcp import (
+    describe_wiki,
+    graph_ttl_resource,
+    info_resource,
+    namespaces_resource,
+    query_sparql,
+)
+from wiki.session import Wiki
+
+
+class TestWikiMcp(unittest.TestCase):
+    def _make_wiki(self, tmpdir: str) -> Wiki:
+        root = Path(tmpdir)
+        wiki_dir = root / "docs" / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (root / "docs" / "wiki.yml").write_text(
+            "wiki:\n  inputs: wiki\n",
+            encoding="utf-8",
+        )
+        (wiki_dir / "Alice.md").write_text(
+            "---\n"
+            "type: Person\n"
+            "givenName: Alice\n"
+            "familyName: Smith\n"
+            "---\n",
+            encoding="utf-8",
+        )
+        return Wiki.load(root / "docs" / "wiki.yml")
+
+    def test_query_sparql_returns_structured_result(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki = self._make_wiki(tmpdir)
+            result = query_sparql(
+                wiki,
+                "SELECT ?given WHERE { ?s <https://schema.org/givenName> ?given }",
+                format="json",
+                inference=False,
+            )
+
+        self.assertEqual(result["format"], "json")
+        self.assertEqual(result["query_form"], "SELECT")
+        parsed = json.loads(result["result"])
+        self.assertEqual(parsed["results"]["bindings"][0]["given"]["value"], "Alice")
+
+    def test_query_sparql_accepts_format_aliases(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki = self._make_wiki(tmpdir)
+            result = query_sparql(
+                wiki,
+                "SELECT ?given WHERE { ?s <https://schema.org/givenName> ?given }",
+                format="text/csv",
+                inference=False,
+            )
+
+        self.assertEqual(result["format"], "csv")
+        self.assertIn("Alice", result["result"])
+
+    def test_query_sparql_rejects_update_and_unsupported_forms(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki = self._make_wiki(tmpdir)
+            with self.assertRaisesRegex(ValueError, "SPARQL Update"):
+                query_sparql(wiki, "INSERT DATA { <urn:s> <urn:p> <urn:o> }")
+            with self.assertRaisesRegex(ValueError, "Could not determine"):
+                query_sparql(wiki, "PREFIX schema: <https://schema.org/> BAD QUERY")
+
+    def test_describe_wiki_includes_observed_vocabulary(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki = self._make_wiki(tmpdir)
+            description = describe_wiki(wiki)
+
+        self.assertEqual(description["config"], "wiki.yml")
+        self.assertEqual(description["inputs"], ["wiki"])
+        self.assertGreater(description["graph"]["triples"], 0)
+        self.assertTrue(description["graph"]["inference"])
+        class_iris = {entry["iri"] for entry in description["vocabulary"]["classes"]}
+        predicate_iris = {entry["iri"] for entry in description["vocabulary"]["predicates"]}
+        self.assertIn("https://schema.org/Person", class_iris)
+        self.assertIn("https://schema.org/givenName", predicate_iris)
+        person = next(entry for entry in description["vocabulary"]["classes"] if entry["iri"] == "https://schema.org/Person")
+        self.assertEqual(person["curie"], "schema:Person")
+        self.assertEqual(person["count"], 1)
+
+    def test_resources_return_json_and_turtle_bodies(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki = self._make_wiki(tmpdir)
+            info = json.loads(info_resource(wiki))
+            namespaces = json.loads(namespaces_resource(wiki))
+            ttl = graph_ttl_resource(wiki)
+
+        self.assertIn("vocabulary", info)
+        self.assertIn("schema", namespaces)
+        self.assertIn("schema:givenName", ttl)
+
+    def test_cli_registers_mcp_command(self) -> None:
+        result = CliRunner().invoke(main, ["mcp", "--help"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("Start a read-only MCP server", result.output)
+        self.assertIn("--mode", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,7 +1,7 @@
 import json
+import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import unittest
 
 from click.testing import CliRunner
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from click.testing import CliRunner
 
 from wiki.cli import main
+from wiki.graph_cache import cache_dir
 from wiki.mcp import (
     describe_wiki,
     graph_ttl_resource,
@@ -88,6 +89,29 @@ class TestWikiMcp(unittest.TestCase):
         self.assertEqual(person["curie"], "schema:Person")
         self.assertEqual(person["count"], 1)
 
+    def test_describe_wiki_can_persist_graph_cache(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki = self._make_wiki(tmpdir)
+            describe_wiki(wiki, disk_cache=True)
+
+            cache_files = list(cache_dir(wiki.config).glob("graph-infer-*.nt"))
+
+        self.assertEqual(len(cache_files), 1)
+
+    def test_query_sparql_can_persist_graph_cache(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            wiki = self._make_wiki(tmpdir)
+            query_sparql(
+                wiki,
+                "SELECT ?given WHERE { ?s <https://schema.org/givenName> ?given }",
+                inference=False,
+                cache=True,
+            )
+
+            cache_files = list(cache_dir(wiki.config).glob("graph-asserted-*.nt"))
+
+        self.assertEqual(len(cache_files), 1)
+
     def test_resources_return_json_and_turtle_bodies(self) -> None:
         with TemporaryDirectory() as tmpdir:
             wiki = self._make_wiki(tmpdir)
@@ -105,6 +129,7 @@ class TestWikiMcp(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("Start a read-only MCP server", result.output)
         self.assertIn("--mode", result.output)
+        self.assertIn("--cache", result.output)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "altgraph"
@@ -18,6 +24,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -43,6 +62,100 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -64,12 +177,117 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "html5rdf"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/55/1b839c43f5ed8207e17a9a02d8b395179520b8b4f00c00a41e113bc205ca/html5rdf-1.2.1.tar.gz", hash = "sha256:ace9b420ce52995bb4f05e7425eedf19e433c981dfe7a831ab391e2fa2e1a195", size = 287899, upload-time = "2024-10-30T05:06:56.384Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/c9/f6e1e8567660bc5b0aba281f2b0017b2a7665fcad6bf3ed67286a0c72cd4/html5rdf-1.2.1-py2.py3-none-any.whl", hash = "sha256:1f519121bc366af3e485310dc8041d2e86e5173c1a320fac3dc9d2604069b83e", size = 109765, upload-time = "2024-10-30T05:06:52.507Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -137,7 +355,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -217,6 +435,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -359,6 +602,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -449,6 +701,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -498,6 +764,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -535,6 +815,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -799,6 +1116,32 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -829,6 +1172,19 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]
+
+[[package]]
 name = "wazootech-wiki"
 version = "0.1.21"
 source = { editable = "." }
@@ -839,6 +1195,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "linked-markdown" },
     { name = "markdown-it-py" },
+    { name = "mcp" },
     { name = "mdformat" },
     { name = "mdformat-footnote" },
     { name = "mdformat-front-matters" },
@@ -871,6 +1228,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.23" },
     { name = "linked-markdown" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
+    { name = "mcp", specifier = ">=1.27,<2" },
     { name = "mdformat", specifier = ">=0.7.19" },
     { name = "mdformat-footnote", specifier = ">=0.1.3" },
     { name = "mdformat-front-matters", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- add a read-only `wiki mcp` stdio server backed by the existing Wiki graph query path
- expose `query_sparql`, `describe_wiki`, and lightweight `wiki://` resources
- include observed class/predicate vocabulary in `describe_wiki` so agents can write grounded SPARQL
- add a minimal TypeScript `wiki.mcp()` spawn helper and docs

## Addressing m13v comment
Credit to @m13v for calling out the real adoption risk in the issue thread:

> the read-only, query-first scope is the right call. the thing that decides whether agents actually use this is describe_wiki, not query_sparql. the recurring failure mode with SPARQL over MCP is the model inventing a predicate that isn't in the graph, getting an empty result set, and reading it as "no data" rather than "bad query". namespaces alone don't prevent that, a handful of real class and predicate names would. so "should describe_wiki stay purely factual" is quietly the load-bearing open question in this issue, not the transport one.

This PR attacks that failure mode by making `describe_wiki` more than config plus namespaces while still keeping it factual/read-only:

- `describe_wiki` includes an observed `vocabulary` block from the current graph.
- Classes are counted from real `rdf:type` triples.
- Predicates are counted from actual graph triples.
- Entries include full `iri`, compact `curie` when namespace bindings support it, and usage `count`.
- The vocabulary is generated from the same inferred graph used by default `query_sparql`, so it reflects what agents actually query.
- The docs call this out explicitly as the load-bearing context that prevents invented predicates from being misread as missing data.

That keeps the MCP surface query-first without leaving agents to guess the graph schema from namespaces alone.

## Verification
- `uv run ruff check .`
- `uv run pytest`
- `npm run test:npm`
- `uv run wiki -c docs/wiki.yml fmt --check docs/wiki/Wiki_Subcommand_mcp.md docs/wiki/Wiki_CLI.md`
- `uv run wiki -c docs/wiki.yml lint --strict`
- `uv run wiki -c docs/wiki.yml check --strict`
- `uv run wiki -c docs/wiki.yml render --check`
