### PR TITLE
Guard wiki-sync template against unresolvable sync anchors

### DIFF
--- a/skills/wiki-sync/workflows/wiki-sync.yml
+++ b/skills/wiki-sync/workflows/wiki-sync.yml
@@ -57,6 +57,13 @@ jobs:
             git checkout -b "$BRANCH" origin/main
           fi
           BASE="$(cat docs/.sync-base 2>/dev/null || git log -1 --format=%H -- docs/)"
+          # An unresolvable anchor (corrupt entry, rewritten history) must
+          # not kill the run: fall back to the last commit touching docs/,
+          # per the skill's "One anchor, deterministic diffs" principle.
+          if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            echo "::warning::docs/.sync-base '$BASE' does not resolve; falling back to the last commit that touched docs/"
+            BASE="$(git log -1 --format=%H -- docs/)"
+          fi
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
           if git diff --quiet "$BASE"..origin/main -- src test bench .github; then


### PR DESCRIPTION
## Summary

Mirrors the Resolve state hardening dogfooded in wazootech/sparql-engine#192 into the upstream `wiki-sync` workflow template: validate the anchor read from `docs/.sync-base` with `git cat-file` before diffing, and fall back to the last commit that touched `docs/` (the skill's existing "One anchor, deterministic diffs" stale-anchor rule) when it does not resolve.

Found by the first Wiki sync dispatch there, which died with `Invalid revision range` on a corrupt anchor entry. Consumers copying the template inherit the guard.

## Verification

- YAML parses.
- `wiki -c docs/wiki.yml fmt --check`, `lint --strict`, `check --strict`: all exit 0.
