### PR TITLE
Close the CLI↔TS mirror contract: flag strings, choice values, union aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Compatibility is allowed at the edges. Wiki CLI may parse, validate, preserve, a
 
 The npm TypeScript API is a thin binding over the Python CLI, not a second implementation. When changing `src/wiki/cli.py` subcommands, flags, choices, or positional arguments, update `npm/src/wiki.ts`, `npm/src/types.ts`, and `npm/test-wiki-api.js` in the same PR. Run `npm run test:npm` before landing those changes.
 
-The option-bag types in `npm/src/types.ts` are generated from the Pydantic `COMMAND_MODELS` models (`src/wiki/schemas/cli.py`): after changing a model's fields, aliases, or docstrings, run `npm run gen:cli-types` and commit the regenerated `npm/src/types.generated.ts`. The drift test (`npm/test-cli-drift.js`) fails CI when the committed generated file falls out of sync with the models.
+The option-bag types in `npm/src/types.ts` are generated from the Pydantic `COMMAND_MODELS` models (`src/wiki/schemas/cli.py`): after changing a model's fields, aliases, or docstrings, run `npm run gen:cli-types` and commit the regenerated `npm/src/types.generated.ts`. The drift test (`npm/test-cli-drift.js`) fails CI when the committed generated file falls out of sync with the models, and it also verifies every `--flag` string the wrapper methods in `npm/src/wiki.ts` emit against the real Click option strings — rename a Click flag and the wrapper must be updated in the same PR or CI fails.
 
 ### Running validations
 

--- a/npm/src/types.generated.ts
+++ b/npm/src/types.generated.ts
@@ -4,6 +4,29 @@
  * model_json_schema(by_alias=True)) compiled by json-schema-to-typescript.
  * Regenerate via: npm run gen:cli-types
  */
+
+// Choice unions — named mirrors of the schema enums (public API aliases).
+
+/** Override ``site.url_style`` (``"file"`` or ``"dir"``). */
+export type UrlStyle = "dir" | "file";
+
+/** RDF serialization format. */
+export type ExportFormat =
+  "dict" | "json-ld" | "turtle" | "xml" | "n3" | "nt" | "trig" | "nquads";
+
+/** JSON-LD mode (``"expanded"`` or ``"compacted"``). */
+export type ExportMode = "expanded" | "compacted";
+
+/** Override ``link.style`` (``"standard"`` or ``"wikilink"``). */
+export type LinkStyle = "standard" | "wikilink";
+
+/** MCP transport mode (default ``"stdio"``). */
+export type McpMode = "stdio";
+
+/** Output format. */
+export type QueryFormat =
+  "table" | "json" | "csv" | "tsv" | "turtle" | "n3" | "markdown";
+
 /**
  * Options for ``Wiki.build()``.
  */

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -5,22 +5,8 @@ import type {
   McpOptions as GeneratedMcpOptions,
   QueryOptions as GeneratedQueryOptions,
   ServeOptions as GeneratedServeOptions,
+  UrlStyle,
 } from "./types.generated";
