### PR TITLE
fix(init): skip the namespace prompt on non-interactive stdin; scaffold an empty wiki/

### DIFF
--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -55,7 +55,7 @@ wiki init --repo wazootech/wiki
 wiki init --git
 ```
 
-`wiki init` writes `wiki.yml`, `README.md`, and a starter `wiki/` folder (`Person_Shape.md`, `Ethan_Davidson.md`). Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly. By default it does not create a Git repository; use `--git` if you want that explicitly. Init requires a clean directory (no existing `wiki.yml`, `README.md`, or non-empty `wiki/`). See [wiki init](wiki_init.md) for all flags.
+`wiki init` writes `wiki.yml`, `README.md`, and an empty `wiki/` folder for your markdown pages. Use `--repo owner/repo` to infer GitHub Pages URLs without a prompt, or pass `--graph-context-wiki` / `--site-base-url` explicitly; in non-interactive contexts (CI, scripts) init skips the prompt and uses the default namespace. By default it does not create a Git repository; use `--git` if you want that explicitly. Init requires a clean directory (no existing `wiki.yml`, `README.md`, or non-empty `wiki/`). See [wiki init](wiki_init.md) for all flags.
 
 ### Branding
 

--- a/docs/wiki/SHACL.md
+++ b/docs/wiki/SHACL.md
@@ -61,7 +61,7 @@ sh:property:
 ---
 ```
 
-`wiki init` scaffolds a starter `Person_Shape.md` with SHACL constraints. Optionally bind JSON Schema on shape documents with `wazoo:jsonSchema` beside `sh:targetClass`, or append per-page schemas with their own `wazoo:jsonSchema` key (string or list). Shape binding documents are not validated as instances — only their schema refs are checked for loadability.
+`wiki init` scaffolds an empty `wiki/` folder — add your own shape documents (e.g. a `sh:NodeShape` frontmatter page for your domain) when you need SHACL validation. Optionally bind JSON Schema on shape documents with `wazoo:jsonSchema` beside `sh:targetClass`, or append per-page schemas with their own `wazoo:jsonSchema` key (string or list). Shape binding documents are not validated as instances — only their schema refs are checked for loadability.
 
 See [Tech Article Shape](Tech_Article_Shape.md) in this wiki for a dogfooded example.
 

--- a/docs/wiki/Style_Guide.md
+++ b/docs/wiki/Style_Guide.md
@@ -97,7 +97,7 @@ Inline SPARQL blocks use `&lt;!-- sparql:start --&gt;` … `&lt;!-- sparql:end -
 
 ## SHACL shapes
 
-Define constraints in frontmatter with `type: sh:NodeShape` (see `wiki init`'s `Person_Shape.md` or [Software Application Shape](Software_Application_Shape.md) in this wiki). Shapes in the wiki are loaded into the validation graph; [wiki check](wiki_check.md) runs PySHACL against every document. Background: [SHACL](SHACL.md).
+Define constraints in frontmatter with `type: sh:NodeShape` (see [Software Application Shape](Software_Application_Shape.md) in this wiki). Shapes in the wiki are loaded into the validation graph; [wiki check](wiki_check.md) runs PySHACL against every document. Background: [SHACL](SHACL.md).
 
 Optionally bind a **JSON Schema** on the same shape document with `wazoo:jsonSchema` (local path under the wiki config root or remote `http(s)` URL). Type-level schemas apply to every page whose effective `type` matches `sh:targetClass`. Pages may append extra schemas with their own `wazoo:jsonSchema` key (scalar or YAML list); all bound schemas must pass.
 

--- a/docs/wiki/wiki.md
+++ b/docs/wiki/wiki.md
@@ -251,24 +251,24 @@ ORDER BY ?command
 ```
 -->
 
