### PR TITLE
docs(skills): add wiki-sync install snippet

### DIFF
--- a/docs/wiki/Wiki_Skills.md
+++ b/docs/wiki/Wiki_Skills.md
@@ -27,6 +27,7 @@ Install agent skills with the [Skills CLI](https://github.com/vercel-labs/skills
 ```bash
 npx skills add wazootech/wiki@wiki -g -y
 npx skills add wazootech/wiki@wiki-feedback -g -y
+npx skills add wazootech/wiki@wiki-sync -g -y
 
 # List skills without installing
 npx skills add wazootech/wiki --list

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,6 +15,7 @@ Typical flow: **install** → **create** → **deploy** → **improve** (each op
 
 ```bash
 npx skills add wazootech/wiki@wiki -g -y
+npx skills add wazootech/wiki@wiki-sync -g -y
 ```
 
 Docs: [Wiki_Skills.md](../docs/wiki/Wiki_Skills.md). User walkthrough: [Getting_Started.md](../docs/wiki/Getting_Started.md).


### PR DESCRIPTION
Adds `npx skills add wazootech/wiki@wiki-sync -g -y` to `skills/README.md` and the `Wiki_Skills.md` install section so the wiki-sync skill is installable via skills.sh. All wiki CI checks (fmt/check/lint/render) pass locally.