### PR TITLE
docs: advertise agent skills in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,36 @@ Three capabilities, one toolchain:
 
 Also: [`init`](#init) scaffolds `wiki.yaml`; `wiki query --pretty` renders Rich tables in the terminal; YAML and JSON frontmatter feed into the same queryable model; per-page layouts via `wazoo:layout`.
 
+## Agent skills
+
+Wiki CLI ships three agent skills for coding assistants (Claude Code, Cursor,
+OpenCode, Gemini). They are not thin wrappers — they encode opinionated
+best practices that apply to any wiki or docs repo:
+
+- **[wiki](skills/wiki/SKILL.md)** — the consolidated operational skill.
+  Routes to install, scaffold, audit, or deploy workflows. Encodes the
+  "silence is golden" philosophy (exit 0 on success) and deterministic
+  verification scripts instead of agent reasoning about whether things look
+  right.
+- **[wiki-sync](skills/wiki-sync/SKILL.md)** — Git-anchored delta sync for
+  code wikis. Treats the last-synced commit as an anchor and diffs forward,
+  editing only the pages the diff demands. Defaults to drift-free docs (no
+  line numbers, no machine-specific measurements) with an opt-in `detail_level`
+  directive. Works on any `docs/` folder, not just this repo.
+- **[wiki-feedback](skills/wiki-feedback/SKILL.md)** — structured feedback on
+  integration and template proposals. Enforces a quality bar for new ecosystem
+  contributions.
+
+```bash
+npx skills add wazootech/wiki@wiki -g -y
+npx skills add wazootech/wiki@wiki-sync -g -y
+npx skills add wazootech/wiki@wiki-feedback -g -y
+```
+
+The skills follow the same convention as the CLI: deterministic scripts
+(`verify.sh`, `audit.sh`) for anything that can be checked, agent reasoning
+only for decisions that require judgment.
+
 ## Templates
 
 All templates live in the [wiki-templates](https://github.com/wazootech/wiki-templates) monorepo. Template specs, epics, and roadmap are tracked in the [wiki-templates issue tracker](https://github.com/wazootech/wiki-templates/issues) (see the [template program umbrella](https://github.com/wazootech/wiki-templates/issues/4)). Clone the one that matches your stack:


### PR DESCRIPTION
## Summary

Add an **"Agent skills"** section between Key features and Templates that explains the three shipped skills with persuasive reasoning about the opinionated best practices they encode.

## Skills covered

- **wiki** — consolidated operational skill. Encodes "silence is golden" (exit 0 on success) and deterministic verification scripts over agent reasoning.
- **wiki-sync** — Git-anchored delta sync for code wikis. Defaults to drift-free docs with opt-in `detail_level`. Works on any `docs/` folder.
- **wiki-feedback** — structured feedback on integration and template proposals.

## Install lines

```bash
npx skills add wazootech/wiki@wiki -g -y
npx skills add wazootech/wiki@wiki-sync -g -y
npx skills add wazootech/wiki@wiki-feedback -g -y
```

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>