### PR TITLE
docs: fix the documented zero-install uvx invocation (#270)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npm install -g wazootech-wiki
 
 This installs the **`wiki`** command globally (the npm package name is `wazootech-wiki`). The npm package automatically creates a private Python virtual environment and installs the matching PyPI version of `wazootech-wiki` as the engine. Python 3.12 or newer is required on the machine.
 
-`npx wazootech-wiki` and `uvx wazootech-wiki` accept the **same subcommands and flags** as `wiki` — they run the same Python CLI via a Node shim.
+`npx wazootech-wiki` (via a Node shim) and `uvx --from wazootech-wiki wiki` (the PyPI package directly) accept the **same subcommands and flags** as `wiki`.
 
 Zero-install (no global install required):
 
@@ -129,7 +129,7 @@ Zero-install (no global install required):
 npx wazootech-wiki --help
 npx wazootech-wiki init
 npx wazootech-wiki -c docs/wiki.yml check
-uvx wazootech-wiki --help
+uvx --from wazootech-wiki wiki --help
 ```
 
 After `npm install -g wazootech-wiki`, use `wiki` instead of the `npx` prefix (for example `wiki check`). For library usage from Node or TypeScript, see [Programmatic APIs](#programmatic-apis).

--- a/docs/wiki/Getting_Started.md
+++ b/docs/wiki/Getting_Started.md
@@ -33,7 +33,7 @@ npx wazootech-wiki init
 npx wazootech-wiki check
 ```
 
-`npx wazootech-wiki` and `uvx wazootech-wiki` accept the same subcommands and flags as `wiki`.
+`npx wazootech-wiki` and `uvx --from wazootech-wiki wiki` accept the same subcommands and flags as `wiki`.
 
 ### Editable install from this repository
 

--- a/docs/wiki/wiki.md
+++ b/docs/wiki/wiki.md
@@ -15,7 +15,7 @@ pip install wazootech-wiki
 wiki --help
 ```
 
-Install options: PyPI (`pip install wazootech-wiki`), npm ([`wazootech-wiki` on npm](https://www.npmjs.com/package/wazootech-wiki) → `wiki` on PATH), or zero-install (`npx wazootech-wiki` / `uvx wazootech-wiki` — same subcommands as `wiki`). See [Getting Started](Getting_Started.md#install).
+Install options: PyPI (`pip install wazootech-wiki`), npm ([`wazootech-wiki` on npm](https://www.npmjs.com/package/wazootech-wiki) → `wiki` on PATH), or zero-install (`npx wazootech-wiki` / `uvx --from wazootech-wiki wiki` — same subcommands as `wiki`). See [Getting Started](Getting_Started.md#install).
 
 ## Quickstart
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -52,7 +52,7 @@ Before any wiki command:
 
 In the **Wiki CLI repository checkout**, if PATH `wiki` fails but `pyproject.toml` exists, use `uv run wiki` or `python -m wiki` when both `--help` and `fmt` capability pass.
 
-Zero-install equivalent: `npx wazootech-wiki <args>` or `uvx wazootech-wiki <args>` in place of `wiki <args>`.
+Zero-install equivalent: `npx wazootech-wiki <args>` or `uvx --from wazootech-wiki wiki <args>` in place of `wiki <args>`.
 
 ## Deterministic scripts
 

--- a/skills/wiki/references/install.md
+++ b/skills/wiki/references/install.md
@@ -47,7 +47,7 @@ npx wazootech-wiki --help
 npx wazootech-wiki fmt --help
 ```
 
-Treat **`npx wazootech-wiki <args>`** (or **`uvx wazootech-wiki <args>`**) as **`wiki <args>`** for all subcommands and flags.
+Treat **`npx wazootech-wiki <args>`** (or **`uvx --from wazootech-wiki wiki <args>`**) as **`wiki <args>`** for all subcommands and flags.
 
 **Standalone binary (no Python):** download the archive for their OS from [GitHub Releases](https://github.com/wazootech/wiki/releases), verify `SHA256SUMS`, extract, and run `./wiki --help` (or `wiki.exe` on Windows).
 


### PR DESCRIPTION
Fixes #270 — replace the broken documented `uvx wazootech-wiki` zero-install command with the working form.

## Problem

The PyPI package exposes `wiki` (i.e. `wiki.exe`), not `wazootech-wiki`. Every documented `uvx wazootech-wiki <args>` invocation fails with:

```
An executable named `wazootech-wiki` is not provided... (wiki.exe)
```

## Change

| File | Change |
|---|---|
| `README.md` | example block → `uvx --from wazootech-wiki wiki --help`; prose now correctly splits the mechanics — **npx** runs via the Node shim, **uvx** runs the PyPI package directly (the issue's second inaccuracy) |
| `docs/wiki/Getting_Started.md` | `uvx wazootech-wiki` → `uvx --from wazootech-wiki wiki` |
| `docs/wiki/wiki.md` | same correction in the install-options line |
| `skills/wiki/SKILL.md` | zero-install equivalent → `uvx --from wazootech-wiki wiki <args>` |
| `skills/wiki/references/install.md` | same |

Diff is exactly +6/−6 across the five files; no other occurrences of the broken form remain.

## Verification

- **Empirical (live PyPI package):** broken form reproduces the issue's exact error; corrected form prints the wiki usage.
- **Docs gates:** all four green from the worktree — `fmt --check`, `lint --strict`, `check --strict`, `render --check`.
- **Rebased** onto current `main` (`910f82c`, v0.1.22 release) with no overlap.