### PR TITLE
Resolve wiki-sync prompt via vendored or pinned fetch in template

### DIFF
--- a/skills/wiki-sync/workflows/wiki-sync.yml
+++ b/skills/wiki-sync/workflows/wiki-sync.yml
@@ -7,6 +7,9 @@
 #      for `deno fmt --check docs/`), plus an optional validate step between
 #      the agent and the commit so a failed run cannot land or bump the
 #      anchor.
+# The prompt is read from a vendored skills/wiki-sync/SKILL.md when present;
+# otherwise "Resolve skill prompt file" fetches it from wazootech/wiki pinned
+# by SKILL_PIN — bump that commit deliberately to pick up skill updates.
 # Enable the cron trigger only after manual dispatch runs prove the loop.
 #
 # Contract (skills/wiki-sync/SKILL.md, "Scheduled syncs (CI)"):
@@ -78,6 +81,28 @@ jobs:
         if: steps.state.outputs.relevant == 'false'
         run: echo "Nothing to sync; stopping cleanly."
 
+      # Locate the prompt source: consumers that vendor the skill use their
+      # local copy; everyone else fetches it pinned to a wiki-toolchain
+      # commit so prompts stay reproducible. Bump SKILL_PIN deliberately.
+      - name: Resolve skill prompt file
+        id: skill
+        if: steps.state.outputs.relevant == 'true'
+        env:
+          SKILL_PIN: e45166c16496866f55cf64ad798d15de0ebf3e4d
+        run: |
+          LOCAL="skills/wiki-sync/SKILL.md"
+          if [ -f "$LOCAL" ]; then
+            echo "path=$LOCAL" >> "$GITHUB_OUTPUT"
+            echo "Using vendored $LOCAL"
+          else
+            DEST="$RUNNER_TEMP/wiki-sync-SKILL.md"
+            curl -fsSL \
+              "https://raw.githubusercontent.com/wazootech/wiki/$SKILL_PIN/$LOCAL" \
+              -o "$DEST"
+            echo "path=$DEST" >> "$GITHUB_OUTPUT"
+            echo "Fetched skill at pinned commit $SKILL_PIN"
+          fi
+
       # Toolchain steps go here if validators need them, e.g.:
       # - uses: denoland/setup-deno@v2
       #   with:
@@ -86,10 +111,12 @@ jobs:
       # =====================================================================
       # AGENT WIRING — uncomment exactly ONE block and set its secret.
       #
-      # This skill file IS the prompt. Each wiring tells the agent to follow
-      # skills/wiki-sync/SKILL.md end to end against THIS checkout, editing
-      # only docs/ and leaving ALL changes uncommitted (no git add/commit/
-      # push, no PRs) — the workflow owns committing and PR creation below.
+      # This skill file IS the prompt: the "Resolve skill prompt file" step
+      # exposes it as SKILL_PATH (vendored copy or pinned fetch). Each
+      # wiring tells the agent to follow the skill end to end against THIS
+      # checkout, editing only docs/ and leaving ALL changes uncommitted
+      # (no git add/commit/push, no PRs) — the workflow owns committing,
+      # pushing, and PR creation below.
       # =====================================================================
 
       # --- OpenCode --------------------------------------------------------
@@ -97,10 +124,15 @@ jobs:
       #   if: steps.state.outputs.relevant == 'true'
       #   env:
       #     BASE: ${{ steps.state.outputs.base }}
+      #     SKILL_PATH: ${{ steps.skill.outputs.path }}
       #     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       #   run: |
       #     curl -fsSL https://opencode.ai/install | bash
-      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #     if [ -z "$ANTHROPIC_API_KEY" ]; then
+      #       echo "::error::ANTHROPIC_API_KEY is not set; add the provider secret to run the sync agent."
+      #       exit 1
+      #     fi
+      #     PROMPT="$(cat "$SKILL_PATH")
       #       Follow this skill end to end for THIS checkout. Base commit:
       #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
       #       skill's Step 8 validation passes. Leave all changes
@@ -115,10 +147,15 @@ jobs:
       #   if: steps.state.outputs.relevant == 'true'
       #   env:
       #     BASE: ${{ steps.state.outputs.base }}
+      #     SKILL_PATH: ${{ steps.skill.outputs.path }}
       #     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       #   run: |
       #     curl -fsSL https://pi.dev/install.sh | sh
-      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #     if [ -z "$ANTHROPIC_API_KEY" ]; then
+      #       echo "::error::ANTHROPIC_API_KEY is not set; add the provider secret to run the sync agent."
+      #       exit 1
+      #     fi
+      #     PROMPT="$(cat "$SKILL_PATH")
       #       Follow this skill end to end for THIS checkout. Base commit:
       #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
       #       skill's Step 8 validation passes. Leave all changes
@@ -130,10 +167,15 @@ jobs:
       #   if: steps.state.outputs.relevant == 'true'
       #   env:
       #     BASE: ${{ steps.state.outputs.base }}
+      #     SKILL_PATH: ${{ steps.skill.outputs.path }}
       #     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       #   run: |
       #     npm install -g @anthropic-ai/claude-code
-      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #     if [ -z "$ANTHROPIC_API_KEY" ]; then
+      #       echo "::error::ANTHROPIC_API_KEY is not set; add the provider secret to run the sync agent."
+      #       exit 1
+      #     fi
+      #     PROMPT="$(cat "$SKILL_PATH")
       #       Follow this skill end to end for THIS checkout. Base commit:
       #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
       #       skill's Step 8 validation passes. Leave all changes
@@ -145,10 +187,15 @@ jobs:
       #   if: steps.state.outputs.relevant == 'true'
       #   env:
       #     BASE: ${{ steps.state.outputs.base }}
+      #     SKILL_PATH: ${{ steps.skill.outputs.path }}
       #     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       #   run: |
       #     npm install -g @openai/codex
-      #     PROMPT="$(cat skills/wiki-sync/SKILL.md)
+      #     if [ -z "$OPENAI_API_KEY" ]; then
+      #       echo "::error::OPENAI_API_KEY is not set; add the provider secret to run the sync agent."
+      #       exit 1
+      #     fi
+      #     PROMPT="$(cat "$SKILL_PATH")
       #       Follow this skill end to end for THIS checkout. Base commit:
       #       ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
       #       skill's Step 8 validation passes. Leave all changes


### PR DESCRIPTION
## Summary

Second dogfood-driven fix to the scheduled-sync template. The first sparql-engine dispatch (wazootech/sparql-engine run 32557848073) failed at the agent wiring with `cat: skills/wiki-sync/SKILL.md: No such file or directory` — copy-to-install consumers do not contain that path.

- **New harness-neutral "Resolve skill prompt file" step**: exposes the skill as `SKILL_PATH` — a vendored `skills/wiki-sync/SKILL.md` when present, otherwise a fetch from wazootech/wiki pinned by `SKILL_PIN` (commit SHA, bumped deliberately) so prompts stay reproducible.
- **Credential guards** in each wiring: a missing provider secret now fails immediately with an actionable `::error::` instead of a confusing downstream auth failure.

## Verification

- YAML parses; `wiki fmt --check` / `lint --strict` / `check --strict` all exit 0.
- Pi installer itself verified headless in the same dogfood run (`@earendil-works/pi-coding-agent`, non-interactive install OK).
