### PR TITLE
chore: add pre-commit hook (fmt-check staged files)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# prettier-check staged files (repo canonical formatter)
+staged=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|md)$')
+[ -z "$staged" ] && exit 0
+exec npx --no-install prettier --check $staged


### PR DESCRIPTION
Part of the org CI-hygiene sweep: installs a .githooks/pre-commit that fmt-checks staged files with the repo's canonical formatter before they leave the machine. Enable once per clone with: `git config core.hooksPath .githooks`