-
-/** Build output URL style: ``<slug>.html`` (file) or ``<slug>/index.html`` (dir). */
-export type UrlStyle = "dir" | "file";
-/** Internal link syntax: ``[text](Page.md)`` (standard) or ``[[Page]]`` (wikilink). */
-export type LinkStyle = "standard" | "wikilink";
-/** Output formats for SPARQL query results. */
-export type QueryFormat =
-  "table" | "json" | "csv" | "tsv" | "turtle" | "n3" | "markdown";
-/** MCP server transport mode. */
-export type McpMode = "stdio";
-/** Output formats for RDF export. */
-export type ExportFormat =
-  "dict" | "json-ld" | "turtle" | "xml" | "n3" | "nt" | "trig" | "nquads";
-/** JSON-LD serialization mode. */
-export type ExportMode = "expanded" | "compacted";
 
 /** Options for loading a Wiki instance. */
 export interface WikiLoadOptions {
@@ -64,26 +50,36 @@ export interface WikiCommandResult {
   command: readonly string[];
 }
 
-// ── Generated CLI option bags ──────────────────────────────────────────────
-// The command option bags are generated from the Pydantic COMMAND_MODELS in
-// src/wiki/schemas/cli.py (scripts/export_cli_schemas.py +
-// scripts/generate_cli_types.mjs via `npm run gen:cli-types`); the drift test
-// in npm/test-cli-drift.js fails when the committed generated file falls out
-// of sync with the models. The bags below that merge SDK-only fields (e.g.
-// parseJson, cwd/env) onto their pure-CLI generated shape re-declare with
-// `extends`; everything else re-exports the generated declaration unchanged.
+// ── Generated CLI option bags and choice unions ────────────────────────────
+// The command option bags and the choice-union aliases (UrlStyle, LinkStyle,
+// QueryFormat, McpMode, ExportFormat, ExportMode) are generated from the
+// Pydantic COMMAND_MODELS in src/wiki/schemas/cli.py
+// (scripts/export_cli_schemas.py + scripts/generate_cli_types.mjs via
+// `npm run gen:cli-types`); the drift test in npm/test-cli-drift.js fails when
+// the committed generated file falls out of sync with the models. The bags
+// below that merge SDK-only fields (e.g. parseJson, cwd/env) onto their
+// pure-CLI generated shape re-declare with `extends`; everything else
+// re-exports the generated declaration unchanged. Only the SDK-runtime layer
+// below (load/run options, results, subprocess types) is hand-authored — it
+// has no CLI counterpart and cannot be generated from COMMAND_MODELS.
 export type {
   BuildOptions,
   CheckOptions,
+  ExportFormat,
+  ExportMode,
   FmtOptions,
   InitOptions,
   InstallOptions,
   LinkOptions,
+  LinkStyle,
   LintOptions,
+  McpMode,
+  QueryFormat,
   RenderOptions,
   RemoveOptions,
   UpdateOptions,
   UpgradeOptions,
+  UrlStyle,
 } from "./types.generated";
 
 /** Mixin for methods that accept a ``files`` filter. */

--- a/npm/test-cli-drift.js
+++ b/npm/test-cli-drift.js
@@ -6,7 +6,10 @@
  * 1. CLI/model conformance (`scripts/check_cli_models.py`): introspects the
  *    real Click command tree and fails when a non-hidden subcommand or
  *    option has no Pydantic model entry (e.g. a new `@click.option` that
- *    was never mirrored into `src/wiki/schemas/cli.py`).
+ *    was never mirrored into `src/wiki/schemas/cli.py`), or when a
+ *    `click.Choice`'s canonical values disagree with the model field's
+ *    `Literal`/`enum` (a choice accepted by the CLI but missing from the
+ *    generated TypeScript, or vice versa).
  * 2. Command presence: every manifest command must have a
  *    Wiki.prototype method (and vice versa for the documented extras that
  *    have no manifest key).

--- a/npm/test-cli-drift.js
+++ b/npm/test-cli-drift.js
@@ -1,7 +1,7 @@
 /**
- * CLI drift detector — verifies TypeScript bindings match Pydantic models.
+ * CLI drift detector — verifies TypeScript bindings match the Python CLI.
  *
- * Runs in three stages:
+ * Runs in four stages:
  *
  * 1. CLI/model conformance (`scripts/check_cli_models.py`): introspects the
  *    real Click command tree and fails when a non-hidden subcommand or
@@ -16,6 +16,15 @@
  *    echo here — the generated file carries the model's aliases, and
  *    `npm/src/types.ts` re-exports/extend it (issue #286 §7(d), the
  *    `EXPECTED_OPTIONS` echo was retired once the freshness gate landed).
+ * 4. Flag-string parity: the wrapper's `--flag` literals in
+ *    `npm/src/wiki.ts` are duplicated from Click's `@click.option`
+ *    declarations, and stages 1–3 never look at them (models carry field
+ *    names/aliases, not flag strings). This stage introspects the real Click
+ *    tree (`scripts/export_cli_flags.py`) and asserts every `--flag` literal
+ *    each wrapper method emits — including direct `args.push` emissions like
+ *    `update`'s `--dry-run` and `init`'s boolean-pair ternary — is a real
+ *    option string on that command (or on the root `wiki` command for
+ *    `args()`, which emits `--config`/`--wiki-inputs` from no model entry).
  */
 
 const { execSync } = require("child_process");
