### PR TITLE
cli: add `i` alias for the install subcommand

### DIFF
--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -753,6 +753,14 @@ def install(wiki: Wiki, url: str | None) -> None:
         click.echo(f"  {name}: {locked.resolved_ref[:12]} ({locked.fetched_at})")
 
 
+@main.command(hidden=True)
+@click.argument("url", required=False, default=None)
+@click.pass_obj
+def i(wiki: Wiki, url: str | None) -> None:
+    """Alias for install."""
+    install(wiki, url)
+
+
 @main.command()
 @click.argument("name", required=False, default=None)
 @click.option("-n", "--dry-run", is_flag=True, help="Show what would update without modifying wiki.lock.")


### PR DESCRIPTION
Add `wiki i` as a short alias for `wiki install`, following the npm convention (`npm i` / `npm install`).

**Changes:**
- Added a hidden Click command `i` that delegates to `install`
- Works identically to `wiki install` but with less typing
- Does not clutter `wiki --help` (registered as `hidden=True`)

**Prior art:** `npm i`, `yarn i`, `pnpm i`

Closes #79