-| command                         | description                                                                                         |
-| ------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [wiki_build](wiki_build.md)     | Generate a static HTML site from the wiki.                                                          |
-| [wiki_check](wiki_check.md)     | Integrity checks — SHACL validation, JSON Schema frontmatter, route safety, and layout frontmatter. |
-| [wiki_export](wiki_export.md)   | Export document frontmatter as RDF or JSON-LD.                                                      |
-| [wiki_fmt](wiki_fmt.md)         | Format markdown wiki pages using mdformat with wikilink preservation.                               |
-| [wiki_graph](wiki_graph.md)     | List read-only RDF named graphs for root and installed source provenance.                           |
-| [wiki_init](wiki_init.md)       | Scaffold wiki.yml and starter wiki pages interactively.                                             |
-| [wiki_install](wiki_install.md) | Fetch and lock external data sources declared in wiki.yml.                                          |
-| [wiki_link](wiki_link.md)       | Suggest missing wikilinks and repair unambiguous broken internal links.                             |
-| [wiki_lint](wiki_lint.md)       | Convention audits for broken links, filename patterns, heading style, and internal link style.      |
-| [wiki_mcp](wiki_mcp.md)         | Run a read-only MCP server for querying the wiki graph.                                             |
-| [wiki_query](wiki_query.md)     | Run SPARQL SELECT or CONSTRUCT against the wiki graph.                                              |
-| [wiki_remove](wiki_remove.md)   | Remove a data source from wiki.yml, its cache, and wiki.lock.                                       |
-| [wiki_render](wiki_render.md)   | Update inline SPARQL result tables in markdown files.                                               |
-| [wiki_serve](wiki_serve.md)     | Local HTTP server for live HTML preview and optional read-only SPARQL endpoint.                     |
-| [wiki_update](wiki_update.md)   | Check locked sources for newer commits and update wiki.lock.                                        |
-| [wiki_upgrade](wiki_upgrade.md) | Check PyPI for updates and upgrade wazootech-wiki.                                                  |
+| command | description |
+| --- | --- |
+| [wiki_build](wiki_build.md) | Generate a static HTML site from the wiki. |
+| [wiki_check](wiki_check.md) | Integrity checks — SHACL validation, JSON Schema frontmatter, route safety, and layout frontmatter. |
+| [wiki_export](wiki_export.md) | Export document frontmatter as RDF or JSON-LD. |
+| [wiki_fmt](wiki_fmt.md) | Format markdown wiki pages using mdformat with wikilink preservation. |
+| [wiki_graph](wiki_graph.md) | List read-only RDF named graphs for root and installed source provenance. |
+| [wiki_init](wiki_init.md) | Scaffold wiki.yml and an empty wiki/ folder for markdown pages. |
+| [wiki_install](wiki_install.md) | Fetch and lock external data sources declared in wiki.yml. |
+| [wiki_link](wiki_link.md) | Suggest missing wikilinks and repair unambiguous broken internal links. |
+| [wiki_lint](wiki_lint.md) | Convention audits for broken links, filename patterns, heading style, and internal link style. |
+| [wiki_mcp](wiki_mcp.md) | Run a read-only MCP server for querying the wiki graph. |
+| [wiki_query](wiki_query.md) | Run SPARQL SELECT or CONSTRUCT against the wiki graph. |
+| [wiki_remove](wiki_remove.md) | Remove a data source from wiki.yml, its cache, and wiki.lock. |
+| [wiki_render](wiki_render.md) | Update inline SPARQL result tables in markdown files. |
+| [wiki_serve](wiki_serve.md) | Local HTTP server for live HTML preview and optional read-only SPARQL endpoint. |
+| [wiki_update](wiki_update.md) | Check locked sources for newer commits and update wiki.lock. |
+| [wiki_upgrade](wiki_upgrade.md) | Check PyPI for updates and upgrade wazootech-wiki. |
 
 <!-- sparql:end -->
 

--- a/docs/wiki/wiki_init.md
+++ b/docs/wiki/wiki_init.md
@@ -1,12 +1,12 @@
 ---
 type: TechArticle
 headline: wiki init
-description: Scaffold wiki.yml and starter wiki pages interactively.
+description: Scaffold wiki.yml and an empty wiki/ folder for markdown pages.
 ---
 
 # `wiki init`
 
-Create a new wiki project in the **current directory**: `wiki.yml`, `README.md`, and starter files under `wiki/`.
+Create a new wiki project in the **current directory**: `wiki.yml`, `README.md`, and an empty `wiki/` folder for your markdown pages.
 
 Does not use loaded Config; safe to run before a config exists. Init runs once per clean directory — if `wiki.yml`, `README.md`, or a non-empty `wiki/` already exist, use a new directory or remove those files before re-running.
 
@@ -48,7 +48,7 @@ When `--graph-context-wiki` is not passed, init resolves `graph.context.wiki` in
 
 1. **`--repo`** — GitHub Pages project site: `https://{owner}.github.io/{repo}/` and `site.base_url: /{repo}` (accepts `owner/repo`, HTTPS, or SSH URLs).
 1. **Git remote** — If `.git` already exists or `--git` was passed, parse `git remote get-url origin` when it points at GitHub.
-1. **Interactive prompt** — **Custom wiki namespace IRI** (default `https://wiki.example.org/`).
+1. **Interactive prompt** — **Custom wiki namespace IRI** (default `https://wiki.example.org/`). The prompt is skipped when stdin is not an interactive terminal (CI, scripts, agent tools); the default is used instead.
 
 `--graph-context-wiki` always wins over `--repo` and remote detection. `--site-base-url` overrides the inferred path from `--repo`.
 
