### PR TITLE
docs(python): fail the Sphinx build on any warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: "20"
 
       - name: Generate Python API docs
-        run: uv run sphinx-build -b html -c docs docs/api/python docs/assets/api/python
+        run: npm run gendocs:python
 
       - name: Generate TypeScript API docs
         run: npm install && npm run gendocs:ts

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,11 +23,9 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "furo"
-html_static_path = ["_static"]
 
 autodoc_default_options = {
     "members": True,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postinstall": "node npm/setup.js",
     "preuninstall": "node npm/uninstall.js",
     "setup": "node npm/setup.js",
-    "gendocs:python": "uv run sphinx-build -b html -c docs docs/api/python docs/assets/api/python",
+    "gendocs:python": "uv run sphinx-build -b html -W -c docs docs/api/python docs/assets/api/python",
     "gendocs:ts": "typedoc",
     "format": "prettier \"npm/**/*.ts\" --write",
     "format:check": "prettier \"npm/**/*.ts\" --check",


### PR DESCRIPTION
## What

Extends the warning-free docs guarantee (currently enforced on the TS side by typedoc's `treatWarningsAsErrors`) to the Python API reference: `gendocs:python` now runs `sphinx-build` with `-W` (warnings-as-errors), so any Sphinx warning fails the build — in CI, and in the Pages deploy.

Three small changes:

- **`package.json`** — `gendocs:python` gains `-W`: `uv run sphinx-build -b html -W -c docs docs/api/python docs/assets/api/python`
- **`docs/conf.py`** — drops the vestigial `templates_path = ["_templates"]` and `html_static_path = ["_static"]` declarations. The `_static` entry was the one latent warning in the build (`html_static_path entry '_static' does not exist`); neither directory exists and nothing in `docs/` references either, so they're dead config, not assets to create.
- **`.github/workflows/deploy.yml`** — the "Generate Python API docs" step now runs `npm run gendocs:python` instead of a duplicated inline copy of the sphinx command, so the gate applies at deploy time too and the command lives in exactly one place (matching how the TS docs step already routes through `npm run gendocs:ts`).

## Verification

- **Gate is green on the current tree**: `npm run gendocs:python` → `build succeeded.`, exit 0, **zero warnings**.
- **Negative test** (restored after): re-adding `html_static_path = ["_static"]` to conf.py → `WARNING: html_static_path entry '_static' does not exist` → build **fails** (exit 1). So a future PR landing a warning in the Python docs fails both CI's "Verify Python API docs build" step and the deploy.
- `uv run ruff check docs/conf.py` — clean.

From merge onward, an undocumented/broken element that makes Sphinx emit any warning blocks the build and the deploy, exactly like the typedoc gate does for the TS API.