### PR TITLE
skill(wiki): add enrich workflow for ingesting raw material

### DIFF
--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -2,7 +2,8 @@
 name: wiki
 description: >-
   Manages Wiki CLI end to end — install and verify wazootech-wiki, scaffold with wiki init,
-  audit vault hygiene (fmt, lint, check, render), plan and execute vault improvements, and deploy to GitHub Pages.
+  audit vault hygiene (fmt, lint, check, render), enrich wikis from raw source material,
+  plan and execute vault improvements, and deploy to GitHub Pages.
   Use whenever the user mentions wiki, Wiki CLI, wazootech-wiki, wiki init, wiki.yml, wiki.yaml, broken links,
   lint/check failures, pre-PR wiki review, GitHub Pages for a wiki, or getting started with
   semantic markdown — even if they do not say "skill". Route to one workflow reference,
@@ -31,6 +32,7 @@ Skills under `skills/` are agent knowledge — **not** wiki pages. Do not add `s
 | New wiki, `wiki init`, tweak step            | [references/init.md](references/init.md)       | Scaffold summarized              |
 | Audit, improve, pre-PR, lint/check failures  | [references/improve.md](references/improve.md) | Findings report delivered        |
 | Formatting, linting, check categories detail | [references/audit.md](references/audit.md)     | Audit criteria verified          |
+| Ingest raw material into wiki pages         | [references/enrich.md](references/enrich.md)   | Change report delivered          |
 | Generate handoff plans, plans layout         | [references/plan.md](references/plan.md)       | Plan file written                |
 | Execute plans, review diff, publish issues   | [references/loop.md](references/loop.md)       | Executor output verified         |
 | GitHub Pages, deploy workflow, CI publish    | [references/deploy.md](references/deploy.md)   | Workflow + URLs summarized       |
@@ -67,6 +69,7 @@ bash skills/wiki/scripts/audit.sh -c path/to/wiki.yml [FILE...]
 | [references/init.md](references/init.md)       | `wiki init` + configuration wizard tweaks                                 |
 | [references/improve.md](references/improve.md) | Recon, audit, vet, and planning workflow                                  |
 | [references/audit.md](references/audit.md)     | Audit check categories and style spot-check                               |
+| [references/enrich.md](references/enrich.md)   | Ingest raw material into canonical wiki pages with semantic frontmatter    |
 | [references/plan.md](references/plan.md)       | Hand-off plans format and layout                                          |
 | [references/loop.md](references/loop.md)       | Running executors, reviewing work, reconciling backlog, publishing issues |
 | [references/deploy.md](references/deploy.md)   | GitHub Pages workflow and alignment checklist                             |

--- a/skills/wiki/references/enrich.md
+++ b/skills/wiki/references/enrich.md
@@ -1,0 +1,68 @@
+# Enrich — ingest raw material into wiki pages
+
+Turn raw source material (transcripts, repo evidence, decisions, notes) into
+canonical wiki pages with semantic frontmatter, evidence links, and freshness
+tracking. The wiki is not a scratchpad — it is synthesized, verified memory.
+
+## Source priority
+
+1. Direct user instruction in the current task.
+2. Current source repository code, configuration, README, issues, PRs, and CI.
+3. Accepted decisions and current-state pages already in the wiki.
+4. Meeting notes, transcripts, private chats, or other raw notes.
+5. External research, clearly marked by source type and date accessed.
+
+## Workflow
+
+1. Read the existing wiki context — start with any index or current-state page
+   relevant to the topic before making assumptions or creating new pages.
+2. Identify the evidence source: transcript, local source repo, GitHub issue,
+   PR, docs page, meeting notes, or direct user instruction. Preserve source
+   links or local raw-file references, but do not paste private dumps into
+   canonical wiki prose.
+3. Classify each claim (see claim status below).
+   Do not upgrade a claim to accepted ownership, production behavior, pricing,
+   public positioning, or launch commitment without explicit evidence or
+   stakeholder confirmation.
+4. Update existing pages before creating new ones. Registers are indexes;
+   create or promote entity pages only when the item needs lifecycle tracking.
+5. Keep semantic frontmatter current. Add or adjust saved queries when a
+   recurring operating question cannot be answered from the existing wiki
+   model.
+6. Summarize durable conclusions in canonical pages. Keep raw notes separate
+   when they are public-safe and useful for later traceability.
+7. Verify (see verification below).
+
+## Claim status
+
+Use explicit status language:
+
+- **Accepted** — durable decision or confirmed operating rule.
+- **Current** — observed implementation or process state.
+- **Proposed** — planned but not accepted or implemented.
+- **Hypothesis** — belief to test.
+- **Open question** — unresolved item needing owner input.
+
+## Standards
+
+- Prefer exact source facts over inference. Mark inference explicitly.
+- Keep the wiki public-safe: no secrets, private customer data, private
+  contact details, raw staff-chat dumps, or unnecessary transcript excerpts.
+- Use standard Markdown links, ATX headings, semantic frontmatter, and
+  sentence case below H1.
+- When source code contradicts the wiki, inspect the source repo and update
+  the wiki with the durable conclusion.
+- End with a short change report: pages changed, source material used,
+  verification run, and open questions.
+
+## Verification
+
+```bash
+# Format, lint, and check
+wiki -c wiki.yml fmt --check
+wiki -c wiki.yml lint --strict
+wiki -c wiki.yml check --strict
+
+# Also run check with verbose output
+wiki -c wiki.yml check -v
+```


### PR DESCRIPTION
Adds an enrich workflow to the wiki skill for turning raw source material (transcripts, repo evidence, decisions) into canonical wiki pages with semantic frontmatter, evidence links, and claim status classification.

This replaces the now-deleted wiki-enrich skill from wazoopedia - see the paired PR in wazoopedia.