@@ -62,6 +62,8 @@ When no flag or git remote supplies `graph.context.wiki`, init prompts once:
 
 When the namespace came from that prompt, the prompt ends and initialization proceeds.
 
+The prompt only appears when stdin is an interactive terminal. In non-interactive contexts (CI, scripts, agent tools), init detects the lack of a TTY and uses the default `https://wiki.example.org/`, printing a note to stderr — pass `--repo` or `--graph-context-wiki` to control the namespace without prompting.
+
 Always includes `schema`, `wiki`, `wazoo`, `foaf`, `dc`, `dcterms`, `sh`, and `xsd` prefixes. The `wazoo` URI is fixed in the scaffold (`https://schema.wazoo.dev/`), like the other built-in prefixes.
 
 ## Generated config
@@ -73,8 +75,7 @@ For every key — schema default, whether init writes it, and which command audi
 ## Generated files
 
 - `README.md` — starter wiki overview and common commands
-- `wiki/Person_Shape.md` — starter `sh:NodeShape` for `schema:Person`
-- `wiki/Ethan_Davidson.md` — starter `schema:Person` example (includes a tweak comment to replace with your first page)
+- `wiki/` — empty directory for your markdown pages with semantic frontmatter
 
 ## Related
 

--- a/skills/wiki/references/init.md
+++ b/skills/wiki/references/init.md
@@ -78,11 +78,11 @@ After Phase A succeeds, **default:** run `wiki check --strict` with the resolved
 
 ### Phase B: tweak
 
-Edit scaffold files marked with `<!-- wiki tweak: … -->` comments (with user approval):
+Review the scaffolded files with the user (config, README, empty `wiki/`):
 
 | Topic           | Action                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------ |
-| First page      | Replace `wiki/Ethan_Davidson.md` (starter includes a tweak comment) or add the user's page |
+| First page      | Add the user's first page under `wiki/` (scaffolded empty) |
 | Config extras   | Uncomment optional blocks in `wiki.yml` — see the Preferences wizard section below         |
 | Lint strictness | Only if user asks — see the Preferences wizard section below                               |
 
