### PR TITLE
feat(npm): bind install/update/remove and init --site-layout; enforce CLI drift (#206)

### DIFF
--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -232,6 +232,8 @@ export interface InitOptions {
   baseUrl?: string;
   /** Override ``site.url_style`` (``"file"`` or ``"dir"``). */
   urlStyle?: UrlStyle;
+  /** Override ``site.layout``. */
+  siteLayout?: string;
   /** Override ``graph.content_predicate``. */
   graphContentPredicate?: string;
   /** Override ``link.style`` (``"standard"`` or ``"wikilink"``). */
@@ -246,6 +248,28 @@ export interface InitOptions {
   graphImplicitTypesPolicy?: "fallback" | "append";
   /** Override ``graph.include_file_extension``. */
   graphIncludeFileExtension?: boolean;
+  /** Scaffold from a starter template in wazootech/wiki-templates. */
+  template?: string;
+}
+
+/** Options for ``Wiki.install()``. */
+export interface InstallOptions {
+  /** Git URL of an external source to add, fetch, and lock. Omit to install all declared sources. */
+  url?: string;
+}
+
+/** Options for ``Wiki.update()``. */
+export interface UpdateOptions {
+  /** Source name to check; omit to check all locked sources. */
+  name?: string;
+  /** Report what would update without modifying wiki.lock. */
+  dryRun?: boolean;
+}
+
+/** Options for ``Wiki.remove()``. */
+export interface RemoveOptions {
+  /** Name of the source to remove. */
+  name: string;
 }
 
 /** Options for ``Wiki.upgrade()``. */

--- a/npm/src/wiki.ts
+++ b/npm/src/wiki.ts
@@ -19,16 +19,19 @@ import type {
   ExportResult,
   FmtOptions,
   InitOptions,
+  InstallOptions,
   LinkOptions,
   LintOptions,
   McpOptions,
   PreflightOptions,
   PreflightResult,
   QueryOptions,
+  RemoveOptions,
   RenderOptions,
   RunOptions,
   RuntimeOptions,
   ServeOptions,
+  UpdateOptions,
   UpgradeOptions,
   WikiCommandResult,
   WikiLoadOptions,
@@ -351,6 +354,7 @@ export class Wiki {
     pushFlag(args, "--graph-context-wiki", options.graphContextWiki);
     pushFlag(args, "--site-base-url", options.baseUrl);
     pushFlag(args, "--site-url-style", options.urlStyle);
+    pushFlag(args, "--site-layout", options.siteLayout);
     pushFlag(args, "--graph-content-predicate", options.graphContentPredicate);
     pushFlag(args, "--link-style", options.linkStyle);
     pushRepeated(args, "--wiki-inputs", options.wikiInputs);
@@ -368,7 +372,43 @@ export class Wiki {
           : "--no-graph-include-file-extension",
       );
     }
+    pushFlag(args, "--template", options.template);
     return this.run(this.args("init", args));
+  }
+
+  /** Fetch and lock external data sources.
+   *
+   * With no URL, installs all sources declared in the config file and updates
+   * wiki.lock. With a URL, adds a new git source to the config, fetches it,
+   * and locks it.
+   *
+   * @param options - Install options (git URL of the source to add).
+   */
+  install(options: InstallOptions = {}): Promise<WikiCommandResult> {
+    const args: string[] = [];
+    if (options.url !== undefined) args.push(options.url);
+    return this.run(this.args("install", args));
+  }
+
+  /** Check locked sources for newer commits and update wiki.lock.
+   *
+   * @param options - Update options (source name filter, dry run).
+   */
+  update(options: UpdateOptions = {}): Promise<WikiCommandResult> {
+    const args: string[] = [];
+    if (options.dryRun) args.push("--dry-run");
+    if (options.name !== undefined) args.push(options.name);
+    return this.run(this.args("update", args));
+  }
+
+  /** Remove a source from the config file, its cache, and wiki.lock.
+   *
+   * @param options - Remove options (name of the source to remove).
+   */
+  remove(options: RemoveOptions): Promise<WikiCommandResult> {
+    const args: string[] = [];
+    args.push(options.name);
+    return this.run(this.args("remove", args));
   }
 
   /** Check for updates and upgrade the wiki CLI.

--- a/npm/test-cli-drift.js
+++ b/npm/test-cli-drift.js
@@ -1,9 +1,15 @@
 /**
  * CLI drift detector — verifies TypeScript bindings match Pydantic models.
  *
- * Generates a command→options map from Pydantic models, then checks
- * that every subcommand has a Wiki.prototype method and matching
- * expected option names.
+ * Runs in two stages:
+ *
+ * 1. CLI/model conformance (`scripts/check_cli_models.py`): introspects the
+ *    real Click command tree and fails when a non-hidden subcommand or
+ *    option has no Pydantic model entry (e.g. a new `@click.option` that
+ *    was never mirrored into `src/wiki/schemas/cli.py`).
+ * 2. Model/TS drift: generates a command→options map from Pydantic models,
+ *    then checks that every subcommand has a Wiki.prototype method and
+ *    matching expected option names.
  */
 
 const { execSync } = require("child_process");
@@ -14,12 +20,16 @@ const EXPECTED_OPTIONS = {
   check: ["files", "strict", "verbose"],
   export: ["files", "format", "mode", "output"],
   fmt: ["check", "files", "verbose"],
-  init: ["baseUrl", "git", "graphBaseIri", "graphContentPredicate", "graphContextWiki", "graphImplicitTypes", "graphImplicitTypesPolicy", "graphIncludeFileExtension", "linkStyle", "repo", "urlStyle", "wikiInputs"],
+  init: ["baseUrl", "git", "graphBaseIri", "graphContentPredicate", "graphContextWiki", "graphImplicitTypes", "graphImplicitTypesPolicy", "graphIncludeFileExtension", "linkStyle", "repo", "siteLayout", "template", "urlStyle", "wikiInputs"],
+  install: ["url"],
   link: ["apply", "check", "dryRun", "files", "fixBroken", "verbose"],
   lint: ["files", "strict", "verbose"],
+  mcp: ["cache", "mode"],
   query: ["cache", "format", "jq", "noInference", "output", "pretty", "query", "reload", "verbose"],
+  remove: ["name"],
   render: ["cache", "check", "files", "noInference", "reload", "verbose"],
   serve: ["baseUrl", "host", "port", "urlStyle", "watch"],
+  update: ["dryRun", "name"],
   upgrade: ["check", "verbose", "yes"],
 };
 
@@ -30,6 +40,20 @@ function main() {
   let exitCode = 0;
   const errors = [];
 
+  // Stage 1: CLI ↔ Pydantic model conformance. Any CLI subcommand/option
+  // missing from COMMAND_MODELS fails here before the TS comparison runs.
+  try {
+    execSync("uv run python scripts/check_cli_models.py", {
+      encoding: "utf-8",
+      stdio: "inherit",
+      timeout: 60_000,
+    });
+  } catch (error) {
+    console.error(error.message || String(error));
+    process.exit(1);
+  }
+
+  // Stage 2: model ↔ TS drift.
   const manifest = JSON.parse(
     execSync("uv run python scripts/export_cli_shapes.py", {
       encoding: "utf-8",

--- a/npm/test-wiki-api.js
+++ b/npm/test-wiki-api.js
@@ -116,6 +116,65 @@ async function main() {
     '--no-graph-include-file-extension',
   ]);
 
+  const siteInitWiki = new TestWiki();
+  await siteInitWiki.init({
+    baseUrl: 'https://wiki.wazoo.dev',
+    urlStyle: 'dir',
+    siteLayout: 'docs',
+    template: 'generic',
+  });
+  assert.deepStrictEqual(siteInitWiki.calls.at(-1), [
+    'init',
+    '--site-base-url',
+    'https://wiki.wazoo.dev',
+    '--site-url-style',
+    'dir',
+    '--site-layout',
+    'docs',
+    '--template',
+    'generic',
+  ]);
+
+  await wiki.install();
+  assert.deepStrictEqual(wiki.calls.at(-1), [
+    '--wiki-inputs',
+    'docs/wiki',
+    '--config',
+    'docs/wiki.yml',
+    'install',
+  ]);
+
+  await wiki.install({ url: 'https://github.com/wazootech/wiki-templates.git' });
+  assert.deepStrictEqual(wiki.calls.at(-1), [
+    '--wiki-inputs',
+    'docs/wiki',
+    '--config',
+    'docs/wiki.yml',
+    'install',
+    'https://github.com/wazootech/wiki-templates.git',
+  ]);
+
+  await wiki.update({ name: 'templates', dryRun: true });
+  assert.deepStrictEqual(wiki.calls.at(-1), [
+    '--wiki-inputs',
+    'docs/wiki',
+    '--config',
+    'docs/wiki.yml',
+    'update',
+    '--dry-run',
+    'templates',
+  ]);
+
+  await wiki.remove({ name: 'templates' });
+  assert.deepStrictEqual(wiki.calls.at(-1), [
+    '--wiki-inputs',
+    'docs/wiki',
+    '--config',
+    'docs/wiki.yml',
+    'remove',
+    'templates',
+  ]);
+
   console.log('npm Wiki API regression ok');
 }
 

--- a/scripts/check_cli_models.py
+++ b/scripts/check_cli_models.py
@@ -1,0 +1,141 @@
+"""Verify Pydantic CLI option models cover the real Click command tree.
+
+The npm drift test (``npm/test-cli-drift.js``) compares the TypeScript
+binding against ``COMMAND_MODELS`` in ``src/wiki/schemas/cli.py``. That
+only catches drift once a command/flag has a model — a subcommand or
+``@click.option`` added without a model entry is invisible to it.
+
+This script closes the loop by introspecting the actual Click CLI
+(``wiki.cli.main``) and failing when a non-hidden command or option has
+no Pydantic model with a matching field (by python name or alias):
+
+- every non-hidden top-level leaf command must be registered in
+  ``COMMAND_MODELS`` with a model whose fields cover every Click param
+  (option and positional argument);
+- nested group leaves (e.g. ``wiki graph list``) must have zero Click
+  params unless they gain a model — the TS binding flattens them into a
+  dedicated method such as ``Wiki.graphList()`` with no options;
+- every model field must correspond to a real Click param (catches stale
+  aliases after a flag is removed).
+
+Mirroring rule from AGENTS.md: when changing ``src/wiki/cli.py``
+subcommands, flags, choices, or positional arguments, update
+``npm/src/wiki.ts``, ``npm/src/types.ts``, and ``npm/test-wiki-api.js``
+in the same PR. This check enforces the first half of that contract
+(CLI -> schemas); the npm drift test enforces the second half
+(schemas -> TypeScript).
+
+Usage:
+    uv run python scripts/check_cli_models.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+_src = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(_src))
+
+from wiki.schemas import COMMAND_MODELS  # noqa: E402 — path inserted above
+
+
+def _covered(model: type, param_name: str) -> bool:
+    """Whether ``model`` has a field matching a Click param name.
+
+    Click param names are the python snake_case names (e.g.
+    ``site_url_style``, ``disk_cache``); model fields use the same python
+    names with camelCase ``alias`` for TS consumers, so either spelling
+    satisfies the match.
+    """
+    for field_name, field_info in model.model_fields.items():
+        if field_name == param_name or field_info.alias == param_name:
+            return True
+    return False
+
+
+def _walk(group: click.Group, errors: list[str], prefix: tuple[str, ...] = ()) -> None:
+    """Collect conformance errors for every leaf command under ``group``."""
+    for name, command in group.commands.items():
+        path = (*prefix, name)
+        if getattr(command, "hidden", False):
+            continue
+
+        if isinstance(command, click.Group):
+            _walk(command, errors, path)
+            continue
+
+        if len(path) > 1:
+            # Nested group leaf (e.g. ``graph list``). The TS binding
+            # flattens it into a dedicated zero-option method
+            # (``Wiki.graphList()``); if it ever gains params, give it a
+            # model and a TS wrapper.
+            if command.params:
+                errors.append(
+                    f"Nested CLI leaf '{' '.join(path)}' has params but no "
+                    f"COMMAND_MODELS entry; add a Pydantic model + TS wrapper."
+                )
+            continue
+
+        leaf = path[0]
+        model = COMMAND_MODELS.get(leaf)
+        if model is None:
+            errors.append(
+                f"CLI command '{leaf}' has no Pydantic model in COMMAND_MODELS "
+                f"(src/wiki/schemas/cli.py); add one and mirror it into the TS "
+                f"binding (npm/src/wiki.ts, npm/src/types.ts)."
+            )
+            continue
+
+        click_params = {param.name for param in command.params}
+        for param in command.params:
+            if not _covered(model, param.name):
+                flags = " ".join(param.opts or [])
+                errors.append(
+                    f"CLI command '{leaf}' {flags or param.name} has no field in "
+                    f"{model.__name__}; add a field with the matching camelCase "
+                    f"alias."
+                )
+        for field_name, field_info in model.model_fields.items():
+            alias = field_info.alias or field_name
+            if field_name not in click_params and alias not in click_params:
+                errors.append(
+                    f"{model.__name__} field '{field_name}' has no matching "
+                    f"Click param on '{leaf}'; remove or realign the field."
+                )
+
+
+def main() -> int:
+    from wiki.cli import main  # noqa: PLC0415 — deferred heavy import
+
+    errors: list[str] = []
+    _walk(main, errors)
+
+    if errors:
+        print(f"CLI/model conformance FAILED ({len(errors)} issue(s)):", file=sys.stderr)
+        for error in errors:
+            print(f"  *  {error}", file=sys.stderr)
+        print(
+            "Fix: update src/wiki/schemas/cli.py so COMMAND_MODELS mirrors the "
+            "Click CLI, then mirror new wrappers into npm/src/wiki.ts, "
+            "npm/src/types.ts, and npm/test-wiki-api.js.",
+            file=sys.stderr,
+        )
+        return 1
+
+    command_count = sum(
+        1
+        for cmd in main.commands.values()
+        if not getattr(cmd, "hidden", False) and not isinstance(cmd, click.Group)
+    )
+    print(
+        f"CLI/model conformance passed: {command_count} commands mirror "
+        f"COMMAND_MODELS."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/wiki/schemas/cli.py
+++ b/src/wiki/schemas/cli.py
@@ -160,6 +160,7 @@ class InitOptions(BaseModel):
     site_url_style: Literal["dir", "file"] | None = Field(
         default=None, alias="urlStyle"
     )
+    site_layout: str | None = Field(default=None, alias="siteLayout")
     graph_content_predicate: str | None = Field(
         default=None, alias="graphContentPredicate"
     )
@@ -181,6 +182,39 @@ class InitOptions(BaseModel):
     graph_include_file_extension: bool | None = Field(
         default=None, alias="graphIncludeFileExtension"
     )
+    init_template: str | None = Field(default=None, alias="template")
+
+
+# ── mcp ──
+
+
+class McpOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    mode: Literal["stdio"] = Field(default="stdio", alias="mode")
+    disk_cache: bool = Field(default=False, alias="cache")
+
+
+# ── sources: install / update / remove ──
+
+
+class InstallOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    url: str | None = Field(default=None, alias="url")
+
+
+class UpdateOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    name: str | None = Field(default=None, alias="name")
+    dry_run: bool = Field(default=False, alias="dryRun")
+
+
+class RemoveOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    name: str = Field(alias="name")
 
 
 # ── fmt ──
@@ -214,8 +248,12 @@ COMMAND_MODELS: dict[str, type[BaseModel]] = {
     "export": ExportOptions,
     "serve": ServeOptions,
     "init": InitOptions,
+    "mcp": McpOptions,
     "fmt": FmtOptions,
     "upgrade": UpgradeOptions,
+    "install": InstallOptions,
+    "update": UpdateOptions,
+    "remove": RemoveOptions,
 }
 
 __all__ = [


### PR DESCRIPTION
## What

Implements both directions proposed in #206: the **gap-fill** (TS wrappers for the drifted CLI surface) and **better drift detection** (Click introspection, so future drift fails CI instead of going unnoticed).

**Gap-fill — new TS wrappers + Pydantic models:**
- `Wiki.install()` / `Wiki.update()` / `Wiki.remove()` with `InstallOptions`, `UpdateOptions`, `RemoveOptions` in `npm/src/types.ts`, mirroring `wiki install|update|remove` (CLI: fetch/lock external git sources, check locked sources, remove a source).
- `init --site-layout` wired through `InitOptions.siteLayout`, the `wiki.init()` arg builder, and the `InitOptions` Pydantic model.
- Ripple fixes required for consistency: `--template` (recently added to `wiki init` in `90e564d`, never bound) and an `McpOptions` Pydantic model (the `mcp` subcommand existed without one, invisible to the old drift test).

**Drift detection — `scripts/check_cli_models.py` (new):**
- Introspects the real Click command tree (`wiki.cli.main`) and fails when a non-hidden subcommand or option has no `COMMAND_MODELS` entry with a matching field (by python name or camelCase alias).
- Also fails on the reverse direction: a model field with no matching Click param (catches stale aliases after a flag is removed).
- Nested group leaves (e.g. `graph list`) must stay zero-param unless given a model, since the TS binding flattens them.
- Wired as stage 1 of `npm/test-cli-drift.js`, so the existing model↔TS comparison now runs after CLI↔model conformance.

Per AGENTS.md, the mirror surface (`npm/src/wiki.ts`, `npm/src/types.ts`, `npm/test-wiki-api.js`) is updated in the same PR.

## Verification (local, mirroring CI)

- `uv run ruff check .` — clean (on rebased main incl. #282)
- `uv run python -m unittest discover -s tests` — 544/544 pass
- `node npm/test-cli-drift.js` — CLI/model conformance passed (15 commands); drift check passed (15 commands, 70 options match TS bindings)
- `npm run test:npm` — build, `test-setup-argv`, and `test-wiki-api` regressions all pass (new arg-builder assertions for `--site-layout`, `--template`, install/update/remove)
- No `docs/wiki/` changes — docs-wiki audits unaffected

Fixes #206