### PR TITLE
ci: add stale issue and PR policy

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 90
+          days-before-close: 30
+          exempt-issue-labels: "wayfinder:task,wayfinder:grilling,wayfinder:prototype,wayfinder:research,wayfinder:map,backlog,needs-triage,ready-for-agent,ready-for-human"
+          exempt-pr-labels: "dependencies"
+          stale-issue-message: "This issue has been inactive for 90 days. If it is no longer relevant, it will be closed in 30 days. Comment or remove the stale label to keep it open."
+          stale-pr-message: "This PR has been inactive for 90 days. Please update it or it will be closed in 30 days."
+          close-issue-message: "Closing because this issue has been inactive for 120 days."
+          close-pr-message: "Closing because this PR has been inactive for 120 days."


### PR DESCRIPTION
Adds a stale-bot workflow so unassigned issues and stale PRs are triaged automatically (root cause fix for workspace#22). Marks issues stale after 90 days of inactivity, closes after 30 more, exempts wayfinder:*/backlog and wiki triage labels.