### PR TITLE
chore: release v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+## 0.1.22 — 2026-09-04
+
+### Added
+
+- `wiki init --template` scaffolds new wikis from the
+  [wiki-templates](https://github.com/wazootech/wiki-templates) monorepo.
+  ([#233](https://github.com/wazootech/wiki/issues/233))
+- `i` alias for the `wiki install` subcommand.
+  ([#265](https://github.com/wazootech/wiki/pull/265))
+- Query-first wiki MCP server (`wiki mcp`), documented in `docs/wiki/wiki_mcp.md`.
+  ([#209](https://github.com/wazootech/wiki/issues/209))
+- TypeScript SDK methods for `install`, `update`, `remove`, `mcp`, and
+  `graphList`, with CLI option types generated from the Pydantic
+  `COMMAND_MODELS`. ([#283](https://github.com/wazootech/wiki/pull/283),
+  [#287](https://github.com/wazootech/wiki/pull/287))
+- wiki-sync skill for Git-anchored code-wiki maintenance.
+  ([#247](https://github.com/wazootech/wiki/pull/247))
+
+### Changed
+
+- The CLI↔TypeScript mirror contract is now enforced in CI: every CLI command
+  and `--flag` must have a corresponding SDK method and option.
+  ([#288](https://github.com/wazootech/wiki/pull/288))
+- Memory orchestration moved to a GitHub Actions cron.
+  ([#263](https://github.com/wazootech/wiki/pull/263))
+- Docs reorganized: `Wiki_CLI`/`Wiki_Subcommand_*` pages renamed to
+  `wiki`/`wiki_*`, and template references point at the wiki-templates
+  monorepo. ([#223](https://github.com/wazootech/wiki/issues/223),
+  [#242](https://github.com/wazootech/wiki/issues/242))
+- Pre-commit hook runs prettier on staged files; LF line endings enforced via
+  `.gitattributes`.
+
+### Fixed
+
+- `wiki init` on non-interactive stdin no longer hangs on the namespace
+  prompt; it scaffolds an empty wiki instead.
+  ([#289](https://github.com/wazootech/wiki/pull/289))
+- Sphinx docs fail the build on any warning; typedoc fails on undocumented
+  public API. ([#285](https://github.com/wazootech/wiki/pull/285),
+  [#284](https://github.com/wazootech/wiki/pull/284))
+- Markdown formatting fixes applied with `wiki fmt`.
+  ([#230](https://github.com/wazootech/wiki/pull/230))
 ## 0.1.21 — 2026-07-12
 
 ### Fixed

--- a/docs/wiki/wiki.md
+++ b/docs/wiki/wiki.md
@@ -1,7 +1,7 @@
 ---
 type: schema:SoftwareApplication
 name: wiki
-softwareVersion: 0.1.21
+softwareVersion: 0.1.22
 description: Command-line interface for querying, validating, and publishing semantic markdown wikis.
 codeRepository: https://github.com/wazootech/wiki
 ---

--- a/docs/wiki/wiki_mcp.md
+++ b/docs/wiki/wiki_mcp.md
@@ -88,7 +88,7 @@ Example shape:
 
 ```json
 {
-  "version": "0.1.21",
+  "version": "0.1.22",
   "config": "docs/wiki.yml",
   "inputs": ["docs/wiki"],
   "namespaces": {

--- a/docs/wiki/wiki_render.md
+++ b/docs/wiki/wiki_render.md
@@ -89,7 +89,7 @@ ORDER BY ?name
 | [Linked_Markdown](Linked_Markdown.md) | Linked Markdown |  |
 | [Obsidian](Obsidian.md) | Obsidian |  |
 | [Vivary](Vivary.md) | Vivary | 0.1.0 |
-| [wiki](wiki.md) | wiki | 0.1.21 |
+| [wiki](wiki.md) | wiki | 0.1.22 |
 
 <!-- sparql:end -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wazootech-wiki",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wazootech-wiki",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazootech-wiki",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Clean, pure, idiomatic CLI for managing a semantic LLM wiki",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wazootech-wiki"
-version = "0.1.21"
+version = "0.1.22"
 description = "Clean, pure, idiomatic Python CLI for managing a semantic LLM wiki"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -19,7 +19,7 @@ from .schemas import (
 )
 from .wiki import Wiki
 
-__version__ = "0.1.21"
+__version__ = "0.1.22"
 
 __all__ = [
     "__version__",

--- a/uv.lock
+++ b/uv.lock
@@ -1186,7 +1186,7 @@ wheels = [
 
 [[package]]
 name = "wazootech-wiki"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release v0.1.22

Bumps `wazootech-wiki` to **0.1.22** across `pyproject.toml`, `package.json`, `src/wiki/__init__.py`, both lockfiles, and the docs version banners; adds the 0.1.22 CHANGELOG section.

Notable since v0.1.21 (see CHANGELOG for the full list):

- `wiki init --template` (wiki-templates monorepo scaffolding), `i` alias for install, non-interactive `wiki init` fix (#289)
- Query-first wiki MCP server
- TypeScript SDK methods `install`/`update`/`remove`/`mcp`/`graphList` + generated CLI option types (#283, #287)
- CLI↔TS mirror contract enforced in CI (#288), plus ESLint/prettier gates (#245, #246)

## After merge

Tag `v0.1.22` will trigger the Release workflow (trusted publishing to PyPI + npm, standalone binaries, GitHub Release).