### PR TITLE
style: fix ruff import-sort in tests/test_cli.py (greens main CI)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1664,9 +1664,9 @@ name: ConfigTest
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:
             with runner.isolated_filesystem(temp_dir=tmpdir):
-                from unittest.mock import patch, MagicMock
                 import shutil
                 from pathlib import Path as P
+                from unittest.mock import MagicMock, patch
 
                 # Create a fake wiki-templates monorepo with a generic template
                 fake_templates_dir = P(tmpdir) / "fake-templates"
@@ -1716,9 +1716,9 @@ name: ConfigTest
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:
             with runner.isolated_filesystem(temp_dir=tmpdir):
-                from unittest.mock import patch, MagicMock
                 import shutil
                 from pathlib import Path as P
+                from unittest.mock import MagicMock, patch
 
                 fake_templates_dir = P(tmpdir) / "fake-templates"
                 fake_templates_dir.mkdir()


### PR DESCRIPTION
Extracted from wazootech/wiki#274 (`40dabc6`), which is being **closed unmerged** — its Phase 0 vocabulary publication was expunged as preemptive (product-scoped `wiki:` vocab superseded by an abstraction-scoped Linked Markdown vocab; recorded as future work at wazootech/linked-markdown#19).

This commit stands alone: `main` is currently red — `uv run ruff check .` fails with I001 import-sort violations at `tests/test_cli.py:1667` and `:1719` (local imports inside two `wiki init --template` test blocks), a pre-existing failure on `main` (`90e564d`). This restores green CI independently of any vocabulary work.

Verified locally on this head: `ruff check .` clean (544-test unit suite also passes — unchanged code, import reorder only).
