### PR TITLE
chore(npm): fail typedoc docs build on undocumented public API

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -5,5 +5,9 @@
   "name": "wazootech-wiki TypeScript API",
   "includeVersion": true,
   "tsconfig": "./tsconfig.json",
-  "highlightLanguages": ["typescript", "javascript", "bash", "json", "yaml", "markdown", "html", "python", "sparql", "powershell"]
+  "highlightLanguages": ["typescript", "javascript", "bash", "json", "yaml", "markdown", "html", "python", "sparql", "powershell"],
+  "validation": {
+    "notDocumented": true
+  },
+  "treatWarningsAsErrors": true
 }


### PR DESCRIPTION
## What

Turns the TypeScript API docs build into a doc-comment gate: typedoc's `validation.notDocumented` (with `treatWarningsAsErrors`) fails `npm run gendocs:ts` whenever a public API symbol lacks a doc comment — a `Wiki` method, an exported interface, or any of their members.

This closes the loop on the mirroring rule from #206 (and AGENTS.md): the drift check ensures every CLI command/flag has a TS binding, and this ensures every public TS binding ships with documentation.

## Why typedoc (not ESLint)

The repo already runs `npm run gendocs:ts` in **both** CI (`Verify TypeScript API docs build`) and the Pages **deploy** workflow — a single 5-line config change enforces the rule everywhere, with zero new dependencies. (An ESLint route would need a new plugin like `eslint-plugin-jsdoc` plus flat-config wiring, and would only gate the NPM job.)

## Verification

- **Current tree passes**: `npm run gendocs:ts` → `html generated`, exit 0, **zero warnings** — every exported symbol in the package is already documented.
- **Negative tests (both restore-verified):**
  - Stripped `Wiki.install()`'s doc comment → `[warning] Wiki.install (CallSignature) ... does not have any documentation`, build **fails** (exit 4).
  - Stripped `RemoveOptions.name`'s member comment → `[warning] RemoveOptions.name (Property) ... does not have any documentation`, build **fails**.
- `npm run build`, `npm run lint`, `npm run format:check` all pass (typedoc.json doesn't affect them).

## Scope note

`treatWarningsAsErrors` applies to all typedoc warnings (invalid links, etc.), not just `notDocumented` — the build is currently warning-free, so nothing else is affected today, and any future typedoc warning failing the docs build is consistent with the intent.