### PR TITLE
Add scheduled CI sync template to wiki-sync skill

### DIFF
--- a/skills/wiki-sync/SKILL.md
+++ b/skills/wiki-sync/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   inventories, or maintain a code wiki incrementally (e.g. wazootech/sparql-engine's docs/). Defaults
   to drift-free docs — no line numbers, machine-specific measurements, or test counts — with an
   opt-in detail_level directive in the repo's AGENTS.md for consumers who want them. Never regenerates a wiki
-  from scratch — it diffs the commits since the last sync anchor and edits only the affected pages.
+  from scratch — it diffs the commits since the last sync anchor and edits only the affected pages. Ships a
+  GitHub Actions template for scheduled CI syncs.
 ---
 
 # `wiki-sync` skill
@@ -106,6 +107,11 @@ its readers.
    measurement units (ms/iter, MiB) may appear in `docs/`.
 5. **Docs-only commits.** The sync PR must never change `src/`, `test/`, or
    `bench/` code.
+6. **Anchor last.** The `.sync-base` bump happens only after validation passes
+   and rides inside the docs-only commit — merging the PR and anchoring the
+   wiki are the same event. An interrupted run leaves the anchor untouched, so
+   the next run safely redoes the whole delta; no run-status bookkeeping is
+   needed.
 
 ## Procedure
 
@@ -115,11 +121,17 @@ its readers.
 git fetch origin
 BASE=$(cat docs/.sync-base)          # last-synced commit
 git log --oneline "$BASE"..origin/main          # the delta
-git diff --stat "$BASE"..origin/main -- src test bench .github   # what moved
+if ! git diff --quiet "$BASE"..origin/main -- src test bench .github; then
+  git diff --stat "$BASE"..origin/main -- src test bench .github   # what moved
+fi
 ```
 
 - No commits → the wiki is current; stop and say so.
-- Docs-only commits → re-check the few touched pages, update `.sync-base`, done.
+- Commits exist but none touch `src`, `test`, `bench`, or `.github` → no
+  wiki-relevant delta: re-check the few touched `docs/` pages, update
+  `.sync-base`, done. This path-scoped quiet check is the gate that keeps
+  scheduled runs cheap ([Scheduled syncs](#scheduled-syncs-ci)) — an empty
+  delta exits before verification passes or agent work begin.
 - Source/test/bench commits → continue.
 
 ### Step 2 — Read the detail level
@@ -275,6 +287,54 @@ expected new content is actually served.
 - In the default style: a structural diff only — no renumbered citations, no
   refreshed snapshot tables. When opted in: corrected line refs, counts, and
   inventory — with the command that produced each number cited.
+
+## Scheduled syncs (CI)
+
+The procedure runs unattended under a scheduled GitHub Actions workflow. Ship
+`workflows/wiki-sync.yml` from this skill's directory into the wiki-owning repo
+as `.github/workflows/wiki-sync.yml` — copy-to-install, so operator
+customizations survive skill updates. The template encodes this contract:
+
+- **Triggers.** `workflow_dispatch` always; a weekly cron ships commented out.
+  Enable it only after manual dispatch runs prove the loop end to end.
+- **Checkout** uses `fetch-depth: 0` so the anchor diff sees full history.
+- **Delta gate first.** Recompute the Step 1 quiet check before anything
+  expensive runs; exit cleanly when nothing wiki-relevant changed.
+- **Resume state machine.**
+
+  | State                   | Action                                                         |
+  | ----------------------- | -------------------------------------------------------------- |
+  | Empty delta, no open PR | skip                                                           |
+  | Delta, no open PR       | branch `docs/sync-ci` off `origin/main`; agent edits; push; PR |
+  | Delta, open PR          | checkout `docs/sync-ci`; rerun agent over its own `$BASE..origin/main`; force-push |
+  | Empty delta, open PR    | skip; the existing PR stands until merged                      |
+
+  Reading `.sync-base` from the checked-out branch — not `main` — is what
+  makes resume correct: the branch carries its own anchor.
+- **Content-level no-op guard.** If the agent changes nothing under `docs/`,
+  nothing is committed and no PR opens or updates.
+- **Anchor semantics.** The agent bumps `.sync-base` after validation, inside
+  the docs-only commit (invariant 6); merging anchors the wiki. Interrupted
+  runs leave the remote anchor untouched, so the next run redoes the delta.
+  Re-running the repo's doc validators in a workflow step *after* the agent
+  and *before* the commit makes this mechanical: failed validation lands
+  nothing.
+- **Authorship and permissions.** Commits are authored by
+  `github-actions[bot]` via `GITHUB_TOKEN` (job permissions:
+  `contents: write`, `pull-requests: write`); machine syncs stay visually
+  distinct from human `docs/sync` branches in history.
+- **Concurrency.** One `concurrency.group` serializes ticks so two runs never
+  race on the branch.
+- **Agent invocation seam.** One replaceable step drives any coding agent with
+  this SKILL.md as the prompt; uncomment exactly one wiring and set its
+  credential secret. Documented wirings: OpenCode (`opencode run`), Pi
+  (`pi -p`), Claude Code (`claude -p`), Codex (`codex exec`) — pick by
+  available credentials or preference; any harness that reads files and runs
+  `git`/`gh` in the checkout works. In CI there is no runtime user preference:
+  the instantiator chooses once, and the secret decides the provider.
+- **Verification rides the PR.** Docs-only PRs trigger the repo's existing
+  path-gated checks; merge only when green (Step 9). Install whatever
+  toolchain the validators need before the agent step.
 
 ## Guiding principles
 

--- a/skills/wiki-sync/workflows/wiki-sync.yml
+++ b/skills/wiki-sync/workflows/wiki-sync.yml
@@ -1,0 +1,196 @@
+# Wiki sync — scheduled CI driver for the wiki-sync skill.
+#
+# Install: copy this file into the wiki-owning repo as
+# .github/workflows/wiki-sync.yml, then:
+#   1. Uncomment exactly ONE block under AGENT WIRING and set its secret.
+#   2. Add toolchain steps the repo's doc validators need (e.g. setup-deno
+#      for `deno fmt --check docs/`), plus an optional validate step between
+#      the agent and the commit so a failed run cannot land or bump the
+#      anchor.
+# Enable the cron trigger only after manual dispatch runs prove the loop.
+#
+# Contract (skills/wiki-sync/SKILL.md, "Scheduled syncs (CI)"):
+# - Exits cheaply when no wiki-relevant source changed since docs/.sync-base.
+# - Resumes an open docs/sync-ci PR; new deltas force-push onto it.
+# - The agent bumps docs/.sync-base inside the single docs-only commit this
+#   workflow creates, so merging the PR anchors the wiki; interrupted runs
+#   leave the anchor untouched and the next run redoes the delta.
+# - Verification rides the PR via the repo's own CI; humans merge.
+
+name: Wiki sync
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "0 6 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # Resume an open docs/sync-ci branch when one exists, THEN read the
+      # anchor: the branch carries its own .sync-base, which scopes the new
+      # delta correctly in both fresh and resumed runs.
+      - name: Resolve state
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="docs/sync-ci"
+          OPEN_PR="$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')"
+          if [ "$OPEN_PR" != "0" ]; then
+            git fetch origin "$BRANCH"
+            git checkout -b "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH" origin/main
+          fi
+          BASE="$(cat docs/.sync-base 2>/dev/null || git log -1 --format=%H -- docs/)"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          if git diff --quiet "$BASE"..origin/main -- src test bench .github; then
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No wiki-relevant source changes since $BASE"
+          else
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            git diff --stat "$BASE"..origin/main -- src test bench .github
+          fi
+
+      - name: Stop — wiki current
+        if: steps.state.outputs.relevant == 'false'
+        run: echo "Nothing to sync; stopping cleanly."
+
+      # Toolchain steps go here if validators need them, e.g.:
+      # - uses: denoland/setup-deno@v2
+      #   with:
+      #     deno-version: v2.x
+
+      # =====================================================================
+      # AGENT WIRING — uncomment exactly ONE block and set its secret.
+      #
+      # This skill file IS the prompt. Each wiring tells the agent to follow
+      # skills/wiki-sync/SKILL.md end to end against THIS checkout, editing
+      # only docs/ and leaving ALL changes uncommitted (no git add/commit/
+      # push, no PRs) — the workflow owns committing and PR creation below.
+      # =====================================================================
+
+      # --- OpenCode --------------------------------------------------------
+      # - name: Run wiki-sync via OpenCode
+      #   if: steps.state.outputs.relevant == 'true'
+      #   env:
+      #     BASE: ${{ steps.state.outputs.base }}
+      #     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      #   run: |
+      #     curl -fsSL https://opencode.ai/install | bash
+      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #       Follow this skill end to end for THIS checkout. Base commit:
+      #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
+      #       skill's Step 8 validation passes. Leave all changes
+      #       uncommitted: do not git add, commit, push, or open PRs."
+      #     opencode run "$PROMPT"
+
+      # --- Pi --------------------------------------------------------------
+      # Provider-agnostic: Pi resolves its model from whichever provider key
+      # the environment carries (ANTHROPIC_API_KEY below; OPENAI_API_KEY,
+      # GEMINI_API_KEY, ... equally valid).
+      # - name: Run wiki-sync via Pi
+      #   if: steps.state.outputs.relevant == 'true'
+      #   env:
+      #     BASE: ${{ steps.state.outputs.base }}
+      #     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      #   run: |
+      #     curl -fsSL https://pi.dev/install.sh | sh
+      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #       Follow this skill end to end for THIS checkout. Base commit:
+      #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
+      #       skill's Step 8 validation passes. Leave all changes
+      #       uncommitted: do not git add, commit, push, or open PRs."
+      #     pi -p "$PROMPT"
+
+      # --- Claude Code -----------------------------------------------------
+      # - name: Run wiki-sync via Claude Code
+      #   if: steps.state.outputs.relevant == 'true'
+      #   env:
+      #     BASE: ${{ steps.state.outputs.base }}
+      #     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      #   run: |
+      #     npm install -g @anthropic-ai/claude-code
+      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #       Follow this skill end to end for THIS checkout. Base commit:
+      #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
+      #       skill's Step 8 validation passes. Leave all changes
+      #       uncommitted: do not git add, commit, push, or open PRs."
+      #     claude -p "$PROMPT" --dangerously-skip-permissions
+
+      # --- Codex -----------------------------------------------------------
+      # - name: Run wiki-sync via Codex
+      #   if: steps.state.outputs.relevant == 'true'
+      #   env:
+      #     BASE: ${{ steps.state.outputs.base }}
+      #     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      #   run: |
+      #     npm install -g @openai/codex
+      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #       Follow this skill end to end for THIS checkout. Base commit:
+      #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
+      #       skill's Step 8 validation passes. Leave all changes
+      #       uncommitted: do not git add, commit, push, or open PRs."
+      #     codex exec "$PROMPT"
+
+      # Recommended: re-run this repo's doc validators here, BEFORE the
+      # commit, so failed validation lands nothing — e.g. for a Deno repo:
+      # - name: Validate docs
+      #   if: steps.state.outputs.relevant == 'true'
+      #   run: deno fmt --check docs/
+
+      - name: Commit and push
+        id: commit
+        if: steps.state.outputs.relevant == 'true'
+        env:
+          BASE: ${{ steps.state.outputs.base }}
+          BRANCH: ${{ steps.state.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Agent made no documentation changes; nothing to land."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            HEAD="$(git rev-parse origin/main)"
+            git commit -m "docs: scheduled wiki sync (${BASE:0:12}..${HEAD:0:12})"
+            git push -u origin "$BRANCH" --force-with-lease
+          fi
+
+      - name: Open or update PR
+        if: >-
+          steps.state.outputs.relevant == 'true' &&
+          steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE: ${{ steps.state.outputs.base }}
+          BRANCH: ${{ steps.state.outputs.branch }}
+        run: |
+          HEAD="$(git rev-parse origin/main)"
+          LOG="$(git log --oneline "$BASE"..origin/main | sed 's/^/    /')"
+          BODY="$(printf '%s\n\nSynced %s..%s:\n\n%s\n\nEdits follow the wiki-sync skill. The anchor (docs/.sync-base) rides inside the docs-only commit: merging anchors the wiki.' \
+            "Scheduled wiki sync." "$BASE" "$HEAD" "$LOG")"
+          EXISTING="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')"
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            gh pr edit "$EXISTING" --body "$BODY"
+          else
+            gh pr create --title "docs: scheduled wiki sync" \
+              --body "$BODY" --base main --head "$BRANCH"
+          fi


### PR DESCRIPTION
## Summary

Enhances the `wiki-sync` skill for unattended, scheduled operation:

- **Step 1 delta gate** — path-scoped `git diff --quiet $BASE..origin/main -- src test bench .github` exits before any expensive work when nothing wiki-relevant changed.
- **Core invariant 6 — anchor last** — the `.sync-base` bump rides inside the docs-only commit; merge = anchored. Interrupted runs leave the anchor untouched, so the next run safely redoes the delta.
- **New "Scheduled syncs (CI)" section** — triggers, resume state machine (fresh/resumed/skip cases), content-level no-op guard, bot authorship + permissions, concurrency, and the harness-agnostic agent invocation seam.
- **New `workflows/wiki-sync.yml` template** — copy-to-install driver with four commented wirings (OpenCode, Pi, Claude Code, Codex), dispatch-only trigger (cron shipped disabled), `github-actions[bot]` commits, and PR-based verification via the target repo's own CI.

## Verification

- YAML parses (`yaml.safe_load`): jobs/steps well-formed.
- `wiki -c docs/wiki.yml fmt --check`, `lint --strict`, `check --strict`: all exit 0.
- No changes under `docs/wiki/` or Python sources; skills/ and workflows/ only.