@@ -91,7 +91,7 @@ Edit scaffold files marked with `<!-- wiki tweak: … -->` comments (with user a
 ### What init creates
 
 - `wiki.yml`
-- `wiki/Person_Shape.md`, `wiki/Ethan_Davidson.md`, `README.md`
+- `wiki/` (empty), `README.md`
 
 ## Post-init hygiene
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -524,7 +524,7 @@ def serve(
 @click.option(
     "--repo",
     default=None,
-    help="GitHub owner/repo; infer graph.context.wiki and site.base_url for GitHub Pages.",
+    help="GitHub owner/repo; infer graph.context.wiki and site.base_url for GitHub Pages (skips the interactive prompt).",
 )
 @click.option(
     "--graph-context-wiki",
@@ -614,7 +614,12 @@ def init(
     graph_implicit_types_policy: str | None,
     graph_include_file_extension: bool | None,
 ) -> None:
-    """Scaffold a new wiki project in the current directory."""
+    """Scaffold a new wiki project in the current directory.
+
+    Non-interactive runs (stdin is not a TTY — CI, scripts, agent tools) skip
+    the namespace prompt and use the default; pass --repo or
+    --graph-context-wiki to control the resulting wiki namespace IRI.
+    """
     cwd = Path.cwd()
     config_path = cwd / "wiki.yml"
     legacy_config_paths = (
@@ -652,7 +657,16 @@ def init(
             sys.exit(1)
 
     def prompt_context_wiki(default: str) -> str:
-        return str(click.prompt("Custom wiki namespace IRI (graph.context.wiki)", default=default))
+        if not sys.stdin.isatty():
+            click.echo(
+                "Non-interactive stdin detected — using the default wiki namespace "
+                f"IRI {default}. Pass --repo or --graph-context-wiki to control it.",
+                err=True,
+            )
+            return default
+        return str(
+            click.prompt("Custom wiki namespace IRI (graph.context.wiki)", default=default)
+        )
 
     if init_template is not None:
         from .init_scaffold import fetch_template

--- a/src/wiki/init_scaffold.py
+++ b/src/wiki/init_scaffold.py
@@ -248,9 +248,7 @@ _README_TEMPLATE = (
     "A semantic markdown knowledge base powered by the Wiki CLI.\n\n"
     "## Wiki layout\n\n"
     "- `wiki.yml` (or `wiki.toml`) — Wiki configuration, namespace prefixes, and `fmt` defaults.\n"
-    "- `wiki/` — Contains markdown files with semantic frontmatter.\n"
-    "  - `Person_Shape.md` — SHACL shape for Person documents.\n"
-    "  - `Ethan_Davidson.md` — An example Person document.\n\n"
+    "- `wiki/` — Empty directory for markdown pages with semantic frontmatter.\n\n"
     "## Commands\n\n"
     "- **Check** (integrity: SHACL, JSON Schema, route safety, layout frontmatter):\n"
     "  ```bash\n"
@@ -270,40 +268,12 @@ _README_TEMPLATE = (
     "  ```\n"
 )
 
-_PERSON_SHAPE_TEMPLATE = (
-    "---\n"
-    "id: wiki:PersonShape\n"
-    "type: sh:NodeShape\n"
-    "sh:targetClass: schema:Person\n"
-    "sh:property:\n"
-    "  - sh:path: schema:givenName\n"
-    "    sh:datatype: xsd:string\n"
-    "    sh:minCount: 1\n"
-    "  - sh:path: schema:familyName\n"
-    "    sh:datatype: xsd:string\n"
-    "    sh:minCount: 1\n"
-    "---\n\n"
-    "# Person shape\n\n"
-    "Defines validation rules for Person profiles in this wiki.\n"
-)
-
 _GITIGNORE_TEMPLATE = (
     "# Source cache (fetched repos)\n"
     ".wiki/\n"
     "\n"
     "# Build output\n"
     "_site/\n"
-)
-
-_EXAMPLE_PERSON_TEMPLATE = (
-    "<!-- wiki tweak: replace with your first page -->\n"
-    "---\n"
-    "type: schema:Person\n"
-    "givenName: Ethan\n"
-    "familyName: Davidson\n"
-    "---\n\n"
-    "# Ethan Davidson\n\n"
-    "Welcome to my personal wiki page! This page serves as a starting point and conforming example of a Person profile.\n"
 )
 
 
@@ -329,12 +299,6 @@ def _scaffold_wiki(
     readme_path.write_text(_README_TEMPLATE, encoding="utf-8")
     written.extend([readme_path, wiki_dir])
 
-    person_shape = wiki_dir / "Person_Shape.md"
-    person_shape.write_text(_PERSON_SHAPE_TEMPLATE, encoding="utf-8")
-    example_person = wiki_dir / "Ethan_Davidson.md"
-    example_person.write_text(_EXAMPLE_PERSON_TEMPLATE, encoding="utf-8")
-    written.extend([person_shape, example_person])
-
     config_content = render_wiki_yaml(init_options)
     config_path.write_text(config_content, encoding="utf-8")
     written.append(config_path)
@@ -352,7 +316,7 @@ def _scaffold_wiki(
             return ScaffoldResult(ok=False, error_message=f"git init failed: {stderr}")
 
     message = (
-        "Initialized wiki config, README.md, and wiki/ starter files."
+        "Initialized wiki config, README.md, and an empty wiki/ directory."
     )
     if init_git:
         message += " Ran git init."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -519,18 +519,10 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
                 self.assertIn("A semantic markdown knowledge base powered by the Wiki CLI.", readme_content)
                 self.assertIn("wiki check", readme_content)
 
-                # Check wiki/Person_Shape.md exists and contains schema:givenName/familyName
-                shape_content = Path("wiki") / "Person_Shape.md"
-                content = shape_content.read_text(encoding="utf-8")
-                self.assertIn("sh:path: schema:givenName", content)
-                self.assertIn("sh:path: schema:familyName", content)
-
-                # Check wiki/Ethan_Davidson.md exists
-                person_content = (Path("wiki") / "Ethan_Davidson.md").read_text(encoding="utf-8")
-                self.assertIn("wiki tweak: replace with your first page", person_content)
-                self.assertIn("givenName: Ethan", person_content)
-                self.assertIn("familyName: Davidson", person_content)
-                self.assertNotIn("wazoo:layout:", person_content)
+                # Check wiki/ is scaffolded empty — no placeholder pages
+                wiki_dir = Path("wiki")
+                self.assertTrue(wiki_dir.is_dir())
+                self.assertEqual(list(wiki_dir.iterdir()), [])
 
                 # Check layout and assets are commented/unused in config
                 self.assertNotIn("manifest:", config_content)
@@ -648,6 +640,18 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
                 self.assertIn("wiki: https://example.org/custom/", config_content)
                 self.assertIn("wiki: https://example.org/custom/", config_content)
                 self.assertIn("base_url: /custom", config_content)
+
+    def test_cli_init_noninteractive_uses_default_namespace(self) -> None:
+        """#264: init without --repo/--graph-context-wiki must not hang on a
+        non-interactive stdin — it uses the default wiki namespace IRI."""
+        runner = CliRunner()
+        with TemporaryDirectory() as tmpdir:
+            with runner.isolated_filesystem(temp_dir=tmpdir):
+                result = runner.invoke(main, ["init"], catch_exceptions=False)
+                self.assertEqual(result.exit_code, 0)
+                config_content = Path("wiki.yml").read_text(encoding="utf-8")
+                self.assertIn("wiki: https://wiki.example.org/", config_content)
+                self.assertIn("Non-interactive stdin detected", result.output)
 
     @patch("wiki.init_scaffold.detect_origin_repo", return_value="wazootech/wiki")
     def test_cli_init_detects_git_remote(self, _detect_mock) -> None:


### PR DESCRIPTION
## Summary

Fixes two `wiki init` issues end-to-end:

**#264 — init hangs on non-interactive stdin.** Without `--repo`/`--graph-context-wiki`, `init` fired an interactive `click.prompt` that blocked indefinitely in CI, scripts, and agent tools (repeated timeouts when an agent tool tried to scaffold a repo). `prompt_context_wiki` now checks `sys.stdin.isatty()`: non-interactive stdin → a stderr note and the default namespace IRI, with **no read from stdin** (so a held-open pipe can never block it). `--repo`'s help text and the init docstring now say so. Git-remote inference (when `.git` exists) is unchanged.

**#266 — default scaffold ships placeholder data.** The scaffold wrote `Person_Shape.md` (a `schema:Person` SHACL shape) and `Ethan_Davidson.md` (a sample Person), biasing every new wiki toward a person entity model that users then deleted. `wiki init` now writes `wiki.yml` + `README.md` + an **empty `wiki/` directory** — a blank canvas that passes `wiki check`/`wiki lint` out of the box (verified). README template, init/Getting Started/SHACL/Style Guide docs, and the agent init skill reference updated to match.

## Files

| File | Change |
|---|---|
| `src/wiki/cli.py` | non-TTY guard on the namespace prompt; `--repo` help + init docstring note |
| `src/wiki/init_scaffold.py` | dropped the two placeholder templates and their writes; empty `wiki/`; README/message updated |
| `tests/test_cli.py` | scaffold test now asserts empty `wiki/`; **new** non-interactive regression test |
| `docs/wiki/wiki_init.md`, `Getting_Started.md`, `SHACL.md`, `Style_Guide.md` | scaffold description + prompt behavior + generated files |
| `skills/wiki/references/init.md` | "What init creates" + first-page guidance |
| `docs/wiki/wiki.md` | re-rendered the SPARQL-generated commands table (the `wiki init` description changed) |

## Verification

**#264 — no hang, default used:**

| Scenario | Result |
|---|---|
| `echo "" \| wiki init` (pipe, EOF) | ✅ exit 0, `wiki: https://wiki.example.org/`, stderr note printed |
| `(sleep 30) \| wiki init` (held-open pipe — the original hang) | ✅ instant; stderr note proves the guard fired before any stdin read |
| `wiki init --repo wazootech/wiki` | ✅ inference unchanged (`https://wazootech.github.io/wiki/`, `base_url: /wiki`) |
| CliRunner regression test (non-TTY stdin) | ✅ `test_cli_init_noninteractive_uses_default_namespace` |

**#266 — blank canvas:**

- Fresh scaffold = `wiki.yml` + `README.md` + empty `wiki/`; `wiki check` exit 0 and `wiki lint` exit 0 with no files.
- `test_cli_init_scaffolds_wiki_files` updated to assert `wiki/` is empty.

**Full suite:**

| Check | Result |
|---|---|
| ruff (full repo) | ✅ |
| pytest | ✅ **545 passed** (one new) |
| docs `render --check` / `fmt --check` / `lint --strict` / `check --strict` | ✅ all green (CI-style, on the re-rendered wiki.md) |

## Notes

- The `render --check` gate caught a real coupling: `wiki.md`'s commands table is SPARQL-generated from page frontmatter, so the `wiki_init.md` description change invalidated the stored block; it was re-rendered in this PR.
- One known quirk: Git Bash's `/dev/null` redirect presents a console-like handle (`isatty()` returns True), so `wiki init < /dev/null` there still prompts-and-aborts on EOF — it never hangs, and every real non-interactive context (CI, agent-tool pipes) is a pipe where the guard fires.