### PR TITLE
Point template proposals at the wiki-templates monorepo

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration-template.yml
+++ b/.github/ISSUE_TEMPLATE/integration-template.yml
@@ -1,13 +1,15 @@
 name: Wiki integration template proposal
-description: Propose a new Wiki CLI ecosystem template or integration pattern.
-title: "Create wiki-<integration>-template for <use case>"
+description: Propose a new Wiki CLI ecosystem template or integration pattern (filed in wazootech/wiki-templates).
+title: "Add <integration> template to wiki-templates for <use case>"
 labels:
   - template
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form to propose a new `wazootech/wiki-*-template` repository or integration pattern.
+        Template proposals are tracked in the [wazootech/wiki-templates](https://github.com/wazootech/wiki-templates) monorepo, not in this repository. Templates are monorepo subdirectories, not standalone `wazootech/wiki-*-template` repos.
+
+        File this proposal there instead: https://github.com/wazootech/wiki-templates/issues/new?template=integration-template.yml
 
         Good proposals make the boundary explicit: Wiki CLI owns the semantic Markdown source layer, validation, querying, export, and publishing. The integration should own a distinct downstream role such as an agent workflow, memory runtime, retrieval index, docs surface, domain model, or work-management bridge.
 
@@ -23,9 +25,9 @@ body:
   - type: input
     id: proposed_repo
     attributes:
-      label: Proposed template repository
-      description: Use the `wiki-<integration>-template` naming pattern unless there is a strong reason not to.
-      placeholder: wazootech/wiki-open-swe-template
+      label: Proposed template subdirectory
+      description: Templates are subdirectories of the `wazootech/wiki-templates` monorepo. Use the `<integration>` naming pattern unless there is a strong reason not to.
+      placeholder: wazootech/wiki-templates/open-swe
     validations:
       required: true
 
@@ -51,7 +53,7 @@ body:
       label: Goal
       description: What should this template demonstrate?
       placeholder: |
-        Create `wazootech/wiki-...-template`: a template showing how ... integrates with Wiki CLI to ...
+        Add `wazootech/wiki-templates/<integration>/`: a template showing how ... integrates with Wiki CLI to ...
     validations:
       required: true
 
@@ -181,7 +183,7 @@ body:
       label: Acceptance criteria
       description: Concrete checklist for when the template is done.
       placeholder: |
-        - [ ] New `wazootech/wiki-...-template` repository exists.
+        - [ ] New `wazootech/wiki-templates/<integration>/` template subdirectory exists.
         - [ ] README explains the Wiki CLI / integration boundary.
         - [ ] Template includes a working Wiki corpus.
         - [ ] `wiki fmt --check` passes.

--- a/docs/wiki/Wiki_Skills.md
+++ b/docs/wiki/Wiki_Skills.md
@@ -57,7 +57,7 @@ The **`wiki`** skill routes operational workflows to focused references:
 
 Read one reference per turn unless the user explicitly asked for a multi-step flow (for example install → create → deploy).
 
-The **`wiki-feedback`** skill handles ecosystem feedback and integration proposals. Use it when comparing an external tool with Wiki CLI, drafting a `wiki-*-template` issue, or turning an integration idea into a repeatable GitHub issue. It reviews existing `template` issues first, preserves the boundary between Wiki CLI and downstream integrations, and recommends `.github/ISSUE_TEMPLATE/integration-template.yml` for final filing.
+The **`wiki-feedback`** skill handles ecosystem feedback and integration proposals. Use it when comparing an external tool with Wiki CLI, drafting a template proposal issue, or turning an integration idea into a repeatable GitHub issue. It reviews existing `template` issues in the [wiki-templates](https://github.com/wazootech/wiki-templates) monorepo first, preserves the boundary between Wiki CLI and downstream integrations, and recommends the `integration-template.yml` issue form in `wazootech/wiki-templates` for final filing.
 
 ## Scripts
 

--- a/skills/wiki-feedback/SKILL.md
+++ b/skills/wiki-feedback/SKILL.md
@@ -2,10 +2,11 @@
 name: wiki-feedback
 description: >-
   Drafts and files repeatable Wiki CLI integration/template proposals. Use when the user asks
-  to evaluate a new integration, create a wiki-*-template issue, compare an external tool with
+  to evaluate a new integration, create a template proposal issue, compare an external tool with
   the Wiki toolchain, or turn integration feedback into a GitHub issue. Reviews existing
-  template issues first, identifies the integration category, preserves Wiki CLI's source-layer
-  boundary, and recommends the GitHub issue form for final filing.
+  template issues in the wazootech/wiki-templates monorepo first, identifies the integration
+  category, preserves Wiki CLI's source-layer boundary, and recommends the GitHub issue form for
+  final filing.
 ---
 
 # Wiki Feedback Skill
@@ -22,7 +23,9 @@ Every integration proposal must make the boundary explicit:
 
 ## Workflow
 
-1. Review existing open issues with label `template`.
+1. Review existing open issues with label `template` in the
+   [wazootech/wiki-templates](https://github.com/wazootech/wiki-templates) repo
+   (`gh search issues --repo wazootech/wiki-templates --label template --state open`).
 1. Classify the proposed integration:
    - Agent workflow / coding agent
    - Runtime memory / retrieval
@@ -32,9 +35,10 @@ Every integration proposal must make the boundary explicit:
    - Ontology / linked data
    - RAG / GraphRAG / search
 1. Identify nearby existing issues and avoid duplicate scope.
-1. Draft the proposal using `.github/ISSUE_TEMPLATE/integration-template.yml`.
+1. Draft the proposal using the `integration-template.yml` issue form in
+   [wazootech/wiki-templates](https://github.com/wazootech/wiki-templates).
 1. Recommend filing through the GitHub issue form when the user wants durable feedback.
-1. If asked to execute, create the issue with label `template`.
+1. If asked to execute, create the issue in `wazootech/wiki-templates` with label `template`.
 
 ## Proposal sections
 
@@ -44,7 +48,7 @@ Use these sections when drafting by hand:
 1. Why this matters
 1. Boundary between Wiki CLI and the integration
 1. Recommended architecture
-1. Template repository
+1. Template subdirectory
 1. Template contents
 1. Wiki corpus examples
 1. Validation and CI
@@ -58,7 +62,10 @@ Use these sections when drafting by hand:
 
 A good proposal:
 
-- states the proposed repo name as `wazootech/wiki-<integration>-template`;
+- states the proposed template as a subdirectory of the
+  [wazootech/wiki-templates](https://github.com/wazootech/wiki-templates)
+  monorepo, e.g. `wazootech/wiki-templates/<integration>/` (templates are
+  monorepo subdirectories, not standalone `wazootech/wiki-*-template` repos);
 - explains what Wiki CLI owns and what the integration owns;
 - includes deterministic validation commands;
 - avoids requiring private credentials in CI;
@@ -80,8 +87,16 @@ Use `docs/wiki.yml` instead of `wiki.yml` when the template follows this reposit
 
 ## Filing guidance
 
-Prefer the GitHub issue form:
+Template proposals are tracked in the [wazootech/wiki-templates](https://github.com/wazootech/wiki-templates)
+repo, not in `wazootech/wiki`. Prefer the GitHub issue form there:
 
 `.github/ISSUE_TEMPLATE/integration-template.yml`
 
-If filing via `gh issue create`, preserve the same structure and apply the `template` label.
+If filing via `gh issue create`, preserve the same structure and apply the `template` label:
+
+```bash
+gh issue create --repo wazootech/wiki-templates --label template --body-file proposal.md
+```
+
+The [template program umbrella issue](https://github.com/wazootech/wiki-templates/issues/4)
+tracks the ranked backlog; the proposal can reference its bucket when relevant.


### PR DESCRIPTION
Update the \wiki-feedback\ skill, its docs reference, and the wiki repo's integration proposal issue form so template proposals are filed in the wazootech/wiki-templates monorepo instead of this repo.

Changes:
- \skills/wiki-feedback/SKILL.md\ — review existing template issues in wazootech/wiki-templates, file proposals there with the \	emplate\ label, treat templates as monorepo subdirectories (not standalone \wiki-*-template\ repos), and reference the template program umbrella issue.
- \docs/wiki/Wiki_Skills.md\ — updated the wiki-feedback skill description to match.
- \.github/ISSUE_TEMPLATE/integration-template.yml\ — reframed as a redirect to the wiki-templates issue form and monorepo subdirectory naming.

CI covers the docs wiki (fmt/lint/check passed locally); the skill and issue template are not wiki content.