@@ -23,6 +32,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const prettier = require("prettier");
+const ts = require("typescript");
 const { Wiki } = require("./dist/index.js");
 
 // Prototype methods without a same-named COMMAND_MODELS key. Note: neither is
@@ -32,6 +42,54 @@ const { Wiki } = require("./dist/index.js");
 const NO_MANIFEST_METHODS = new Set(["preflight", "format"]);
 
 const GENERATED_TYPES = "npm/src/types.generated.ts";
+const ROOT_FLAGS_KEY = "__root__";
+const ROOT_DISPLAY = "wiki (root)";
+
+/**
+ * Stage 4: per-method `--flag` string literals from npm/src/wiki.ts, using the
+ * TypeScript compiler API so doc comments can't leak false flags and direct
+ * `args.push(...)` emissions (update's `--dry-run`, init's boolean-pair
+ * ternary) are captured as well as `pushFlag`/`pushRepeated` arguments.
+ */
+function extractMethodFlags(source) {
+  const sf = ts.createSourceFile(
+    "wiki.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS,
+  );
+  const byMethod = new Map();
+
+  function collectFlags(body) {
+    const flags = new Set();
+    (function walk(node) {
+      if (ts.isStringLiteral(node) && node.text.startsWith("--")) {
+        flags.add(node.text);
+      }
+      ts.forEachChild(node, walk);
+    })(body);
+    return flags;
+  }
+
+  (function visit(node) {
+    if (ts.isClassDeclaration(node) && node.name && node.name.text === "Wiki") {
+      for (const member of node.members) {
+        if (
+          (ts.isMethodDeclaration(member) ||
+            ts.isConstructorDeclaration(member)) &&
+          member.body
+        ) {
+          const name = member.name ? member.name.getText(sf) : "constructor";
+          byMethod.set(name, collectFlags(member.body));
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  })(sf);
+
+  return byMethod;
+}
 
 /** Stage 3: regenerate the generated types and compare to the committed file. */
 async function checkFreshness() {
@@ -127,10 +185,53 @@ async function main() {
   const freshnessError = await checkFreshness();
   if (freshnessError) errors.push(freshnessError);
 
+  // Stage 4: flag-string parity — every `--flag` a wrapper method emits must
+  // be a real Click option string on that command (or on the root command).
+  const commandFlags = JSON.parse(
+    execSync("uv run python scripts/export_cli_flags.py", {
+      encoding: "utf-8",
+      timeout: 30_000,
+    }),
+  );
+  const flagsByMethod = extractMethodFlags(
+    fs.readFileSync("npm/src/wiki.ts", "utf8"),
+  );
+  let flagCount = 0;
+  for (const [method, flags] of flagsByMethod) {
+    const cmd = Object.prototype.hasOwnProperty.call(commandFlags, method)
+      ? method
+      : method === "args"
+        ? ROOT_FLAGS_KEY
+        : undefined;
+    if (cmd === undefined) {
+      if (flags.size > 0) {
+        errors.push(
+          `Wiki.prototype.${method}() emits flags (${[...flags].join(", ")}) but ` +
+            `'${method}' is not a CLI command; emit them through a command method ` +
+            `or add a mapping to the drift check.`,
+        );
+      }
+      continue;
+    }
+    const real = new Set(commandFlags[cmd] ?? []);
+    const display = cmd === ROOT_FLAGS_KEY ? ROOT_DISPLAY : `'${cmd}'`;
+    for (const flag of flags) {
+      flagCount++;
+      if (!real.has(flag)) {
+        errors.push(
+          `Wiki.prototype.${method}() emits ${flag} but the ${display} command has ` +
+            `no such option (real options: ${[...real].join(", ") || "none"}).`,
+        );
+      }
+    }
+  }
+
   if (exitCode === 0 && errors.length === 0) {
     const cmdCount = Object.keys(manifest).length;
     console.log(
-      `Drift check passed: ${cmdCount} commands mirrored on Wiki.prototype; generated types are fresh.`,
+      `Drift check passed: ${cmdCount} commands mirrored on Wiki.prototype; ` +
+        `${flagCount} wrapper flag emissions verified against the Click tree; ` +
+        `generated types are fresh.`,
     );
   } else {
     exitCode = 1;

--- a/scripts/check_cli_models.py
+++ b/scripts/check_cli_models.py
@@ -16,7 +16,18 @@ no Pydantic model with a matching field (by python name or alias):
   params unless they gain a model — the TS binding flattens them into a
   dedicated method such as ``Wiki.graphList()`` with no options;
 - every model field must correspond to a real Click param (catches stale
-  aliases after a flag is removed).
+  aliases after a flag is removed);
+- **choice values must agree** — where a Click param uses ``click.Choice``
+  (or the ``FormatChoice`` subclass), the set of canonical choices must
+  equal the allowed values of the matching model field (its ``Literal[...]``
+  annotation and/or ``json_schema_extra={"enum": [...]}`` list). A new
+  choice accepted by the CLI but missing from the model — and therefore
+  from the generated TypeScript — fails here before it can ship, and so
+  does a model value the CLI rejects. For ``case_sensitive=False`` choices
+  the comparison is case-insensitive (Click accepts ``JSON`` while the
+  model documents the canonical ``json``). ``FormatChoice`` MIME/extension
+  aliases are intentionally not compared: they resolve to canonical choices
+  the model already lists.
 
 Mirroring rule from AGENTS.md: when changing ``src/wiki/cli.py``
 subcommands, flags, choices, or positional arguments, update
@@ -32,7 +43,9 @@ Usage:
 from __future__ import annotations
 
 import sys
+import types
 from pathlib import Path
+from typing import Literal, Union, get_args, get_origin, get_type_hints
 
 import click
 
@@ -42,8 +55,8 @@ sys.path.insert(0, str(_src))
 from wiki.schemas import COMMAND_MODELS  # noqa: E402 — path inserted above
 
 
-def _covered(model: type, param_name: str) -> bool:
-    """Whether ``model`` has a field matching a Click param name.
+def _matching_field(model: type, param_name: str) -> tuple[str, object] | None:
+    """The (field name, field info) in ``model`` matching a Click param name.
 
     Click param names are the python snake_case names (e.g.
     ``site_url_style``, ``disk_cache``); model fields use the same python
@@ -52,8 +65,58 @@ def _covered(model: type, param_name: str) -> bool:
     """
     for field_name, field_info in model.model_fields.items():
         if field_name == param_name or field_info.alias == param_name:
-            return True
-    return False
+            return field_name, field_info
+    return None
+
+
+def _literal_values(annotation: object) -> set[str]:
+    """String values allowed by a ``Literal[...]`` annotation (union-aware)."""
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return {v for v in get_args(annotation) if isinstance(v, str)}
+    if origin in (Union, types.UnionType):
+        values: set[str] = set()
+        for arg in get_args(annotation):
+            values |= _literal_values(arg)
+        return values
+    return set()
+
+
+def _model_choice_values(
+    model: type,
+    field_name: str,
+    field_info: object,
+    hints: dict[str, object],
+) -> set[str]:
+    """Allowed values the model declares for ``field_name``.
+
+    Combines any ``Literal[...]`` annotation with a
+    ``json_schema_extra={"enum": [...]}`` list — the two ways choice unions
+    are expressed in ``src/wiki/schemas/cli.py``.
+    """
+    values = _literal_values(hints.get(field_name))
+    extra = getattr(field_info, "json_schema_extra", None)
+    if isinstance(extra, dict):
+        enum = extra.get("enum")
+        if isinstance(enum, list):
+            values.update(v for v in enum if isinstance(v, str))
+    return values
+
+
+def _click_choice_values(
+    param: click.Parameter,
+) -> tuple[set[str], bool] | None:
+    """Canonical choices of a Click Choice param, or None for non-Choice params.
+
+    Returns ``(choices, case_sensitive)``. ``FormatChoice`` (a ``click.Choice``
+    subclass) is handled transparently: ``.choices`` holds the canonical short
+    names, while its MIME/extension aliases are CLI-only conveniences that
+    resolve to those canonical names and are not part of the mirror contract.
+    """
+    if not isinstance(param.type, click.Choice):
+        return None
+    case_sensitive = bool(getattr(param.type, "case_sensitive", True))
+    return set(param.type.choices), case_sensitive
 
 
 def _walk(group: click.Group, errors: list[str], prefix: tuple[str, ...] = ()) -> None:
@@ -90,13 +153,54 @@ def _walk(group: click.Group, errors: list[str], prefix: tuple[str, ...] = ()) -
             continue
 
         click_params = {param.name for param in command.params}
+        hints = get_type_hints(model)
         for param in command.params:
-            if not _covered(model, param.name):
-                flags = " ".join(param.opts or [])
+            match = _matching_field(model, param.name)
+            flags = " ".join(param.opts or []) or param.name
+            if match is None:
                 errors.append(
-                    f"CLI command '{leaf}' {flags or param.name} has no field in "
+                    f"CLI command '{leaf}' {flags} has no field in "
                     f"{model.__name__}; add a field with the matching camelCase "
                     f"alias."
+                )
+                continue
+            field_name, field_info = match
+            click_choice = _click_choice_values(param)
+            model_choices = _model_choice_values(model, field_name, field_info, hints)
+            if click_choice is None and not model_choices:
+                continue
+            if click_choice is None:
+                errors.append(
+                    f"CLI command '{leaf}' {flags} accepts any value but "
+                    f"{model.__name__}.{field_name} restricts to "
+                    f"{sorted(model_choices)}; add a click.Choice so the CLI and "
+                    f"TypeScript agree on accepted values."
+                )
+                continue
+            choices, case_sensitive = click_choice
+            if not model_choices:
+                errors.append(
+                    f"CLI command '{leaf}' {flags} restricts to {sorted(choices)} "
+                    f"but {model.__name__}.{field_name} declares no Literal/enum; "
+                    f"mirror the Choice into the model (and the TS union)."
+                )
+                continue
+            norm = (lambda v: v) if case_sensitive else (lambda v: v.casefold())
+            cli_set = {norm(v) for v in choices}
+            model_set = {norm(v) for v in model_choices}
+            if cli_set != model_set:
+                parts = []
+                cli_only = sorted(cli_set - model_set)
+                model_only = sorted(model_set - cli_set)
+                if cli_only:
+                    parts.append(f"CLI-only: {cli_only}")
+                if model_only:
+                    parts.append(f"model-only: {model_only}")
+                errors.append(
+                    f"CLI command '{leaf}' {flags} choices {sorted(choices)} "
+                    f"differ from {model.__name__}.{field_name} "
+                    f"{sorted(model_choices)} ({'; '.join(parts)}); comparison is "
+                    f"case-{'insensitive' if not case_sensitive else 'sensitive'}."
                 )
         for field_name, field_info in model.model_fields.items():
             alias = field_info.alias or field_name

--- a/scripts/export_cli_flags.py
+++ b/scripts/export_cli_flags.py
@@ -1,0 +1,84 @@
+"""Emit the real Click option strings for every top-level command.
+
+Stage 4 of the npm drift test (``npm/test-cli-drift.js``): the wrapper's flag
+emissions in ``npm/src/wiki.ts`` are literal strings duplicated from Click's
+``@click.option`` declarations, and until now nothing verified the two agree —
+a renamed or misspelled flag passed every earlier stage (models only carry
+field names/aliases, never flag strings) and failed at runtime with Click's
+"no such option". This script closes that hole by introspecting the real Click
+tree (same walk as ``scripts/check_cli_models.py``) and printing, per top-level
+leaf command, the exact option strings Click accepts:
+
+- ``param.opts`` carries every spelling of an option (long and short, e.g.
+  ``--verbose`` and ``-v``); ``param.secondary_opts`` carries the negative
+  half of ``"/"`` boolean pairs (e.g. ``--no-graph-include-file-extension``).
+  Only ``-``-prefixed strings are collected, so positional arguments
+  (whose ``opts`` is just the bare name) never pollute the set.
+- The root group's own params (``--config``, ``--wiki-inputs``) are emitted
+  under the ``"__root__"`` key — they live in no ``COMMAND_MODELS`` entry, so
+  no earlier stage guards them.
+- Nested leaves (e.g. ``graph list``) are zero-param by construction
+  (``check_cli_models.py`` enforces it), so they carry no options to emit.
+
+The drift test extracts every ``--flag`` string literal from each wrapper
+method and asserts each one is in its command's set here.
+
+Usage:
+    uv run python scripts/export_cli_flags.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+_src = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(_src))
+
+# Aliased so this script's own main() below doesn't shadow the CLI group.
+from wiki.cli import main as cli_main  # noqa: E402 — path inserted above
+
+ROOT_KEY = "__root__"
+
+
+def _opts(params: list[click.Parameter]) -> list[str]:
+    """Sorted unique option strings for ``params``.
+
+    Excludes the auto ``--help`` param and positional arguments (whose
+    ``opts`` is just the bare name — never a ``-``-prefixed string).
+    """
+    strings: set[str] = set()
+    for param in params:
+        if param.name == "help":
+            continue
+        for opt in (*param.opts, *getattr(param, "secondary_opts", ())):
+            if opt.startswith("-"):
+                strings.add(opt)
+    return sorted(strings)
+
+
+def main() -> int:
+    result: dict[str, list[str]] = {ROOT_KEY: _opts(cli_main.params)}
+
+    def walk(group: click.Group, prefix: tuple[str, ...] = ()) -> None:
+        for name, command in group.commands.items():
+            path = (*prefix, name)
+            if getattr(command, "hidden", False):
+                continue
+            if isinstance(command, click.Group):
+                walk(command, path)
+                continue
+            if len(path) == 1:
+                result[name] = _opts(command.params)
+
+    walk(cli_main)
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_cli_types.mjs
+++ b/scripts/generate_cli_types.mjs
@@ -35,6 +35,11 @@
  *    deliberately requires a single scalar `query: string`. The patch below
  *    encodes that documented divergence; a schema-shape guard throws if the
  *    CLI positional ever changes shape so the delta cannot silently rot.
+ * 5. Choice-union aliases — the public union types (`UrlStyle`,
+ *    `QueryFormat`, …) are emitted here from the schema `enum`/`const`, so
+ *    the hand-written copies in types.ts re-export them instead of drifting
+ *    independently. Values come from the model; a name maps conflicting
+ *    value sets across models and the generator throws.
  */
 
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
@@ -53,6 +58,38 @@ const header = [
   " */",
   "",
 ].join("\n");
+
+/**
+ * Public choice-union aliases, keyed by model → schema property (the camelCase
+ * alias) → exported type name. The values come from the schema enum/const, so
+ * the hand-written copies in types.ts are retired without drift: a choice
+ * added or removed in the model updates the alias automatically, and the
+ * freshness gate enforces the regenerated file.
+ */
+const CHOICE_ALIASES = {
+  BuildOptions: { urlStyle: "UrlStyle" },
+  ExportOptions: { format: "ExportFormat", mode: "ExportMode" },
+  InitOptions: { urlStyle: "UrlStyle", linkStyle: "LinkStyle" },
+  McpOptions: { mode: "McpMode" },
+  QueryOptions: { format: "QueryFormat" },
+  ServeOptions: { urlStyle: "UrlStyle" },
+};
+
+/** Union values from a property schema: `enum` array, single `const`, or an anyOf branch. */
+function enumValues(propSchema) {
+  if (propSchema === null || typeof propSchema !== "object") return null;
+  if (Array.isArray(propSchema.enum) && propSchema.enum.length > 0) {
+    return propSchema.enum.map((v) => String(v));
+  }
+  if ("const" in propSchema) return [String(propSchema.const)];
+  if (Array.isArray(propSchema.anyOf)) {
+    for (const branch of propSchema.anyOf) {
+      const values = enumValues(branch);
+      if (values) return values;
+    }
+  }
+  return null;
+}
 
 /** Recursively drop `title` keys so jstt inlines property types. */
 function stripTitles(node) {
@@ -145,17 +182,63 @@ const files = (await readdir(schemasDir))
   .sort();
 
 const chunks = [];
+const aliasChunks = [];
+const emittedAliases = new Map(); // alias name -> sorted values
+
 for (const file of files) {
   const name = file.replace(/\.schema\.json$/, "");
   const schema = JSON.parse(await readFile(path.join(schemasDir, file), "utf8"));
   applyQueryDelta(schema);
   stripTitles(schema);
   stripNullFromOptional(schema);
+
+  for (const [propName, alias] of Object.entries(CHOICE_ALIASES[name] ?? {})) {
+    const values = enumValues(schema.properties?.[propName]);
+    if (values === null) {
+      throw new Error(
+        `${name}.${propName} is mapped to alias ${alias} but its schema has no ` +
+          `enum/const — remove or fix the mapping.`
+      );
+    }
+    const sorted = [...values].sort();
+    const seen = emittedAliases.get(alias);
+    if (seen) {
+      if (JSON.stringify(seen) !== JSON.stringify(sorted)) {
+        throw new Error(
+          `Alias ${alias} maps conflicting value sets: ${JSON.stringify(seen)} ` +
+            `vs ${JSON.stringify(sorted)}.`
+        );
+      }
+      continue;
+    }
+    emittedAliases.set(alias, sorted);
+    const description = schema.properties[propName].description;
+    const jsdoc = description
+      ? `/** ${description.replace(/\*\//g, "*\\/").replace(/\s+/g, " ").trim()} */\n`
+      : "";
+    aliasChunks.push(
+      `${jsdoc}export type ${alias} = ${values
+        .map((v) => JSON.stringify(v))
+        .join(" | ")};`
+    );
+  }
+
   let out = await compile(schema, name, { bannerComment: "" });
   out = applyReadonly(out, name, schema);
   chunks.push(out);
 }
 
+const parts = [header];
+if (aliasChunks.length) {
+  parts.push(
+    "// Choice unions — named mirrors of the schema enums (public API aliases)."
+  );
+  parts.push(aliasChunks.join("\n\n"));
+}
+parts.push(chunks.join("\n\n"));
+
 await mkdir(path.dirname(outFile), { recursive: true });
-await writeFile(outFile, header + chunks.join("\n\n") + "\n");
-console.log(`Wrote ${chunks.length} model declarations to ${outFile}`);
+await writeFile(outFile, parts.join("\n\n") + "\n");
+console.log(
+  `Wrote ${chunks.length} model declarations and ${aliasChunks.length} choice-union aliases to ${outFile}`
+);


### PR DESCRIPTION
## Summary

Closes the last gaps in the CLI↔TS mirror contract (`npm/test-cli-drift.js`), making every hand-written, unverified surface in the TypeScript binding source-anchored. Three commits:

1. **Stage 4 — flag-string parity.** Every `--flag` string literal the wrapper methods in `npm/src/wiki.ts` emit is verified against the **real Click option strings** from the introspected command tree. The wrapper's flags were hand-written literals duplicated from `@click.option(...)` declarations; a renamed or misspelled flag passed every earlier gate and failed only at runtime with Click's `no such option`. Covers direct `args.push` emissions (`update`'s `--dry-run`, `init`'s boolean-pair ternary) via TypeScript-compiler-API extraction, the root `--config`/`--wiki-inputs` emissions (which live in no `COMMAND_MODELS`), and requires zero flags from unmapped methods (`preflight`, `format`, `graphList`, `run`).

2. **Choice-value parity.** `scripts/check_cli_models.py` (stage 1) now compares each `click.Choice`'s canonical values against the matching model field's `Literal[...]`/`enum` in both directions — a choice accepted by the CLI but missing from the generated TypeScript union fails CI, and so does a model value the CLI rejects. Case-insensitive for `case_sensitive=False` choices (Click accepts `JSON`, the model documents `json`); a Choice missing on either side is also flagged. `FormatChoice` MIME/extension aliases are intentionally out of scope (they resolve to the canonical names being compared).

3. **Generated union aliases.** The six public union types (`UrlStyle`, `LinkStyle`, `QueryFormat`, `McpMode`, `ExportFormat`, `ExportMode`) are now emitted by the type generator straight from the schema `enum`/`const` (JSDoc from the field descriptions), deduped by name with a throw if one alias ever maps conflicting value sets across models. `types.ts` re-exports them; the hand-written copies are deleted, so a model change can no longer silently drift the public aliases while the inline bag unions update.

## Files

| File | Change |
|---|---|
| `scripts/export_cli_flags.py` | **new** — real Click `opts` per command (incl. `secondary_opts` for `/` pairs) + root group under `"__root__"` |
| `scripts/check_cli_models.py` | choice-value parity against model `Literal`/`enum` |
| `scripts/generate_cli_types.mjs` | emits the 6 choice-union aliases from schema enums |
| `npm/test-cli-drift.js` | stage 4 (flag-string parity) + stage-1 doc |
| `npm/src/types.ts` | re-exports generated aliases; hand copies deleted; `RuntimeOptions.urlStyle` uses the generated type |
| `npm/src/types.generated.ts` | regenerated — **purely additive** (23 insertions, 0 deletions; bags byte-identical) |
| `AGENTS.md` | drift paragraph notes the flag-string enforcement |

## Verification

**Positive** — drift check green end-to-end (all 4 stages):

```
Drift check passed: 15 commands mirrored on Wiki.prototype; 63 wrapper flag emissions verified against the Click tree; generated types are fresh.
```

**Negative tests (each fails the intended stage, then restored clean):**

| Tamper | Result |
|---|---|
| `build`: `--output-dir` → `--output-dirr` | ❌ stage 4 — flag not in `build`'s real options |
| `args()`: `--config` → `--configx` | ❌ stage 4 — not in `wiki (root)` options |
| `init`: `/`-pair negative half misspelled | ❌ stage 4 — caught via `secondary_opts` |
| `format()`: injected `--bogus` | ❌ stage 4 — unmapped method must emit no flags |
| Model `Literal` gains a value the CLI rejects | ❌ stage 1 — `model-only: [...]` |
| Click `Choice` gains a value the model lacks | ❌ stage 1 — `CLI-only: [...]` |
| Alias mapped to a field with no enum | ❌ generator throws (mapping-rot guard) |

**Full suite:**

| Check | Result |
|---|---|
| ruff (full repo) | ✅ |
| eslint | ✅ |
| prettier format:check | ✅ |
| `npm run test:npm` (build + setup-argv + Wiki API regressions) | ✅ |
| typedoc gate (#284) — including the new generated aliases | ✅ zero warnings |
| Unit tests | ✅ 544 passed |

**Public surface:** the bundled `index.d.ts` exports all six aliases with values identical to the retired hand copies (`UrlStyle = "dir" | "file"`, `QueryFormat` = the 7 SPARQL formats, `ExportFormat` = the 8 RDF formats, etc.), now sourced from the model schemas.

## Notes

- Two Click quirks surfaced and handled: `Argument.opts` returns the bare param name (filtered), and `/` boolean pairs store the negative half in `param.secondary_opts` (now collected).
- The reverse flag direction (every real Click opt must be emitted by a wrapper) is intentionally not enforced — it would false-positive on composite methods like `preflight`/`format` and needs an allowlist design.
- With this PR, nothing hand-authored in `types.ts` duplicates CLI data; what remains hand-authored is the SDK-runtime layer (`RunOptions`, `WikiCommandResult`, `WikiLoadOptions`, results, subprocess types, the `parseJson`/`cwd`/`env` extends fields), which has no CLI counterpart and cannot be generated from `COMMAND_MODELS`.