### PR TITLE
ci: add prettier and format:check step for npm typescript sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
     - name: Install npm dependencies
       run: npm ci --ignore-scripts
 
+    - name: Verify TypeScript Prettier formatting
+      run: npm run format:check
+
     - name: Check npm/PyPI version consistency
       run: |
         PY_VER=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml').read())['project']['version'])")

--- a/npm/src/errors.ts
+++ b/npm/src/errors.ts
@@ -6,7 +6,10 @@ export class WikiCommandError extends Error {
   readonly result: WikiCommandResult;
 
   constructor(result: WikiCommandResult) {
-    const detail = result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`;
+    const detail =
+      result.stderr.trim() ||
+      result.stdout.trim() ||
+      `exit code ${result.exitCode}`;
     super(`wiki command failed: ${detail}`);
     this.name = "WikiCommandError";
     this.result = result;

--- a/npm/src/runner.ts
+++ b/npm/src/runner.ts
@@ -39,11 +39,15 @@ export function ensurePythonReady(): string {
     setup();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new WikiSetupError(`wazootech-wiki Python environment setup failed: ${message}`);
+    throw new WikiSetupError(
+      `wazootech-wiki Python environment setup failed: ${message}`,
+    );
   }
 
   if (!venvIsReady()) {
-    throw new WikiSetupError("wazootech-wiki Python environment is not usable after setup");
+    throw new WikiSetupError(
+      "wazootech-wiki Python environment is not usable after setup",
+    );
   }
   return getVenvPython();
 }
@@ -56,7 +60,10 @@ export function ensurePythonReady(): string {
  * @param args - Arguments to pass to the wiki CLI.
  * @param options - Execution options (cwd, env, timeout, stdin, signal).
  */
-export function runWiki(args: readonly string[], options: RunOptions = {}): Promise<WikiCommandResult> {
+export function runWiki(
+  args: readonly string[],
+  options: RunOptions = {},
+): Promise<WikiCommandResult> {
   const pythonExe = ensurePythonReady();
   const command = [pythonExe, "-m", "wiki", ...args];
   const child = spawn(pythonExe, ["-m", "wiki", ...args], {
@@ -98,12 +105,24 @@ export function runWiki(args: readonly string[], options: RunOptions = {}): Prom
     if (options.timeoutMs !== undefined) {
       timeout = setTimeout(() => {
         child.kill("SIGTERM");
-        finish({ ok: false, exitCode: -1, stdout, stderr: `${stderr}\nCommand timed out`.trim(), command });
+        finish({
+          ok: false,
+          exitCode: -1,
+          stdout,
+          stderr: `${stderr}\nCommand timed out`.trim(),
+          command,
+        });
       }, options.timeoutMs);
     }
 
     child.on("error", (error) => {
-      finish({ ok: false, exitCode: -1, stdout, stderr: error.message, command });
+      finish({
+        ok: false,
+        exitCode: -1,
+        stdout,
+        stderr: error.message,
+        command,
+      });
     });
     child.on("close", (code) => {
       const exitCode = code ?? -1;
@@ -122,7 +141,10 @@ export function runWiki(args: readonly string[], options: RunOptions = {}): Prom
  * @param options - Spawn options (cwd, env).
  * @returns The spawned child process.
  */
-export function spawnWiki(args: readonly string[], options: SpawnOptions = {}): ChildProcess {
+export function spawnWiki(
+  args: readonly string[],
+  options: SpawnOptions = {},
+): ChildProcess {
   const pythonExe = ensurePythonReady();
   return spawn(pythonExe, ["-m", "wiki", ...args], {
     stdio: "inherit",

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -5,11 +5,13 @@ export type UrlStyle = "dir" | "file";
 /** Internal link syntax: ``[text](Page.md)`` (standard) or ``[[Page]]`` (wikilink). */
 export type LinkStyle = "standard" | "wikilink";
 /** Output formats for SPARQL query results. */
-export type QueryFormat = "table" | "json" | "csv" | "tsv" | "turtle" | "n3" | "markdown";
+export type QueryFormat =
+  "table" | "json" | "csv" | "tsv" | "turtle" | "n3" | "markdown";
 /** MCP server transport mode. */
 export type McpMode = "stdio";
 /** Output formats for RDF export. */
-export type ExportFormat = "dict" | "json-ld" | "turtle" | "xml" | "n3" | "nt" | "trig" | "nquads";
+export type ExportFormat =
+  "dict" | "json-ld" | "turtle" | "xml" | "n3" | "nt" | "trig" | "nquads";
 /** JSON-LD serialization mode. */
 export type ExportMode = "expanded" | "compacted";
 

--- a/npm/src/wiki.ts
+++ b/npm/src/wiki.ts
@@ -45,13 +45,20 @@ function pushFlag(args: string[], flag: string, value: FlagValue): void {
   args.push(flag, String(value));
 }
 
-function pushRepeated(args: string[], flag: string, values: readonly string[] | undefined): void {
+function pushRepeated(
+  args: string[],
+  flag: string,
+  values: readonly string[] | undefined,
+): void {
   for (const value of values ?? []) {
     args.push(flag, value);
   }
 }
 
-function appendFiles(args: string[], files: readonly string[] | undefined): void {
+function appendFiles(
+  args: string[],
+  files: readonly string[] | undefined,
+): void {
   if (files?.length) args.push(...files);
 }
 
@@ -127,13 +134,18 @@ export class Wiki {
    * @param args - Full argument list.
    * @param options - Run options (cwd, env, timeout, stdin).
    */
-  run(args: readonly string[], options: RunOptions = {}): Promise<WikiCommandResult> {
+  run(
+    args: readonly string[],
+    options: RunOptions = {},
+  ): Promise<WikiCommandResult> {
     const runOptions: RunOptions = { env: { ...this.env, ...options.env } };
     const cwd = options.cwd ?? this.cwd;
     if (cwd !== undefined) runOptions.cwd = cwd;
     if (options.stdin !== undefined) runOptions.stdin = options.stdin;
-    if (options.timeoutMs !== undefined) runOptions.timeoutMs = options.timeoutMs;
-    if (options.throwOnError !== undefined) runOptions.throwOnError = options.throwOnError;
+    if (options.timeoutMs !== undefined)
+      runOptions.timeoutMs = options.timeoutMs;
+    if (options.throwOnError !== undefined)
+      runOptions.throwOnError = options.throwOnError;
     if (options.signal !== undefined) runOptions.signal = options.signal;
     return runWiki(args, runOptions);
   }
@@ -180,7 +192,11 @@ export class Wiki {
     const args: string[] = [];
     pushFlag(args, "--output-dir", options.outputDir);
     pushFlag(args, "--site-base-url", options.baseUrl ?? this.runtime.baseUrl);
-    pushFlag(args, "--site-url-style", options.urlStyle ?? this.runtime.urlStyle);
+    pushFlag(
+      args,
+      "--site-url-style",
+      options.urlStyle ?? this.runtime.urlStyle,
+    );
     pushFlag(args, "--render", options.render);
     pushFlag(args, "--reload", options.reload);
     pushFlag(args, "--cache", options.cache);
@@ -225,14 +241,20 @@ export class Wiki {
    *
    * @param options - Export options (format, mode, output, file filter).
    */
-  async export<T = unknown>(options: ExportOptions = {}): Promise<ExportResult<T>> {
+  async export<T = unknown>(
+    options: ExportOptions = {},
+  ): Promise<ExportResult<T>> {
     const args: string[] = [];
     pushFlag(args, "--output", options.output);
     pushFlag(args, "--format", options.format);
     pushFlag(args, "--mode", options.mode);
     appendFiles(args, options.files);
     const result = await this.run(this.args("export", args));
-    const shouldParseJson = options.parseJson ?? (options.format === undefined || options.format === "dict" || options.format === "json-ld");
+    const shouldParseJson =
+      options.parseJson ??
+      (options.format === undefined ||
+        options.format === "dict" ||
+        options.format === "json-ld");
     if (shouldParseJson) {
       return parseJsonOutput<T>(result);
     }
@@ -291,7 +313,11 @@ export class Wiki {
     pushFlag(args, "--host", options.host);
     pushFlag(args, "--port", options.port);
     pushFlag(args, "--site-base-url", options.baseUrl ?? this.runtime.baseUrl);
-    pushFlag(args, "--site-url-style", options.urlStyle ?? this.runtime.urlStyle);
+    pushFlag(
+      args,
+      "--site-url-style",
+      options.urlStyle ?? this.runtime.urlStyle,
+    );
     pushFlag(args, "--watch", options.watch);
     return spawnWiki(this.args("serve", args), {
       cwd: options.cwd ?? this.cwd,
@@ -330,9 +356,17 @@ export class Wiki {
     pushRepeated(args, "--wiki-inputs", options.wikiInputs);
     pushFlag(args, "--graph-base-iri", options.graphBaseIri);
     pushRepeated(args, "--graph-implicit-types", options.graphImplicitTypes);
-    pushFlag(args, "--graph-implicit-types-policy", options.graphImplicitTypesPolicy);
+    pushFlag(
+      args,
+      "--graph-implicit-types-policy",
+      options.graphImplicitTypesPolicy,
+    );
     if (options.graphIncludeFileExtension !== undefined) {
-      args.push(options.graphIncludeFileExtension ? "--graph-include-file-extension" : "--no-graph-include-file-extension");
+      args.push(
+        options.graphIncludeFileExtension
+          ? "--graph-include-file-extension"
+          : "--no-graph-include-file-extension",
+      );
     }
     return this.run(this.args("init", args));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/node": "^24.0.0",
         "esbuild": "0.28.1",
+        "prettier": "^3.9.5",
         "tsup": "^8.3.0",
         "typedoc": "^0.28.0",
         "typescript": "^5.8.0"
@@ -1448,6 +1449,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode.js": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "setup": "node npm/setup.js",
     "gendocs:python": "uv run sphinx-build -b html -c docs docs/api/python docs/assets/api/python",
     "gendocs:ts": "typedoc",
+    "format": "prettier \"npm/**/*.ts\" --write",
+    "format:check": "prettier \"npm/**/*.ts\" --check",
     "test:npm": "npm run build && node npm/test-setup-argv.js && node npm/test-wiki-api.js"
   },
   "files": [
@@ -48,6 +50,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "esbuild": "0.28.1",
+    "prettier": "^3.9.5",
     "tsup": "^8.3.0",
     "typedoc": "^0.28.0",
     "typescript": "^5.8.0"


### PR DESCRIPTION
## Summary

- Added \prettier\ devDependency and \ormat\ / \ormat:check\ scripts for \
pm/**/*.ts\ sources in \package.json\.
- Added \
pm run format:check\ step to \
pm-checks\ job in \.github/workflows/ci.yml\.
- Formatted TypeScript sources with Prettier.

## Verification
- \
pm run format:check\ passed 100% green.
- \
pm run build\ passed 100% green.