### PR TITLE
feat!: rename --wiki-inputs to --input and wiki.inputs to wiki.input (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- Renamed the `--wiki-inputs` CLI flag to `--input` and the `wiki.inputs`
+  config key to `wiki.input` (the TypeScript SDK option is now `input`).
+  **Migration:** rename `wiki.inputs` to `wiki.input` in existing
+  `wiki.yml` files and update `--wiki-inputs` / `wikiInputs` usages.
+  ([#227](https://github.com/wazootech/wiki/issues/227))
+
 ## 0.1.22 — 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ wiki -c docs/wiki.yml lint
 python -m wiki -c docs/wiki.yml serve --watch
 ```
 
-`serve --watch` rebuilds when files under `wiki.inputs` and `wiki.assets` change. It does **not** hot-reload Python changes in `src/wiki/` — restart the server after editing CLI code (even when using `python -m wiki`).
+`serve --watch` rebuilds when files under `wiki.input` and `wiki.assets` change. It does **not** hot-reload Python changes in `src/wiki/` — restart the server after editing CLI code (even when using `python -m wiki`).
 
 Suggested contributor loop:
 
@@ -405,7 +405,7 @@ wiki render wiki/people/*.md
 wiki render --no-inference
 ```
 
-**Graph cache:** By default, the wiki graph (including OWL-RL when inference is on) is built once per process and reused for every SPARQL query and `render` pass in that run, so you do not reload the graph for each block or subcommand. A new shell still starts cold unless you opt into `--cache`, which persists the current graph under `.wiki/cache/` and reuses it across one-shot `query`, `render`, and `build --render` invocations when the wiki fingerprint still matches. Use `wiki serve --watch` for a long-lived process that rebuilds the graph and SPARQL output when files under `wiki.inputs` or `wiki.assets` change (not when CLI source code changes).
+**Graph cache:** By default, the wiki graph (including OWL-RL when inference is on) is built once per process and reused for every SPARQL query and `render` pass in that run, so you do not reload the graph for each block or subcommand. A new shell still starts cold unless you opt into `--cache`, which persists the current graph under `.wiki/cache/` and reuses it across one-shot `query`, `render`, and `build --render` invocations when the wiki fingerprint still matches. Use `wiki serve --watch` for a long-lived process that rebuilds the graph and SPARQL output when files under `wiki.input` or `wiki.assets` change (not when CLI source code changes).
 
 Disk-cache tradeoffs: `--cache` speeds up repeated one-shot commands on unchanged wikis, but it adds `.wiki/cache/` artifacts and still invalidates on wiki or config changes. `--reload` rebuilds from source and refreshes the current cache entry.
 
@@ -501,7 +501,7 @@ _site/
     +-- ...
 ```
 
-Page URLs are derived from the source path under `wiki.inputs`, minus `.md`, with case preserved. Folders are preserved. `index.md` maps to its containing folder route, so `wiki/index.md` owns `/wiki/` and `wiki/games/index.md` owns `/wiki/games/`. For ordinary pages, the default examples use Wikipedia-style filenames such as `Gregory_Davidson.md` and `Pokemon_Diamond.md`. Headings do not create separate pages; they receive GitHub-compatible fragment IDs such as `#release-history`.
+Page URLs are derived from the source path under `wiki.input`, minus `.md`, with case preserved. Folders are preserved. `index.md` maps to its containing folder route, so `wiki/index.md` owns `/wiki/` and `wiki/games/index.md` owns `/wiki/games/`. For ordinary pages, the default examples use Wikipedia-style filenames such as `Gregory_Davidson.md` and `Pokemon_Diamond.md`. Headings do not create separate pages; they receive GitHub-compatible fragment IDs such as `#release-history`.
 
 `wiki build` runs `wiki check` and `wiki lint` before cleaning output unless `--no-check` is passed. If checks fail, the previous output is left untouched. Once checks pass, the owned output path is treated as disposable build output and rebuilt.
 
@@ -636,7 +636,7 @@ wiki serve --watch
 python -m wiki serve --watch
 ```
 
-`--watch` polls `wiki.inputs` and `wiki.assets` only. Restart the server after changing Python code in the installed package. Set the metadata pane with `?metadata_format=FORMAT` (for example `turtle`, `ttl`, or `json-ld`).
+`--watch` polls `wiki.input` and `wiki.assets` only. Restart the server after changing Python code in the installed package. Set the metadata pane with `?metadata_format=FORMAT` (for example `turtle`, `ttl`, or `json-ld`).
 
 When `sparql_service.enabled` is true in `wiki.yaml`, `wiki serve` also exposes a read-only SPARQL endpoint (default path `/api/sparql`).
 
@@ -686,7 +686,7 @@ These flags can be used on any subcommand:
 | Option                 | Description                                                                |
 | ---------------------- | -------------------------------------------------------------------------- |
 | `-c, --config <path>`  | Path to `wiki.yaml` config file or directory containing one (default: `.`) |
-| `--wiki-inputs <path>` | Override `wiki.inputs` for this invocation (can be repeated)               |
+| `--input <path>` | Override `wiki.input` for this invocation (can be repeated)               |
 
 ### Printing and piping
 

--- a/_finish.py
+++ b/_finish.py
@@ -1,0 +1,21 @@
+"""Fix straggler tokens missed by the main rename (doc comments, test asserts)."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+
+def repl(path: str, old: str, new: str, count: int) -> None:
+    p = ROOT / path
+    s = p.read_text(encoding="utf-8")
+    n = s.count(old)
+    assert n == count, f"{path}: expected {count} of {old!r}, found {n}"
+    p.write_text(s.replace(old, new), encoding="utf-8", newline="\n")
+    print(f"  {path}: {n}x {old!r} -> {new!r}")
+
+repl("npm/src/types.ts", "Override ``wiki.inputs``", "Override ``wiki.input``", 1)
+repl("npm/src/wiki.ts", "Overridden ``wiki.inputs`` paths.", "Overridden ``wiki.input`` paths.", 1)
+repl("npm/src/wiki.ts", "Prepends ``--wiki-inputs`` and ``--config``", "Prepends ``--input`` and ``--config``", 1)
+repl("tests/test_config.py", "config.wiki.inputs", "config.wiki.input", 4)
+repl("skills/README.md", "do not add this folder to ``wiki.inputs``", "do not add this folder to ``wiki.input``", 1)
+
+print("STRAggLER FIXES APPLIED")

--- a/_rename.py
+++ b/_rename.py
@@ -1,0 +1,134 @@
+"""One-shot shape-(b) rename for #227. See design notes in the original."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+
+def sub(path: str, old: str, new: str, count: int) -> None:
+    p = ROOT / path
+    s = p.read_text(encoding="utf-8")
+    n = s.count(old)
+    assert n == count, f"{path}: expected {count} of {old!r}, found {n}"
+    p.write_text(s.replace(old, new), encoding="utf-8", newline="\n")
+    print(f"  {path}: {n}x {old!r} -> {new!r}")
+
+# --- Flag strings: --wiki-inputs -> --input ---
+sub("src/wiki/cli.py", '"--wiki-inputs",', '"--input",', 2)
+sub("npm/src/wiki.ts", '"--wiki-inputs"', '"--input"', 2)
+sub("npm/test-wiki-api.js", "'--wiki-inputs'", "'--input'", 11)
+
+for t in ("tests/test_cli.py", "tests/test_fmt.py"):
+    p = ROOT / t
+    s = p.read_text(encoding="utf-8")
+    n = s.count("--wiki-inputs")
+    assert n > 0, t
+    s = s.replace("--wiki-inputs", "--input")
+    p.write_text(s, encoding="utf-8", newline="\n")
+    print(f"  {t}: {n}x --wiki-inputs -> --input")
+
+# --- Doc comments referencing the flag ---
+sub("npm/test-cli-drift.js", "--wiki-inputs", "--input", 1)
+sub("scripts/export_cli_flags.py", "``--wiki-inputs``", "``--input``", 1)
+
+# --- Config key prose: wiki.inputs -> wiki.input (python + docs + skills) ---
+PY = [
+    "src/wiki/graph.py", "src/wiki/graph_cache.py", "src/wiki/mcp.py",
+    "src/wiki/paths.py", "src/wiki/publish.py", "src/wiki/serve.py",
+    "src/wiki/wiki.py", "src/wiki/schemas/wiki_config.py",
+    "src/wiki/schemas/cli.py", "src/wiki/cli.py",
+]
+for path in PY:
+    p = ROOT / path
+    s = p.read_text(encoding="utf-8")
+    n = s.count("wiki.inputs")
+    if n:
+        s = s.replace("wiki.inputs", "wiki.input")
+        p.write_text(s, encoding="utf-8", newline="\n")
+        print(f"  {path}: {n}x wiki.inputs -> wiki.input")
+
+MD = sorted((ROOT / "docs/wiki").rglob("*.md")) + sorted((ROOT / "skills/wiki").rglob("*.md")) + [ROOT / "README.md"]
+for path in MD:
+    s = path.read_text(encoding="utf-8")
+    n = s.count("wiki.inputs")
+    if n:
+        s = s.replace("wiki.inputs", "wiki.input")
+        path.write_text(s, encoding="utf-8", newline="\n")
+        print(f"  {path}: {n}x wiki.inputs -> wiki.input")
+
+# --- Flag strings in docs/skills/README prose ---
+for path in MD:
+    s = path.read_text(encoding="utf-8")
+    n = s.count("--wiki-inputs")
+    if n:
+        s = s.replace("--wiki-inputs", "--input")
+        path.write_text(s, encoding="utf-8", newline="\n")
+        print(f"  {path}: {n}x --wiki-inputs -> --input")
+
+# --- Schema aliases: wikiInputs -> input (MainOptions + InitOptions) ---
+sub("src/wiki/schemas/cli.py", 'alias="wikiInputs"', 'alias="input"', 2)
+
+# --- TS refs: wikiInputs -> input (wiki.ts, types.ts) ---
+for path in ("npm/src/wiki.ts", "npm/src/types.ts", "npm/test-wiki-api.js"):
+    p = ROOT / path
+    s = p.read_text(encoding="utf-8")
+    n = s.count("wikiInputs")
+    if n:
+        s = s.replace("wikiInputs", "input")
+        p.write_text(s, encoding="utf-8", newline="\n")
+        print(f"  {path}: {n}x wikiInputs -> input")
+
+# --- Config schema field: WikiConfig.inputs -> input (+validator) ---
+p = ROOT / "src/wiki/schemas/wiki_config.py"
+s = p.read_text(encoding="utf-8")
+old = "    inputs: list[Path] = Field(default_factory=lambda: [Path(\"wiki\")])"
+new = "    input: list[Path] = Field(default_factory=lambda: [Path(\"wiki\")])"
+assert s.count(old) == 1
+s = s.replace(old, new)
+old = '    @field_validator("inputs", mode="before")'
+new = '    @field_validator("input", mode="before")'
+assert s.count(old) == 1
+s = s.replace(old, new)
+old = "    def _validate_inputs(cls, value: object) -> list[Path]:"
+new = "    def _validate_input(cls, value: object) -> list[Path]:"
+assert s.count(old) == 1
+s = s.replace(old, new)
+old = '            "inputs": inputs,'
+new = '            "input": inputs,'
+assert s.count(old) == 1, s.count(old)
+s = s.replace(old, new)
+p.write_text(s, encoding="utf-8", newline="\n")
+print("  wiki_config.py: field+validator renamed to input")
+
+# --- YAML keys: `inputs:` directly under `wiki:` -> `input:` ---
+def fix_wiki_inputs_key(path: str) -> None:
+    p = ROOT / path
+    lines = p.read_text(encoding="utf-8").splitlines()
+    out = []
+    changed = 0
+    top = None
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            out.append(line)
+            continue
+        if not line[:1].isspace() and ":" in line and not stripped.startswith("-"):
+            key = stripped.split(":", 1)[0].strip().strip('"')
+            top = key
+            out.append(line)
+            continue
+        if top == "wiki" and stripped == "inputs:" and line.startswith("  "):
+            out.append(line.replace("inputs:", "input:", 1))
+            changed += 1
+            continue
+        out.append(line)
+    assert changed > 0, path
+    p.write_text("\n".join(out) + "\n", encoding="utf-8", newline="\n")
+    print(f"  {path}: {changed}x inputs: -> input: (under wiki:)")
+
+fix_wiki_inputs_key("src/wiki/templates/wiki.yml")
+fix_wiki_inputs_key("docs/wiki.yml")
+for md in ("docs/wiki/SHACL.md", "docs/wiki/Recursive_Semantic_Datasets.md",
+           "docs/wiki/Wiki_Configuration.md"):
+    fix_wiki_inputs_key(md)
+
+print("ALL RENAME EDITS APPLIED")

--- a/docs/wiki.yml
+++ b/docs/wiki.yml
@@ -2,7 +2,7 @@
 # Wiki paths, assets, and filename policy (wiki check / wiki lint).
 wiki:
   # Markdown and data directories to index (relative to this file).
-  inputs:
+  input:
     - wiki
   # Static files for custom CSS, logos, favicons (copied on wiki build).
   assets:

--- a/docs/wiki/Linked_Markdown.md
+++ b/docs/wiki/Linked_Markdown.md
@@ -25,7 +25,7 @@ Under the Linked Markdown protocol:
 
 ## Subject URI resolution
 
-The subject IRI of a document is inferred from its relative filepath from the wiki root (under `wiki.inputs`). The default namespace prefix is `wiki:`, resolving to the configured base IRI.
+The subject IRI of a document is inferred from its relative filepath from the wiki root (under `wiki.input`). The default namespace prefix is `wiki:`, resolving to the configured base IRI.
 
 For example, a file located at `wiki/people/Alice_Smith.md` resolves to:
 

--- a/docs/wiki/Recursive_Semantic_Datasets.md
+++ b/docs/wiki/Recursive_Semantic_Datasets.md
@@ -46,7 +46,7 @@ Those may become separate capabilities, but they need the read-only provenance l
 
 ```yaml
 wiki:
-  inputs:
+  input:
     - wiki
 
 sources:

--- a/docs/wiki/SHACL.md
+++ b/docs/wiki/SHACL.md
@@ -12,11 +12,11 @@ In this wiki, SHACL is used to enforce structure via the [wiki](wiki.md) validat
 
 ## Defining custom SHACL shapes (validation)
 
-SHACL shapes load from the wiki graph. Add a dedicated `shapes/` tree to [Wiki Configuration](Wiki_Configuration.md) `wiki.inputs` so shape documents stay separate from prose pages:
+SHACL shapes load from the wiki graph. Add a dedicated `shapes/` tree to [Wiki Configuration](Wiki_Configuration.md) `wiki.input` so shape documents stay separate from prose pages:
 
 ```yaml
 wiki:
-  inputs:
+  input:
     - wiki
     - shapes
 ```
@@ -65,7 +65,7 @@ sh:property:
 
 See [Tech Article Shape](Tech_Article_Shape.md) in this wiki for a dogfooded example.
 
-Pure `.ttl` or `.trig` files in `shapes/` also load when that directory is listed in `wiki.inputs`; markdown frontmatter is the default authoring style in this wiki.
+Pure `.ttl` or `.trig` files in `shapes/` also load when that directory is listed in `wiki.input`; markdown frontmatter is the default authoring style in this wiki.
 
 ## Related
 
@@ -73,7 +73,7 @@ Pure `.ttl` or `.trig` files in `shapes/` also load when that directory is liste
 - [wiki lint](wiki_lint.md) — prose and link conventions (separate from shapes)
 - [Style Guide](Style_Guide.md) — shape authoring and filenames
 - [Software Application Shape](Software_Application_Shape.md) — example `sh:NodeShape`
-- [Wiki Configuration](Wiki_Configuration.md) — `wiki.inputs` and shapes layout
+- [Wiki Configuration](Wiki_Configuration.md) — `wiki.input` and shapes layout
 
 ## References
 

--- a/docs/wiki/Style_Guide.md
+++ b/docs/wiki/Style_Guide.md
@@ -12,7 +12,7 @@ In **this repository**, [AGENTS.md](https://github.com/wazootech/wiki/blob/main/
 
 ## File layout
 
-- Put pages under directories listed in `wiki.inputs` (usually `wiki/`).
+- Put pages under directories listed in `wiki.input` (usually `wiki/`).
 - **Prefer Wikipedia-style filenames** — preserved capitalization and underscores, for example `Gregory_Davidson.md`, `LLM_Wiki.md`, and `JSON_LD.md`. Do not use lowercase kebab-case such as `gregory-house.md` unless your project explicitly chooses that convention in `wiki.filename_pattern`.
 - Avoid spaces and other unsafe route characters in page paths.
 - Use `index.md` only for folder index routes (for example `wiki/games/index.md` → `/wiki/games/`).

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -40,7 +40,7 @@ Three audit lanes map to three commands:
 - Putting a regex under `check.filename_pattern` fails at load with a hint.
 - `check.filename_pattern` and `check.headings` fail at load — use `lint.filename_pattern` and `lint.headings`.
 
-Relative **`--wiki-inputs`** paths on the CLI resolve against the config file directory (same as paths in yaml), not the shell cwd.
+Relative **`--input`** paths on the CLI resolve against the config file directory (same as paths in yaml), not the shell cwd.
 
 ### Blocks
 
@@ -80,7 +80,7 @@ These apply regardless of yaml severities:
 
 ```yaml
 wiki:  # optional block
-  inputs: [wiki]                    # default [wiki]; init writes
+  input: [wiki]                    # default [wiki]; init writes
   assets: [assets]                  # default [assets] if assets/ exists, else []; init writes
   exclude: []                         # default []; init omits
   filename_pattern: "[A-Za-z0-9_()-]+\\.md"  # no default; recommended; init writes
@@ -93,7 +93,7 @@ wiki:  # optional block
 | `exclude`          | optional               | `[]`                                        | omits  | indexing (skipped paths)                   |
 | `filename_pattern` | optional (recommended) | unset — no regex check until set            | writes | `wiki lint` (`lint.filename_pattern`)      |
 
-Page URLs come from paths under `wiki.inputs`: `wiki/Alice.md` → `/wiki/Alice/` with default `site.base_url` and `site.url_style: dir`. `index.md` in a folder owns that folder’s route (for example `wiki/index.md` → `/wiki/`).
+Page URLs come from paths under `wiki.input`: `wiki/Alice.md` → `/wiki/Alice/` with default `site.base_url` and `site.url_style: dir`. `index.md` in a folder owns that folder’s route (for example `wiki/index.md` → `/wiki/`).
 
 See [Filename conventions](#filename-conventions) for regex patterns.
 
@@ -249,7 +249,7 @@ sources:  # optional block
 
 Each source must have a unique `name`. The `type` field is currently limited to `git`. Unknown keys and unsupported types are rejected at config load time.
 
-Run `wiki install` to fetch all declared sources and write `wiki.lock`. Check `wiki.lock` into version control for reproducible builds. The resolved source paths are automatically appended to `wiki.inputs` so the existing graph, check, and build pipeline picks them up.
+Run `wiki install` to fetch all declared sources and write `wiki.lock`. Check `wiki.lock` into version control for reproducible builds. The resolved source paths are automatically appended to `wiki.input` so the existing graph, check, and build pipeline picks them up.
 
 Use `wiki graph list` to inspect the root graph and installed source graph URIs. Source graph URIs are derived from `graph.context.wiki`:
 
@@ -545,7 +545,7 @@ Under `lint`, each rule is `error`, `warning`, or `off`:
 
 ## Related
 
-- [wiki](wiki.md#global-options) — `-c` and `--wiki-inputs` global options
+- [wiki](wiki.md#global-options) — `-c` and `--input` global options
 - [wiki init](wiki_init.md) — scaffold a new wiki project
 - [wiki check](wiki_check.md) — integrity checks
 - [wiki lint](wiki_lint.md) — convention audits

--- a/docs/wiki/Wiki_Programmatic_API.md
+++ b/docs/wiki/Wiki_Programmatic_API.md
@@ -41,7 +41,7 @@ from pathlib import Path
 from wiki import Wiki
 
 w = Wiki.load("wiki.yml")
-# or override inputs (same as --wiki-inputs):
+# or override inputs (same as --input):
 w = Wiki.load("wiki.yml", wiki_inputs=["docs/wiki"])
 
 report = w.check()

--- a/docs/wiki/Wiki_Skills.md
+++ b/docs/wiki/Wiki_Skills.md
@@ -6,7 +6,7 @@ description: Procedural knowledge for coding agents — install, scaffold, impro
 
 # Wiki CLI Agent Skills
 
-[Procedural Knowledge](Procedural_Knowledge.md) for coding agents lives in the Wiki CLI repository under `skills/`. The **`wiki`** skill routes operational workflows to focused references, including code-wiki sync. Skills are **not** wiki pages — do not add `skills/` to `wiki.inputs`.
+[Procedural Knowledge](Procedural_Knowledge.md) for coding agents lives in the Wiki CLI repository under `skills/`. The **`wiki`** skill routes operational workflows to focused references, including code-wiki sync. Skills are **not** wiki pages — do not add `skills/` to `wiki.input`.
 
 Onboarding workflows are **independent modules** with no required order. Each completes its job and stops unless the user asks for the next step in the same turn.
 

--- a/docs/wiki/wiki.md
+++ b/docs/wiki/wiki.md
@@ -122,7 +122,7 @@ GitHub **template repositories** in the [wazootech](https://github.com/wazootech
 
 External templates consume Wiki CLI outputs — they do not replace the compiler:
 
-- **`wiki.yml`** / **`wiki.yaml`** — config root; `wiki.inputs`, `graph.*`, `site.*`
+- **`wiki.yml`** / **`wiki.yaml`** — config root; `wiki.input`, `graph.*`, `site.*`
 - **`wiki export`** — JSON-LD, Turtle, TriG, and other RDF serializations
 - **`wiki build`** — static HTML under `site.base_url`
 
@@ -152,7 +152,7 @@ Do not use these in new prose: `sparql-service-template` (→ `wiki-templates/ya
 
 ### Input pipelines
 
-Wiki CLI processes files through two distinct pipelines. Files in `wiki.inputs` are classified as either **documents** (frontmatter parsed, IRI derived from file path, link-checked) or **raw RDF sources** (loaded directly via rdflib, no document processing):
+Wiki CLI processes files through two distinct pipelines. Files in `wiki.input` are classified as either **documents** (frontmatter parsed, IRI derived from file path, link-checked) or **raw RDF sources** (loaded directly via rdflib, no document processing):
 
 | Category            | Extensions                                               | Pipeline             | Key behavior                                                                                  |
 | ------------------- | -------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------- |
@@ -188,7 +188,7 @@ Files with raw RDF extensions are parsed directly by rdflib using the format map
 - **`@context` auto-injection** — Document files that lack an `@context` key get default `wiki:` and `foaf:` prefixes injected. If `@context` is present as a dict, those defaults are merged in.
 - **Only `.md` carries body text** — Data-only formats cannot carry a body literal in the graph; the entire file content is the data dict.
 - **Inline ```` ```turtle ``` ```` blocks** — Any fenced code block with `turtle` language inside a `.md` file is parsed as Turtle RDF and merged into the wiki graph. This is separate from SPARQL result blocks.
-- **`.toml` is a document format** — TOML files under `wiki.inputs` are treated as data-only wiki documents, subject to `@context` injection and route generation.
+- **`.toml` is a document format** — TOML files under `wiki.input` are treated as data-only wiki documents, subject to `@context` injection and route generation.
 
 ### Related
 
@@ -222,14 +222,14 @@ Example:
 wiki -c docs/wiki.yml check
 ```
 
-### `--wiki-inputs PATH` (repeatable)
+### `--input PATH` (repeatable)
 
-Override or extend `wiki.inputs` from config for a single invocation. Relative paths resolve against the config file directory. Useful for one-off queries against a subdirectory.
+Override or extend `wiki.input` from config for a single invocation. Relative paths resolve against the config file directory. Useful for one-off queries against a subdirectory.
 
 Example:
 
 ```bash
-wiki --wiki-inputs ./wiki --wiki-inputs ./imported query "SELECT * WHERE { ?s ?p ?o } LIMIT 5"
+wiki --input ./wiki --input ./imported query "SELECT * WHERE { ?s ?p ?o } LIMIT 5"
 ```
 
 ## Command reference
@@ -272,7 +272,7 @@ ORDER BY ?command
 
 <!-- sparql:end -->
 
-Global flags: `-c`, `--wiki-inputs`.
+Global flags: `-c`, `--input`.
 
 ## Publishing
 

--- a/docs/wiki/wiki_init.md
+++ b/docs/wiki/wiki_init.md
@@ -36,7 +36,7 @@ wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywi
 | `--site-url-style`               | Override `site.url_style`: `dir` or `file` (default `dir`)                                     | `site.url_style`                                 |
 | `--graph-content-predicate`      | Override `graph.content_predicate` CURIE (e.g. `schema:articleBody`)                           | `graph.content_predicate`                        |
 | `--link-style`                   | Override `link.style`: standard page links (`standard`) or wikilinks (`wikilink`)              | `link.style`                                     |
-| `--wiki-inputs`                  | Override `wiki.inputs` list (can be specified multiple times, default `[wiki]`)                | `wiki.inputs`                                    |
+| `--input`                        | Override `wiki.input` list (can be specified multiple times, default `[wiki]`)                 | `wiki.input`                                     |
 | `--graph-base-iri`               | Override `graph.base_iri` URI                                                                  | `graph.base_iri`                                 |
 | `--graph-implicit-types`         | Override `graph.implicit_types` (can be specified multiple times)                              | `graph.implicit_types`                           |
 | `--graph-implicit-types-policy`  | Override `graph.implicit_types_policy`: `fallback` or `append`                                 | `graph.implicit_types_policy`                    |

--- a/docs/wiki/wiki_mcp.md
+++ b/docs/wiki/wiki_mcp.md
@@ -13,7 +13,7 @@ Start a local [Model Context Protocol](https://modelcontextprotocol.io/) server 
 ```bash
 wiki mcp
 wiki -c docs/wiki.yml mcp
-wiki --wiki-inputs docs/wiki mcp
+wiki --input docs/wiki mcp
 wiki mcp --mode stdio
 wiki mcp --cache
 ```

--- a/npm/src/types.generated.ts
+++ b/npm/src/types.generated.ts
@@ -161,9 +161,9 @@ export interface InitOptions {
    */
   linkStyle?: "standard" | "wikilink";
   /**
-   * Override ``wiki.inputs`` (repeatable).
+   * Override ``wiki.input`` (repeatable).
    */
-  wikiInputs?: readonly string[];
+  input?: readonly string[];
   /**
    * Override ``graph.base_iri``.
    */

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -12,8 +12,8 @@ import type {
 export interface WikiLoadOptions {
   /** Path to ``wiki.yml`` (or directory containing it). */
   config?: string;
-  /** Override ``wiki.inputs`` from the config file. */
-  wikiInputs?: readonly string[];
+  /** Override ``wiki.input`` from the config file. */
+  input?: readonly string[];
   /** Working directory for the wiki CLI subprocess. */
   cwd?: string;
   /** Environment variables for the wiki CLI subprocess. */

--- a/npm/src/wiki.ts
+++ b/npm/src/wiki.ts
@@ -76,8 +76,8 @@ function parseJsonOutput<T>(result: WikiCommandResult): ExportResult<T> {
 export class Wiki {
   /** Path to the ``wiki.yml`` config file (or directory). */
   readonly config: string | undefined;
-  /** Overridden ``wiki.inputs`` paths. */
-  readonly wikiInputs: readonly string[];
+  /** Overridden ``wiki.input`` paths. */
+  readonly input: readonly string[];
   /** Working directory for CLI subprocesses. */
   readonly cwd: string | undefined;
   /** Extra environment variables. */
@@ -88,7 +88,7 @@ export class Wiki {
   /** @internal Use {@link Wiki.load} to construct. */
   constructor(options: WikiLoadOptions & { runtime?: RuntimeOptions } = {}) {
     this.config = options.config;
-    this.wikiInputs = options.wikiInputs ?? [];
+    this.input = options.input ?? [];
     this.cwd = options.cwd;
     this.env = options.env;
     this.runtime = options.runtime ?? {};
@@ -108,7 +108,7 @@ export class Wiki {
    */
   withRuntime(options: RuntimeOptions): Wiki {
     const loadOptions: WikiLoadOptions & { runtime?: RuntimeOptions } = {
-      wikiInputs: this.wikiInputs,
+      input: this.input,
       runtime: { ...this.runtime, ...options },
     };
     if (this.config !== undefined) loadOptions.config = this.config;
@@ -119,14 +119,14 @@ export class Wiki {
 
   /** Build the argv array for a subcommand.
    *
-   * Prepends ``--wiki-inputs`` and ``--config`` from the instance state.
+   * Prepends ``--input`` and ``--config`` from the instance state.
    *
    * @param subcommand - CLI subcommand name (e.g. ``"check"``).
    * @param subcommandArgs - Additional arguments for the subcommand.
    */
   args(subcommand: string, subcommandArgs: readonly string[] = []): string[] {
     const args: string[] = [];
-    pushRepeated(args, "--wiki-inputs", this.wikiInputs);
+    pushRepeated(args, "--input", this.input);
     pushFlag(args, "--config", this.config);
     args.push(subcommand, ...subcommandArgs);
     return args;
@@ -357,7 +357,7 @@ export class Wiki {
     pushFlag(args, "--site-layout", options.siteLayout);
     pushFlag(args, "--graph-content-predicate", options.graphContentPredicate);
     pushFlag(args, "--link-style", options.linkStyle);
-    pushRepeated(args, "--wiki-inputs", options.wikiInputs);
+    pushRepeated(args, "--input", options.input);
     pushFlag(args, "--graph-base-iri", options.graphBaseIri);
     pushRepeated(args, "--graph-implicit-types", options.graphImplicitTypes);
     pushFlag(

--- a/npm/test-cli-drift.js
+++ b/npm/test-cli-drift.js
@@ -27,7 +27,7 @@
  *    each wrapper method emits — including direct `args.push` emissions like
  *    `update`'s `--dry-run` and `init`'s boolean-pair ternary — is a real
  *    option string on that command (or on the root `wiki` command for
- *    `args()`, which emits `--config`/`--wiki-inputs` from no model entry).
+ *    `args()`, which emits `--config`/`--input` from no model entry).
  * 5. Config-key conformance (`scripts/check_config_keys.py`): every
  *    config-key reference in the scaffold template
  *    (`src/wiki/templates/wiki.yml`) and the docs (`docs/wiki`,

--- a/npm/test-wiki-api.js
+++ b/npm/test-wiki-api.js
@@ -18,9 +18,9 @@ async function main() {
   const esm = await import('./dist/index.mjs');
   assert.strictEqual(typeof esm.Wiki, 'function');
 
-  const wiki = new TestWiki({ config: 'docs/wiki.yml', wikiInputs: ['docs/wiki'], cwd: 'repo' });
+  const wiki = new TestWiki({ config: 'docs/wiki.yml', input: ['docs/wiki'], cwd: 'repo' });
   assert.deepStrictEqual(wiki.args('check', ['--strict', 'docs/wiki/Page.md']), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -31,7 +31,7 @@ async function main() {
 
   await wiki.build({ outputDir: '_site', baseUrl: '', urlStyle: 'file', render: true, cache: true, noCheck: true });
   assert.deepStrictEqual(wiki.calls.at(-1), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -49,7 +49,7 @@ async function main() {
 
   await wiki.link({ apply: true, fixBroken: true, dryRun: true, check: true, verbose: true, files: ['Page.md'] });
   assert.deepStrictEqual(wiki.calls.at(-1), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -72,7 +72,7 @@ async function main() {
 
   await wiki.graphList();
   assert.deepStrictEqual(wiki.calls.at(-1), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -81,7 +81,7 @@ async function main() {
   ]);
 
   assert.deepStrictEqual(wiki.args('mcp', ['--mode', 'stdio', '--cache']), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -96,7 +96,7 @@ async function main() {
     git: true,
     repo: 'wazootech/wiki',
     linkStyle: 'standard',
-    wikiInputs: ['wiki', 'docs/wiki'],
+    input: ['wiki', 'docs/wiki'],
     graphImplicitTypes: ['schema:Thing'],
     graphIncludeFileExtension: false,
   });
@@ -107,9 +107,9 @@ async function main() {
     'wazootech/wiki',
     '--link-style',
     'standard',
-    '--wiki-inputs',
+    '--input',
     'wiki',
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--graph-implicit-types',
     'schema:Thing',
@@ -137,7 +137,7 @@ async function main() {
 
   await wiki.install();
   assert.deepStrictEqual(wiki.calls.at(-1), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -146,7 +146,7 @@ async function main() {
 
   await wiki.install({ url: 'https://github.com/wazootech/wiki-templates.git' });
   assert.deepStrictEqual(wiki.calls.at(-1), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -156,7 +156,7 @@ async function main() {
 
   await wiki.update({ name: 'templates', dryRun: true });
   assert.deepStrictEqual(wiki.calls.at(-1), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',
@@ -167,7 +167,7 @@ async function main() {
 
   await wiki.remove({ name: 'templates' });
   assert.deepStrictEqual(wiki.calls.at(-1), [
-    '--wiki-inputs',
+    '--input',
     'docs/wiki',
     '--config',
     'docs/wiki.yml',

--- a/scripts/export_cli_flags.py
+++ b/scripts/export_cli_flags.py
@@ -14,7 +14,7 @@ leaf command, the exact option strings Click accepts:
   half of ``"/"`` boolean pairs (e.g. ``--no-graph-include-file-extension``).
   Only ``-``-prefixed strings are collected, so positional arguments
   (whose ``opts`` is just the bare name) never pollute the set.
-- The root group's own params (``--config``, ``--wiki-inputs``) are emitted
+- The root group's own params (``--config``, ``--input``) are emitted
   under the ``"__root__"`` key — they live in no ``COMMAND_MODELS`` entry, so
   no earlier stage guards them.
 - Nested leaves (e.g. ``graph list``) are zero-param by construction

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,7 +2,7 @@
 
 [![skills.sh](https://skills.sh/b/wazootech/wiki)](https://skills.sh/wazootech/wiki)
 
-One agent skill for [Wiki CLI](https://github.com/wazootech/wiki): install the CLI, scaffold a wiki project, audit hygiene, and deploy to GitHub Pages. Skills live under `skills/` and are **not** wiki content — do not add this folder to `wiki.inputs`.
+One agent skill for [Wiki CLI](https://github.com/wazootech/wiki): install the CLI, scaffold a wiki project, audit hygiene, and deploy to GitHub Pages. Skills live under `skills/` and are **not** wiki content — do not add this folder to `wiki.input`.
 
 Typical flow: **install** → **create** → **deploy** → **improve** (each optional; route to one workflow per turn).
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 
 Procedural knowledge for coding agents working with [Wiki CLI](https://github.com/wazootech/wiki) (`wiki` command, PyPI **`wazootech-wiki`**).
 
-Skills under `skills/` are agent knowledge — **not** wiki pages. Do not add `skills/` to `wiki.inputs`.
+Skills under `skills/` are agent knowledge — **not** wiki pages. Do not add `skills/` to `wiki.input`.
 
 ## Principles
 

--- a/skills/wiki/references/audit.md
+++ b/skills/wiki/references/audit.md
@@ -30,7 +30,7 @@ Valid settings and keys in the `wiki.yml` or legacy `wiki.yaml` file:
 
 - **Invalid keys**: Unknown top-level configuration keys that cause `wiki check` to fail.
 - **Deprecated branding properties**: Presence of old `site.manifest`, `site.title`, or `site.theme_color` keys that are no longer part of the schema.
-- **Inputs folder exclusions**: The `wiki.inputs` configuration listing directories like `skills/`, `.agents/`, `.git/`, or test folders, which imports agent instructions as content pages.
+- **Inputs folder exclusions**: The `wiki.input` configuration listing directories like `skills/`, `.agents/`, `.git/`, or test folders, which imports agent instructions as content pages.
 - **Base URL issues**: `site.base_url` undefined or lacking a leading slash (should be `""` or `/path`).
 
 ## Deploy and CI/CD alignment

--- a/skills/wiki/references/improve.md
+++ b/skills/wiki/references/improve.md
@@ -9,7 +9,7 @@ The founding rule: **the advisor never directly modifies wiki pages or config fi
 1. **Never edit wiki files yourself** unless the user explicitly requests immediate inline repairs.
 1. **Never guess** — cite the exact `file:line` or CLI output for every finding.
 1. **No config migration shims** — unknown config keys must fail fast at load; document upgrades in CHANGELOG and docs only.
-1. **Skills are not wiki inputs** — never index, build, or list the `skills/` or `.agents/` folder under `wiki.inputs`.
+1. **Skills are not wiki inputs** — never index, build, or list the `skills/` or `.agents/` folder under `wiki.input`.
 1. **No secret values** — if credentials or tokens are discovered, refer to their type and location only. Suggest rotation, never copy the value.
 
 ## Workflow
@@ -19,7 +19,7 @@ The founding rule: **the advisor never directly modifies wiki pages or config fi
 Understand the specific wiki configuration before auditing:
 
 - Locate the config file (prefer `wiki.yml`; fallback to legacy `wiki.yaml`).
-- Read configuration settings: `wiki.inputs`, `lint:`, `check:`, `link.style`, `wiki.filename_pattern`, `site.layout`.
+- Read configuration settings: `wiki.input`, `lint:`, `check:`, `link.style`, `wiki.filename_pattern`, `site.layout`.
 - Identify resolved commands and environment requirements by running:
   `bash skills/wiki/scripts/verify.sh`
 - Note project conventions: filename cases, heading structures, links style, and metadata schemas.

--- a/skills/wiki/references/init.md
+++ b/skills/wiki/references/init.md
@@ -55,7 +55,7 @@ When context already supplies values, **do not re-prompt**:
 | Custom namespace       | No GitHub / custom site                      | `--graph-context-wiki https://…/` and optional `--site-base-url` |
 | Git repository         | User wants `git init` now                    | `--git`                                                          |
 | Link style             | Wikilinks vs standard page links             | `--link-style wikilink`                                          |
-| Inputs directory       | Custom markdown folder                       | `--wiki-inputs myfolder`                                         |
+| Inputs directory       | Custom markdown folder                       | `--input myfolder`                                         |
 | URL style              | File vs directory routes                     | `--site-url-style dir` or `file`                                 |
 | Content predicate      | Body text RDF predicate                      | `--graph-content-predicate schema:articleBody`                   |
 | Document IRIs          | IRIs differ from `wiki:` namespace           | `--graph-base-iri https://…/`                                    |

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -37,11 +37,11 @@ def optional_files_argument(f):
 @click.group()
 @click.version_option(version=__version__, prog_name="wiki")
 @click.option(
-    "--wiki-inputs",
+    "--input",
     "wiki_inputs",
     multiple=True,
     default=None,
-    help="Override wiki.inputs from config file (.md, .yaml, .json, .toml; repeatable).",
+    help="Override wiki.input from config file (.md, .yaml, .json, .toml; repeatable).",
 )
 @click.option(
     "-c",
@@ -565,11 +565,11 @@ def serve(
     help="Override link.style.",
 )
 @click.option(
-    "--wiki-inputs",
+    "--input",
     "wiki_inputs",
     multiple=True,
     default=None,
-    help="Override wiki.inputs (repeatable).",
+    help="Override wiki.input (repeatable).",
 )
 @click.option("--graph-base-iri", "graph_base_iri", default=None, help="Override graph.base_iri.")
 @click.option(

--- a/src/wiki/graph.py
+++ b/src/wiki/graph.py
@@ -101,7 +101,7 @@ def graph_descriptors(config: Config) -> list[GraphDescriptor]:
 
     root_inputs = []
     source_descriptors = []
-    for input_dir in config.wiki.inputs:
+    for input_dir in config.wiki.input:
         resolved = input_dir.resolve()
         descriptor = source_paths.get(resolved)
         if descriptor is None:
@@ -413,7 +413,7 @@ def _build_graph_from_wiki(context: Config) -> Graph:
 
     document_files = set(iter_document_files(context))
 
-    for input_dir in context.wiki.inputs:
+    for input_dir in context.wiki.input:
         _process_input_dir(graph, context, input_dir, document_files)
 
     return graph
@@ -468,7 +468,7 @@ def load_dataset(
     }
     root_descriptor = descriptors[0]
 
-    for input_dir in context.wiki.inputs:
+    for input_dir in context.wiki.input:
         resolved = input_dir.resolve()
         descriptor = source_by_path.get(resolved, root_descriptor)
         graph = dataset.graph(URIRef(descriptor.uri))

--- a/src/wiki/graph_cache.py
+++ b/src/wiki/graph_cache.py
@@ -49,7 +49,7 @@ def iter_wiki_files(config: Config) -> list[Path]:
     """All non-excluded files under inputs that contribute to the graph."""
     files: list[Path] = []
     cache_root = cache_dir(config).resolve()
-    for input_dir in config.wiki.inputs:
+    for input_dir in config.wiki.input:
         if not input_dir.exists():
             continue
         for file_path in sorted(input_dir.rglob("*")):

--- a/src/wiki/mcp.py
+++ b/src/wiki/mcp.py
@@ -87,7 +87,7 @@ def describe_wiki(wiki: Wiki, *, disk_cache: bool = False) -> dict[str, Any]:
     return {
         "version": __version__,
         "config": _display_path(wiki.config_path, root),
-        "inputs": [_relative_path(path, root) for path in config.wiki.inputs],
+        "inputs": [_relative_path(path, root) for path in config.wiki.input],
         "namespaces": _namespace_map(graph),
         "graph": {
             **graph_stats(graph),

--- a/src/wiki/paths.py
+++ b/src/wiki/paths.py
@@ -15,7 +15,7 @@ UNSAFE_ROUTE_CHARS = set("?#%")
 
 def iter_document_files(config: Config) -> list[Path]:
     doc_files: list[Path] = []
-    for input_dir in config.wiki.inputs:
+    for input_dir in config.wiki.input:
         if input_dir.exists():
             for file_path in sorted(input_dir.rglob("*")):
                 if not file_path.is_file() or file_path.suffix.lower() not in DOCUMENT_EXTENSIONS:
@@ -168,7 +168,7 @@ def validate_route_safety(config: Config) -> list[str]:
 
 
 def _relative_to_input_dir(config: Config, md_file: Path) -> Path:
-    for root in config.wiki.inputs:
+    for root in config.wiki.input:
         try:
             return md_file.relative_to(root)
         except ValueError:

--- a/src/wiki/publish.py
+++ b/src/wiki/publish.py
@@ -32,7 +32,7 @@ def _validate_build_output_dir(page_output_dir: Path, config) -> None:
     protected: list[tuple[str, Path]] = [
         ("config root", config.config_root.resolve()),
     ]
-    for input_dir in config.wiki.inputs:
+    for input_dir in config.wiki.input:
         protected.append(("wiki input", input_dir.resolve()))
     for asset_dir in config.wiki.assets:
         protected.append(("wiki asset", asset_dir.resolve()))
@@ -66,8 +66,8 @@ def _build_static_site(wiki: Wiki, options: BuildOptions) -> BuildResult:
             wiki.graph(infer=True, reload=True, disk_cache=True)
             wiki.dataset(infer=True, reload=True, disk_cache=True)
 
-    if not any(path.exists() for path in config.wiki.inputs):
-        dirs_str = ", ".join(str(path) for path in config.wiki.inputs)
+    if not any(path.exists() for path in config.wiki.input):
+        dirs_str = ", ".join(str(path) for path in config.wiki.input)
         return BuildResult(ok=False, error_message=f"none of the input directories exist ({dirs_str})")
 
     if not options.skip_preflight:

--- a/src/wiki/schemas/cli.py
+++ b/src/wiki/schemas/cli.py
@@ -29,8 +29,8 @@ class MainOptions(BaseModel):
 
     wiki_inputs: tuple[str, ...] | None = Field(
         default=None,
-        alias="wikiInputs",
-        description="Override ``wiki.inputs`` from the config file.",
+        alias="input",
+        description="Override ``wiki.input`` from the config file.",
     )
     config_path: str = Field(
         default=".",
@@ -366,8 +366,8 @@ class InitOptions(BaseModel):
     )
     wiki_inputs: tuple[str, ...] | None = Field(
         default=None,
-        alias="wikiInputs",
-        description="Override ``wiki.inputs`` (repeatable).",
+        alias="input",
+        description="Override ``wiki.input`` (repeatable).",
     )
     graph_base_iri: str | None = Field(
         default=None,

--- a/src/wiki/schemas/wiki_config.py
+++ b/src/wiki/schemas/wiki_config.py
@@ -259,14 +259,14 @@ def find_config_path(path: Path) -> Path | None:
 class WikiConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    inputs: list[Path] = Field(default_factory=lambda: [Path("wiki")])
+    input: list[Path] = Field(default_factory=lambda: [Path("wiki")])
     assets: list[Path] | None = None
     exclude: list[str] = Field(default_factory=list)
     filename_pattern: str | None = None
 
-    @field_validator("inputs", mode="before")
+    @field_validator("input", mode="before")
     @classmethod
-    def _validate_inputs(cls, value: object) -> list[Path]:
+    def _validate_input(cls, value: object) -> list[Path]:
         return _coerce_path_list(value)
 
     @field_validator("assets", mode="before")
@@ -441,7 +441,7 @@ class Config(BaseModel):
         def resolve_list(paths: list[Path]) -> list[Path]:
             return [_resolve_path(p, base_dir) for p in paths]
 
-        inputs = resolve_list(self.wiki.inputs)
+        inputs = resolve_list(self.wiki.input)
         if self.wiki.assets is None:
             assets_raw = [Path("assets")] if (base_dir / "assets").is_dir() else []
         else:
@@ -459,7 +459,7 @@ class Config(BaseModel):
         fmt = FmtConfig.parse_raw(self.fmt, config_name, base_dir)
 
         object.__setattr__(self, "wiki", self.wiki.model_copy(update={
-            "inputs": inputs,
+            "input": inputs,
             "assets": assets,
             "exclude": exclude,
         }))

--- a/src/wiki/serve.py
+++ b/src/wiki/serve.py
@@ -346,7 +346,7 @@ def create_server(
     server = HTTPServer((host, port), WikiHandler)
     server.state = server_state  # type: ignore[attr-defined]
     print(f"Wiki server ready at http://{host}:{port}/")
-    dirs_str = ", ".join(str(d) for d in config.wiki.inputs)
+    dirs_str = ", ".join(str(d) for d in config.wiki.input)
     print(f"Serving {len(site.pages)} pages from {dirs_str}")
     if not site.pages:
         print("Warning: no pages found. Ensure your wiki directory has .md, .yaml, .yml, or .json files.")
@@ -566,7 +566,7 @@ def run_server(
     )
 
     if watch:
-        watch_dirs = list(config.wiki.inputs) + [d for d in config.wiki.assets if d.exists()]
+        watch_dirs = list(config.wiki.input) + [d for d in config.wiki.assets if d.exists()]
         stop_event = threading.Event()
         mtimes = _snapshot_watch_dirs(watch_dirs)
         threading.Thread(

--- a/src/wiki/site/build.py
+++ b/src/wiki/site/build.py
@@ -29,7 +29,7 @@ def build_site(
         config = input_dirs
     else:
         dirs_arg = [input_dirs] if isinstance(input_dirs, Path) else input_dirs
-        config = Config.for_root(Path.cwd(), wiki={"inputs": [str(p) for p in dirs_arg]})
+        config = Config.for_root(Path.cwd(), wiki={"input": [str(p) for p in dirs_arg]})
     resolved_base_url = config.site.base_url if base_url is None else base_url
     resolved_url_style = config.site.url_style if url_style is None else url_style
     pages: list[VirtualPage] = []

--- a/src/wiki/templates/wiki.yml
+++ b/src/wiki/templates/wiki.yml
@@ -3,7 +3,7 @@
 # Wiki paths, assets, and filename policy (wiki check / wiki lint).
 wiki:
   # Markdown and data directories to index (relative to this file).
-  inputs:
+  input:
 {% if wiki_inputs %}
 {% for inp in wiki_inputs %}
     - {{ inp }}

--- a/src/wiki/wiki.py
+++ b/src/wiki/wiki.py
@@ -89,7 +89,7 @@ class Wiki:
 
         Args:
             config_path: Path to wiki config file or a directory containing one.
-            wiki_inputs: Override ``wiki.inputs`` from the config file.
+            wiki_inputs: Override ``wiki.input`` from the config file.
 
         Returns:
             A new ``Wiki`` instance backed by the loaded config.
@@ -98,16 +98,16 @@ class Wiki:
         resolved_config_path = find_config_path(load_path)
         config = Config.load(load_path)
         if wiki_inputs:
-            config.wiki.inputs = [
+            config.wiki.input = [
                 Path(entry) if Path(entry).is_absolute() else config.config_root / entry
                 for entry in wiki_inputs
             ]
         resolved = resolve_sources(config)
         if resolved:
-            existing = set(config.wiki.inputs)
+            existing = set(config.wiki.input)
             for path in resolved:
                 if path not in existing:
-                    config.wiki.inputs.append(path)
+                    config.wiki.input.append(path)
         return cls(config, resolved_config_path)
 
     def with_runtime(

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -25,7 +25,7 @@ class TestChecking(unittest.TestCase):
     def test_lint_filenames_validation(self) -> None:
         """Test auditing of filenames for lowercase kebab-case naming standard."""
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir], "filename_pattern": r"[a-z0-9-]+\.md"})
+            config = Config(wiki={"input": [tmpdir], "filename_pattern": r"[a-z0-9-]+\.md"})
             
             # Create valid and invalid files
             valid_path = Path(tmpdir) / "valid-kebab-case.md"
@@ -41,7 +41,7 @@ class TestChecking(unittest.TestCase):
     def test_lint_broken_links_validation(self) -> None:
         """Test auditing of internal link structures (WikiLinks and Markdown links)."""
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             
             # Create one target file
             target_path = Path(tmpdir) / "target-page.md"
@@ -68,7 +68,7 @@ And a valid Markdown link [Target](target-page.md) and a broken Markdown link [B
     def test_audit_broken_wiki_curie_in_frontmatter(self) -> None:
         """Frontmatter wiki: CURIEs must resolve to an existing document route."""
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "wiki.md").write_text("---\ntype: SoftwareApplication\n---\n", encoding="utf-8")
             Path(tmpdir, "Farzapedia.md").write_text(
                 "---\ntype: TechArticle\nabout: wiki:wiki-cli\n---\n",
@@ -83,7 +83,7 @@ And a valid Markdown link [Target](target-page.md) and a broken Markdown link [B
     def test_wiki_curie_with_fragment_resolves_to_page_route(self) -> None:
         """wiki:Page#fragment refers to the same wiki route as wiki:Page."""
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Microdata.md").write_text(
                 '---\ntype: TechArticle\n---\n<div itemid="wiki:Microdata#example"></div>\n',
                 encoding="utf-8",
@@ -92,7 +92,7 @@ And a valid Markdown link [Target](target-page.md) and a broken Markdown link [B
 
     def test_markdown_can_link_to_yaml_document(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
 
             yml_target = Path(tmpdir) / "yml-target.yml"
             yml_target.write_text("type: Thing\nname: YML\n", encoding="utf-8")
@@ -107,7 +107,7 @@ And a valid Markdown link [Target](target-page.md) and a broken Markdown link [B
 
     def test_lint_filenames_skips_yaml_documents(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir], "filename_pattern": r"[a-z0-9-]+\.md"})
+            config = Config(wiki={"input": [tmpdir], "filename_pattern": r"[a-z0-9-]+\.md"})
 
             Path(tmpdir, "Invalid_Name.yml").write_text("type: Thing\n", encoding="utf-8")
             Path(tmpdir, "Invalid_Name.yaml").write_text("type: Thing\n", encoding="utf-8")
@@ -129,7 +129,7 @@ And a valid Markdown link [Target](target-page.md) and a broken Markdown link [B
             self.assertEqual(len(shapes), 0)
             
             # Loading from configuration with missing directories
-            config = Config(wiki={"inputs": [Path(tmpdir) / "non-existent"]})
+            config = Config(wiki={"input": [Path(tmpdir) / "non-existent"]})
             data_graph_conf = load_graph(config, infer=False)
             shapes_conf = load_shapes(data_graph_conf)
             self.assertEqual(len(shapes_conf), 0)
@@ -156,7 +156,7 @@ schema:PersonShape
     ] .
 """
             (wiki_dir / "person-shape.ttl").write_text(shape_content, encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
             
             # 1. No frontmatter -> check_shacl_file returns None
             no_fm_file = wiki_dir / "no-fm.md"
@@ -200,7 +200,7 @@ type: schema:WebPage
 """, encoding="utf-8")
 
             config_warning = Config(
-                wiki={"inputs": [wiki_dir], "filename_pattern": r"[a-z0-9-]+\.md"},
+                wiki={"input": [wiki_dir], "filename_pattern": r"[a-z0-9-]+\.md"},
                 lint={"filename_pattern": "warning"},
             )
             res_warning = run_lint(config_warning)
@@ -209,7 +209,7 @@ type: schema:WebPage
             self.assertEqual(len(res_warning.errors), 0)
 
             config_error = Config(
-                wiki={"inputs": [wiki_dir], "filename_pattern": r"[a-z0-9-]+\.md"},
+                wiki={"input": [wiki_dir], "filename_pattern": r"[a-z0-9-]+\.md"},
                 lint={"filename_pattern": "error"},
             )
             res_error = run_lint(config_error)
@@ -218,7 +218,7 @@ type: schema:WebPage
             self.assertEqual(len(res_error.errors), 1)
 
             config_off = Config(
-                wiki={"inputs": [wiki_dir], "filename_pattern": r"[a-z0-9-]+\.md"},
+                wiki={"input": [wiki_dir], "filename_pattern": r"[a-z0-9-]+\.md"},
                 lint={"filename_pattern": "off"},
             )
             res_off = run_lint(config_off)
@@ -233,7 +233,7 @@ type: schema:WebPage
             (wiki_dir / "Ethan_Davidson.md").write_text("---\ntype: schema:Person\n---\n", encoding="utf-8")
             (wiki_dir / "ethan-davidson.md").write_text("---\ntype: schema:Person\n---\n", encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki_dir], "filename_pattern": r"[A-Z][A-Za-z0-9_]*\.md"})
+            config = Config(wiki={"input": [wiki_dir], "filename_pattern": r"[A-Z][A-Za-z0-9_]*\.md"})
             res = run_lint(config)
 
             self.assertTrue(res.ok)
@@ -250,14 +250,14 @@ type: schema:WebPage
                 encoding="utf-8",
             )
 
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
             res = run_lint(config)
 
             self.assertTrue(any("Broken WikiLink [Ethan Davidson]" in w.message for w in res.warnings))
 
     def test_lint_headings_numbered_and_thematic_break(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             page = Path(tmpdir) / "Bad.md"
             page.write_text(
                 "---\ntype: TechArticle\n---\n## 1. First step\n\n---\n\nBody.\n",
@@ -271,7 +271,7 @@ type: schema:WebPage
 
     def test_lint_headings_title_case(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n## Related Standards Guide\n",
                 encoding="utf-8",
@@ -281,7 +281,7 @@ type: schema:WebPage
 
     def test_lint_headings_h1_title_case_not_flagged(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n# Agent Memory Filesystems\n",
                 encoding="utf-8",
@@ -291,7 +291,7 @@ type: schema:WebPage
 
     def test_lint_headings_h2_title_case_flagged(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n## Agent Memory Filesystems\n",
                 encoding="utf-8",
@@ -301,7 +301,7 @@ type: schema:WebPage
 
     def test_lint_headings_setext_not_warned(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\nMy Title\n=======\n\nBody.\n",
                 encoding="utf-8",
@@ -311,7 +311,7 @@ type: schema:WebPage
 
     def test_lint_headings_setext_h2_not_warned(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\nSection title\n---------\n\nBody.\n",
                 encoding="utf-8",
@@ -321,7 +321,7 @@ type: schema:WebPage
 
     def test_lint_headings_atx_does_not_warn_setext(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n# My Title\n\n## Section title\n",
                 encoding="utf-8",
@@ -331,7 +331,7 @@ type: schema:WebPage
 
     def test_lint_headings_skips_setext_inside_fenced_code(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Example.md").write_text(
                 "---\ntype: TechArticle\n---\n```markdown\nTitle\n===\n```\n",
                 encoding="utf-8",
@@ -341,7 +341,7 @@ type: schema:WebPage
 
     def test_lint_headings_skips_thematic_break_inside_fenced_code(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Example.md").write_text(
                 "---\ntype: TechArticle\n---\n```yaml\n---\nname: Example\n---\n```\n",
                 encoding="utf-8",
@@ -351,7 +351,7 @@ type: schema:WebPage
 
     def test_lint_headings_allows_proper_noun_headings(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Deploy.md").write_text(
                 "---\ntype: TechArticle\n---\n# Deploying to GitHub Pages\n",
                 encoding="utf-8",
@@ -361,7 +361,7 @@ type: schema:WebPage
 
     def test_lint_headings_ignores_capitalized_link_text_in_headings(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Compare.md").write_text(
                 "---\ntype: TechArticle\n---\n"
                 "## Comparison with [Wiki CLI](wiki.md) and [Letta MemFS](Letta_MemFS.md)\n",
@@ -372,7 +372,7 @@ type: schema:WebPage
 
     def test_lint_heading_levels_skip(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n# A\n\n### C\n",
                 encoding="utf-8",
@@ -383,7 +383,7 @@ type: schema:WebPage
 
     def test_lint_heading_levels_ok_increment(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n# A\n\n## B\n\n### C\n",
                 encoding="utf-8",
@@ -392,7 +392,7 @@ type: schema:WebPage
 
     def test_lint_heading_levels_first_h2_ok(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n## Intro\n",
                 encoding="utf-8",
@@ -401,7 +401,7 @@ type: schema:WebPage
 
     def test_lint_heading_levels_skips_fenced_code(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n## Real\n\n```md\n# Fake\n### Also fake\n```\n",
                 encoding="utf-8",
@@ -410,7 +410,7 @@ type: schema:WebPage
 
     def test_lint_duplicate_headings_h2(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n## Foo\n\nBody.\n\n## Foo\n",
                 encoding="utf-8",
@@ -422,7 +422,7 @@ type: schema:WebPage
 
     def test_lint_duplicate_headings_h1_allowed(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n# Foo\n\n# Foo\n",
                 encoding="utf-8",
@@ -431,7 +431,7 @@ type: schema:WebPage
 
     def test_lint_duplicate_headings_case_insensitive(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n## Foo\n\n## foo\n",
                 encoding="utf-8",
@@ -441,7 +441,7 @@ type: schema:WebPage
 
     def test_lint_duplicate_headings_skips_fenced_code(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             Path(tmpdir, "Page.md").write_text(
                 "---\ntype: TechArticle\n---\n## Foo\n\n```\n## Foo\n```\n",
                 encoding="utf-8",
@@ -457,7 +457,7 @@ type: schema:WebPage
                 "# Guide\n\nSee [[Target]] for details.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=Path(tmpdir))
+            config = Config(wiki={"input": [wiki]}, config_root=Path(tmpdir))
             warnings = lint_link_style(config)
             self.assertEqual(len(warnings), 1)
             self.assertIn("Wikilink '[[Target]]'", warnings[0])
@@ -470,11 +470,11 @@ type: schema:WebPage
                 "# Guide\n\nLiteral `[[Target]]` and fenced:\n\n```\n[[Target]]\n```\n",
                 encoding="utf-8",
             )
-            standard_config = Config(wiki={"inputs": [wiki]}, config_root=Path(tmpdir))
+            standard_config = Config(wiki={"input": [wiki]}, config_root=Path(tmpdir))
             self.assertEqual(lint_link_style(standard_config), [])
 
             wikilink_config = Config(
-                wiki={"inputs": [wiki]},
+                wiki={"input": [wiki]},
                 config_root=Path(tmpdir),
                 link={"style": "wikilink"},
             )
@@ -489,7 +489,7 @@ type: schema:WebPage
             wiki = Path(tmpdir) / "wiki"
             wiki.mkdir()
             (wiki / "Guide.md").write_text("# Guide\n\nSee [[Target]].\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=Path(tmpdir), lint={"link_style": "error"})
+            config = Config(wiki={"input": [wiki]}, config_root=Path(tmpdir), lint={"link_style": "error"})
             res = run_lint(config)
             self.assertFalse(res.ok)
             self.assertTrue(any("Wikilink" in e.message for e in res.errors))
@@ -502,7 +502,7 @@ type: schema:WebPage
                 "---\ntype: TechArticle\n---\n## 1. Bad\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki_dir]}, lint={"headings": "error"})
+            config = Config(wiki={"input": [wiki_dir]}, lint={"headings": "error"})
             res = run_lint(config)
             self.assertFalse(res.ok)
             self.assertTrue(any("Numbered heading" in e.message for e in res.errors))
@@ -515,7 +515,7 @@ type: schema:WebPage
                 "---\ntype: TechArticle\n---\n# A\n\n### C\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki_dir]}, lint={"heading_levels": "error"})
+            config = Config(wiki={"input": [wiki_dir]}, lint={"heading_levels": "error"})
             res = run_lint(config)
             self.assertFalse(res.ok)
             self.assertTrue(any("skips level" in e.message for e in res.errors))
@@ -528,7 +528,7 @@ type: schema:WebPage
                 "---\ntype: TechArticle\n---\n## Foo\n\n## Foo\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki_dir]}, lint={"duplicate_headings": "error"})
+            config = Config(wiki={"input": [wiki_dir]}, lint={"duplicate_headings": "error"})
             res = run_lint(config)
             self.assertFalse(res.ok)
             self.assertTrue(any("Duplicate heading" in e.message for e in res.errors))
@@ -539,7 +539,7 @@ type: schema:WebPage
             wiki_dir = Path(tmpdir) / "wiki"
             wiki_dir.mkdir()
 
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
 
             # Create a shape inside markdown frontmatter
             shape_file = wiki_dir / "project-shape.md"
@@ -589,7 +589,7 @@ name: Wiki CLI
                 "---\ntype: TechArticle\nwazoo:layout: layouts/missing.html\n---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             issues = check_layout_frontmatter(config)
             self.assertEqual(len(issues), 1)
@@ -607,7 +607,7 @@ name: Wiki CLI
                 "---\ntype: TechArticle\nwazoo:layout: layouts/plain.html\n---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             issues = check_layout_frontmatter(config)
             self.assertEqual(issues, [])

--- a/tests/test_audit_reports.py
+++ b/tests/test_audit_reports.py
@@ -33,7 +33,7 @@ class TestAuditReports(unittest.TestCase):
                 encoding="utf-8",
             )
             config = Config(
-                wiki={"inputs": [wiki_dir]},
+                wiki={"input": [wiki_dir]},
                 lint={"broken_links": "error", "link_style": "error"},
                 link={"style": "standard"},
             )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -22,7 +22,7 @@ class TestWikiBuild(unittest.TestCase):
             assets = root / "assets" / "items"
             wiki.mkdir()
             assets.mkdir(parents=True)
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n  assets: [assets]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n  assets: [assets]\n", encoding="utf-8")
             (wiki / "Item.md").write_text("# Item\n\n![label](../assets/items/label.jpg)", encoding="utf-8")
             (assets / "label.jpg").write_text("image", encoding="utf-8")
             output_dir = root / "_site"
@@ -43,7 +43,7 @@ class TestWikiBuild(unittest.TestCase):
             wiki.mkdir()
             owned.mkdir(parents=True)
             (owned / "old.html").write_text("old", encoding="utf-8")
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\nlint:\n  broken_links: error\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\nlint:\n  broken_links: error\n", encoding="utf-8")
             (wiki / "Page.md").write_text("# Page\n\n[[Missing]]", encoding="utf-8")
 
             result = runner.invoke(main, ["--config", str(root), "build", "--output-dir", str(output_dir)])
@@ -61,7 +61,7 @@ class TestWikiBuild(unittest.TestCase):
             wiki.mkdir()
             owned.mkdir(parents=True)
             (owned / "old.html").write_text("old", encoding="utf-8")
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\nlint:\n  broken_links: error\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\nlint:\n  broken_links: error\n", encoding="utf-8")
             (wiki / "Page.md").write_text("# Page\n\n[[Missing]]", encoding="utf-8")
 
             result = runner.invoke(main, ["--config", str(root), "build", "--output-dir", str(output_dir), "--no-check"])
@@ -77,7 +77,7 @@ class TestWikiBuild(unittest.TestCase):
             wiki = root / "wiki"
             output_dir = root / "_site"
             wiki.mkdir()
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
             (wiki / "index.md").write_text("# Custom Home\n\nWelcome.", encoding="utf-8")
             (wiki / "Page.md").write_text("# Page", encoding="utf-8")
 
@@ -95,7 +95,7 @@ class TestWikiBuild(unittest.TestCase):
             wiki = root / "wiki"
             output_dir = root / "_site"
             wiki.mkdir()
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
             (wiki / "person.yaml").write_text("type: Person\nname: Gregory Davidson\n", encoding="utf-8")
             (wiki / "place.yml").write_text("type: Place\nname: Princeton\n", encoding="utf-8")
 
@@ -111,7 +111,7 @@ class TestWikiBuild(unittest.TestCase):
             root = Path(tmpdir)
             wiki = root / "wiki"
             wiki.mkdir()
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
             (wiki / "Page.md").write_text("# Page\n\nContent.", encoding="utf-8")
 
             for url_style in ("dir", "file"):
@@ -143,7 +143,7 @@ class TestWikiBuild(unittest.TestCase):
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "Page.md").write_text("# Page\n\nContent.", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, site={"base_url": "/wiki", "url_style": "dir"}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, site={"base_url": "/wiki", "url_style": "dir"}, config_root=root)
 
             with patch("wiki.cli.Wiki.load") as load_mock:
                 load_mock.return_value = Wiki(config)
@@ -197,7 +197,7 @@ class TestWikiBuild(unittest.TestCase):
 </body>
 </html>"""
             (root / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\nsite:\n  layout: test_shell.html\n", encoding="utf-8"
+                "wiki:\n  input: [wiki]\nsite:\n  layout: test_shell.html\n", encoding="utf-8"
             )
             write_layout(root, "test_shell.html", test_template)
             (wiki / "Gregory_Davidson.yaml").write_text(
@@ -254,7 +254,7 @@ name: Bella Davidson
 </body>
 </html>"""
             (root / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\nsite:\n  layout: test_shell.html\n", encoding="utf-8"
+                "wiki:\n  input: [wiki]\nsite:\n  layout: test_shell.html\n", encoding="utf-8"
             )
             write_layout(root, "test_shell.html", template)
             (wiki / "Page.md").write_text(
@@ -284,7 +284,7 @@ about: wiki:Alice_Theory
             output_dir = root / "_site"
             wiki.mkdir()
             (root / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\nsite:\n  layout: nonexistent.html\n", encoding="utf-8"
+                "wiki:\n  input: [wiki]\nsite:\n  layout: nonexistent.html\n", encoding="utf-8"
             )
             (wiki / "Page.md").write_text("# Page\n\nContent.", encoding="utf-8")
             result = runner.invoke(main, ["--config", str(root), "build", "--output-dir", str(output_dir)])
@@ -310,7 +310,7 @@ about: wiki:Alice_Theory
                 encoding="utf-8",
             )
             (root / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\n  assets: [assets]\n"
+                "wiki:\n  input: [wiki]\n  assets: [assets]\n"
                 "site:\n  layout: test_shell.html\n",
                 encoding="utf-8",
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ class TestCLI(unittest.TestCase):
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:
             # 1. Running check on empty directory conforms silently (success)
-            result = runner.invoke(main, ["--wiki-inputs", tmpdir, "check"])
+            result = runner.invoke(main, ["--input", tmpdir, "check"])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(result.output, "")
             
@@ -41,7 +41,7 @@ name: Invalid Page
 ---
 """, encoding="utf-8")
             
-            result_strict = runner.invoke(main, ["--wiki-inputs", tmpdir, "check", "--strict", "-v"])
+            result_strict = runner.invoke(main, ["--input", tmpdir, "check", "--strict", "-v"])
             self.assertEqual(result_strict.exit_code, 1)
             self.assertIn("Errors:", result_strict.output)
             self.assertIn("spaces are not allowed", result_strict.output)
@@ -62,7 +62,7 @@ name: Invalid Page
                 yaml.dump(
                     {
                         "wiki": {
-                            "inputs": ["wiki"],
+                            "input": ["wiki"],
                             "filename_pattern": r"[A-Za-z0-9_()-]+\.md",
                         },
                         "lint": {"filename_pattern": "warning"},
@@ -91,7 +91,7 @@ name: Invalid Page
             config_dir = Path(tmpdir)
             extra_dir = config_dir / "extra"
             extra_dir.mkdir()
-            (config_dir / "wiki.yaml").write_text("wiki:\n  inputs:\n    - wiki\n", encoding="utf-8")
+            (config_dir / "wiki.yaml").write_text("wiki:\n  input:\n    - wiki\n", encoding="utf-8")
             (extra_dir / "note.md").write_text(
                 "---\ntype: schema:WebPage\nname: Extra\n---\n",
                 encoding="utf-8",
@@ -102,7 +102,7 @@ name: Invalid Page
                 [
                     "-c",
                     str(config_dir),
-                    "--wiki-inputs",
+                    "--input",
                     "extra",
                     "query",
                     "--no-inference",
@@ -150,7 +150,7 @@ family_name: Anderson
 """, encoding="utf-8")
 
             # Without --fix: should FAIL SHACL because keys don't match expected schema:givenName/familyName.
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "check", str(file_path), "-v"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "check", str(file_path), "-v"])
             self.assertEqual(result.exit_code, 1)
             self.assertIn("SHACL Validation Violation", result.output)
             content = file_path.read_text(encoding="utf-8")
@@ -173,7 +173,7 @@ name: Valid File
 """, encoding="utf-8")
             
             # Conforming single file check
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "check", str(valid_file)])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "check", str(valid_file)])
             self.assertEqual(result.exit_code, 0)
             
             # Non-conforming single file check
@@ -184,7 +184,7 @@ type: schema:WebPage
 name: Invalid Name
 ---
 """, encoding="utf-8")
-            result_invalid = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "check", str(invalid_file), "--strict"])
+            result_invalid = runner.invoke(main, ["--input", str(wiki_dir), "check", str(invalid_file), "--strict"])
             self.assertEqual(result_invalid.exit_code, 1)
 
     def test_file_argument_accepts_multiple_paths(self) -> None:
@@ -203,7 +203,7 @@ name: Invalid Name
             wiki_dir = config_dir / "wiki"
             wiki_dir.mkdir()
             (config_dir / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": ["wiki"]}}),
+                yaml.dump({"wiki": {"input": ["wiki"]}}),
                 encoding="utf-8",
             )
             first = wiki_dir / "first.md"
@@ -232,7 +232,7 @@ name: Invalid Name
             wiki_dir = config_dir / "wiki"
             wiki_dir.mkdir()
             (config_dir / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": ["wiki"]}}),
+                yaml.dump({"wiki": {"input": ["wiki"]}}),
                 encoding="utf-8",
             )
             first = wiki_dir / "first.md"
@@ -269,7 +269,7 @@ name: Invalid Name
                 encoding="utf-8",
             )
             (config_dir / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": ["wiki"]}}),
+                yaml.dump({"wiki": {"input": ["wiki"]}}),
                 encoding="utf-8",
             )
             (wiki_dir / "Article_Shape.md").write_text(
@@ -318,18 +318,18 @@ familyName: Smith
             query_str = "SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }"
             
             # Table format
-            res_table = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", query_str])
+            res_table = runner.invoke(main, ["--input", str(wiki_dir), "query", "--no-inference", query_str])
             self.assertEqual(res_table.exit_code, 0)
             self.assertIn("Alice", res_table.output)
             
             # JSON format
-            res_json = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "-f", "json", "--no-inference", query_str])
+            res_json = runner.invoke(main, ["--input", str(wiki_dir), "query", "-f", "json", "--no-inference", query_str])
             self.assertEqual(res_json.exit_code, 0)
             parsed = json.loads(res_json.output)
             self.assertIn("results", parsed)
             
             # Error mode - invalid SPARQL syntax
-            res_err = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "INVALID QUERY"])
+            res_err = runner.invoke(main, ["--input", str(wiki_dir), "query", "INVALID QUERY"])
             self.assertEqual(res_err.exit_code, 1)
 
     def test_cli_query_jq_filter(self) -> None:
@@ -348,7 +348,7 @@ familyName: Smith
 
             # --jq auto-switches to JSON and extracts the value
             result = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
+                "--input", str(wiki_dir),
                 "query", "--no-inference", query_str,
                 "--jq", "results.bindings[].givenName.value"
             ])
@@ -357,7 +357,7 @@ familyName: Smith
 
             # --jq with no matches produces no output
             result_empty = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
+                "--input", str(wiki_dir),
                 "query", "--no-inference", query_str,
                 "--jq", "results.nonexistent"
             ])
@@ -379,7 +379,7 @@ familyName: Smith
             out_file = Path(tmpdir) / "results.json"
 
             result = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
+                "--input", str(wiki_dir),
                 "query", "--no-inference", query_str,
                 "-f", "json", "-o", str(out_file)
             ])
@@ -403,28 +403,28 @@ familyName: Smith
             query_str = "SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }"
 
             # CSV
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", "-f", "csv", query_str])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "query", "--no-inference", "-f", "csv", query_str])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
             # TSV (previously broken — now works with inline formatter)
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", "-f", "tsv", query_str])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "query", "--no-inference", "-f", "tsv", query_str])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
             # Markdown table
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", "-f", "markdown", query_str])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "query", "--no-inference", "-f", "markdown", query_str])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
             self.assertIn("|", res.output)
 
             # MIME alias — "text/csv" resolves to "csv"
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", "-f", "text/csv", query_str])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "query", "--no-inference", "-f", "text/csv", query_str])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
             # Case-insensitive — "JSON" accepted via case_sensitive=False
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", "-f", "JSON", query_str])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "query", "--no-inference", "-f", "JSON", query_str])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
@@ -448,7 +448,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
             file_path = wiki_dir / "gregory.md"
             file_path.write_text(source_content, encoding="utf-8")
             
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", "--no-inference", "-v"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "render", "--no-inference", "-v"])
             self.assertEqual(result.exit_code, 0)
             
             # Verify the SPARQL block was rendered and updated inline
@@ -474,7 +474,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
             file_path.write_text(source_content, encoding="utf-8")
             
             # 1. Check should FAIL because the table is missing (stale)
-            result_stale = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", "--no-inference", "--check"])
+            result_stale = runner.invoke(main, ["--input", str(wiki_dir), "render", "--no-inference", "--check"])
             self.assertEqual(result_stale.exit_code, 1)
             self.assertIn("Error: Inline SPARQL blocks are out of date", result_stale.output)
             
@@ -484,11 +484,11 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
             self.assertNotIn("Gregory", current_content.split("```")[-1])
             
             # 2. Now, actually render it
-            result_render = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", "--no-inference"])
+            result_render = runner.invoke(main, ["--input", str(wiki_dir), "render", "--no-inference"])
             self.assertEqual(result_render.exit_code, 0)
             
             # 3. Now, check should SUCCEED since it's up to date
-            result_clean = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", "--no-inference", "--check", "-v"])
+            result_clean = runner.invoke(main, ["--input", str(wiki_dir), "render", "--no-inference", "--check", "-v"])
             self.assertEqual(result_clean.exit_code, 0)
             self.assertIn("All dynamic SPARQL blocks are fully up to date", result_clean.output)
 
@@ -670,7 +670,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:
             with runner.isolated_filesystem(temp_dir=tmpdir):
-                Path("wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+                Path("wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
                 result = runner.invoke(
                     main,
                     ["init", "--graph-context-wiki", "https://wiki.example.org/"],
@@ -690,7 +690,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
     def test_config_rejects_unknown_html_template_key(self) -> None:
         with TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "wiki.yaml"
-            config_path.write_text("wiki:\n  inputs: [wiki]\nhtml_template: layouts/default.html\n", encoding="utf-8")
+            config_path.write_text("wiki:\n  input: [wiki]\nhtml_template: layouts/default.html\n", encoding="utf-8")
             with self.assertRaises(ValueError) as ctx:
                 Config.load(config_path)
             self.assertIn("unknown top-level keys: html_template", str(ctx.exception))
@@ -698,7 +698,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
     def test_config_rejects_unknown_wiki_page_layout_key(self) -> None:
         with TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "wiki.yaml"
-            config_path.write_text("wiki:\n  inputs: [wiki]\nwiki_page_layout: layouts/default.html\n", encoding="utf-8")
+            config_path.write_text("wiki:\n  input: [wiki]\nwiki_page_layout: layouts/default.html\n", encoding="utf-8")
             with self.assertRaises(ValueError) as ctx:
                 Config.load(config_path)
             self.assertIn("unknown top-level keys: wiki_page_layout", str(ctx.exception))
@@ -743,7 +743,7 @@ SELECT ?givenName WHERE {{ ?s <https://schema.org/givenName> ?givenName }}
             alpha.write_text(source.format(name="Alpha"), encoding="utf-8")
             beta.write_text(source.format(name="Beta"), encoding="utf-8")
 
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", str(alpha), "--no-inference"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "render", str(alpha), "--no-inference"])
             self.assertEqual(result.exit_code, 0)
 
             self.assertIn("Alpha", alpha.read_text(encoding="utf-8"))
@@ -774,7 +774,7 @@ SELECT ?givenName WHERE {{ ?s <https://schema.org/givenName> ?givenName }}
 
             result = runner.invoke(
                 main,
-                ["--wiki-inputs", str(wiki_dir), "render", str(person), "--no-inference"],
+                ["--input", str(wiki_dir), "render", str(person), "--no-inference"],
             )
             self.assertEqual(result.exit_code, 0)
 
@@ -788,7 +788,7 @@ SELECT ?givenName WHERE {{ ?s <https://schema.org/givenName> ?givenName }}
             record = wiki_dir / "person.yaml"
             record.write_text("type: Person\ngivenName: Gregory\n", encoding="utf-8")
 
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", str(record), "--no-inference"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "render", str(record), "--no-inference"])
             self.assertEqual(result.exit_code, 1)
             self.assertIn("only supports .md files", result.output)
 
@@ -807,8 +807,8 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 <!-- sparql:end -->
 """
             (wiki_dir / "gregory.md").write_text(source, encoding="utf-8")
-            runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", "--no-inference"])
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", "--no-inference", "-v"])
+            runner.invoke(main, ["--input", str(wiki_dir), "render", "--no-inference"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "render", "--no-inference", "-v"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("Updated 0 files", result.output)
 
@@ -830,7 +830,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 """
                 (wiki_dir / "gregory.md").write_text(source, encoding="utf-8")
 
-                result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "render", "--no-inference", "--cache"])
+                result = runner.invoke(main, ["--input", str(wiki_dir), "render", "--no-inference", "--cache"])
                 self.assertEqual(result.exit_code, 0)
                 cache_root = Path(".wiki") / "cache"
                 self.assertTrue(cache_root.exists())
@@ -852,7 +852,7 @@ familyName: Smith
 
             result = runner.invoke(
                 main,
-                ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", "--pretty", query_str],
+                ["--input", str(wiki_dir), "query", "--no-inference", "--pretty", query_str],
             )
             self.assertEqual(result.exit_code, 0)
             self.assertIn("givenName", result.output)
@@ -862,7 +862,7 @@ familyName: Smith
             result_output = runner.invoke(
                 main,
                 [
-                    "--wiki-inputs",
+                    "--input",
                     str(wiki_dir),
                     "query",
                     "--no-inference",
@@ -877,7 +877,7 @@ familyName: Smith
 
             result_json = runner.invoke(
                 main,
-                ["--wiki-inputs", str(wiki_dir), "query", "--no-inference", "--pretty", "-f", "json", query_str],
+                ["--input", str(wiki_dir), "query", "--no-inference", "--pretty", "-f", "json", query_str],
             )
             self.assertEqual(result_json.exit_code, 1)
             self.assertIn("table format", result_json.output)
@@ -897,14 +897,14 @@ givenName: Gregory
 """, encoding="utf-8")
             
             # Bulk export (raw default)
-            result_bulk = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export"])
+            result_bulk = runner.invoke(main, ["--input", str(wiki_dir), "export"])
             self.assertEqual(result_bulk.exit_code, 0)
             data_bulk = json.loads(result_bulk.output)
             self.assertEqual(len(data_bulk), 1)
             self.assertEqual(data_bulk[0]["rdf"]["givenName"], "Gregory")
             
             # Single file export (raw default)
-            result_single = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(valid_file)])
+            result_single = runner.invoke(main, ["--input", str(wiki_dir), "export", str(valid_file)])
             self.assertEqual(result_single.exit_code, 0)
             data_single = json.loads(result_single.output)
             self.assertEqual(data_single["rdf"]["givenName"], "Gregory")
@@ -912,7 +912,7 @@ givenName: Gregory
             # Single file export failure (no frontmatter)
             no_fm_file = wiki_dir / "no-fm.md"
             no_fm_file.write_text("Hello", encoding="utf-8")
-            result_fail = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(no_fm_file)])
+            result_fail = runner.invoke(main, ["--input", str(wiki_dir), "export", str(no_fm_file)])
             self.assertEqual(result_fail.exit_code, 1)
 
             second = wiki_dir / "alice.md"
@@ -923,7 +923,7 @@ givenName: Alice
 """, encoding="utf-8")
             result_multi = runner.invoke(
                 main,
-                ["--wiki-inputs", str(wiki_dir), "export", str(valid_file), str(second)],
+                ["--input", str(wiki_dir), "export", str(valid_file), str(second)],
             )
             self.assertEqual(result_multi.exit_code, 0)
             data_multi = json.loads(result_multi.output)
@@ -933,7 +933,7 @@ givenName: Alice
 
             result_raw_multi = runner.invoke(
                 main,
-                ["--wiki-inputs", str(wiki_dir), "export", "-f", "turtle", str(valid_file), str(second)],
+                ["--input", str(wiki_dir), "export", "-f", "turtle", str(valid_file), str(second)],
             )
             self.assertEqual(result_raw_multi.exit_code, 1)
             self.assertIn("single FILE", result_raw_multi.output)
@@ -947,16 +947,16 @@ givenName: Alice
             yaml_file.write_text("type: Person\ngivenName: Gregory\n", encoding="utf-8")
             json_file.write_text('{"type": "Person", "givenName": "Alice"}', encoding="utf-8")
 
-            result_bulk = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export"])
+            result_bulk = runner.invoke(main, ["--input", str(wiki_dir), "export"])
             self.assertEqual(result_bulk.exit_code, 0)
             data_bulk = json.loads(result_bulk.output)
             self.assertEqual(len(data_bulk), 2)
 
-            result_yaml = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(yaml_file)])
+            result_yaml = runner.invoke(main, ["--input", str(wiki_dir), "export", str(yaml_file)])
             self.assertEqual(result_yaml.exit_code, 0)
             self.assertEqual(json.loads(result_yaml.output)["rdf"]["givenName"], "Gregory")
 
-            result_json = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(json_file)])
+            result_json = runner.invoke(main, ["--input", str(wiki_dir), "export", str(json_file)])
             self.assertEqual(result_json.exit_code, 0)
             self.assertEqual(json.loads(result_json.output)["rdf"]["givenName"], "Alice")
     
@@ -975,7 +975,7 @@ about: wiki:Alice_Theory
 """, encoding="utf-8")
             
             # json-ld format returns expanded JSON-LD
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "json-ld"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "json-ld"])
             self.assertEqual(result.exit_code, 0)
             data = json.loads(result.output)
             self.assertIsInstance(data["rdf"], list)
@@ -983,7 +983,7 @@ about: wiki:Alice_Theory
             self.assertIn("https://schema.org/givenName", data["rdf"][0])
 
             # compacted JSON-LD includes @context and compacted predicates
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "json-ld", "--mode", "compacted"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "json-ld", "--mode", "compacted"])
             self.assertEqual(result.exit_code, 0)
             compacted = json.loads(result.output)
             self.assertIn("@context", compacted["rdf"])
@@ -992,18 +992,18 @@ about: wiki:Alice_Theory
             self.assertEqual(compacted["rdf"]["schema:about"]["@id"], "wiki:Alice_Theory")
             
             # turtle format returns raw serialized turtle (no JSON wrapper)
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "turtle", "--mode", "compacted"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "turtle", "--mode", "compacted"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("schema:givenName", result.output)  # turtle has prefix:name
             self.assertIn("Alice", result.output)
             
             # xml format returns raw serialized RDF/XML
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "xml"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "xml"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("rdf:Description", result.output)
             
             # nt format returns raw N-Triples
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "nt"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "nt"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("Alice", result.output)
             self.assertIn(".", result.output.strip()[-1])  # N-Triples ends with dot
@@ -1022,7 +1022,7 @@ familyName: Smith
 
             out_file = Path(tmpdir) / "export.json"
             result = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
+                "--input", str(wiki_dir),
                 "export", str(page),
                 "-o", str(out_file)
             ])
@@ -1045,7 +1045,7 @@ familyName: Smith
 ---""", encoding="utf-8")
 
             result = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
+                "--input", str(wiki_dir),
                 "export", str(page),
                 "-f", "turtle"
             ])
@@ -1066,22 +1066,22 @@ familyName: Smith
 ---""", encoding="utf-8")
 
             # N3
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "n3"])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "n3"])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
             # Trig
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "trig"])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "trig"])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
             # MIME alias — "text/n3" resolves to "n3"
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "text/n3"])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "text/n3"])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
             # Case-insensitive — "TURTLE" accepted
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "TURTLE"])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "TURTLE"])
             self.assertEqual(res.exit_code, 0)
             self.assertIn("Alice", res.output)
 
@@ -1097,7 +1097,7 @@ id: wiki:doc
 name: TestDoc
 ---""", encoding="utf-8")
 
-            res = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "export", str(page), "--format", "nquads"])
+            res = runner.invoke(main, ["--input", str(wiki_dir), "export", str(page), "--format", "nquads"])
             self.assertEqual(res.exit_code, 0)
             # Raw N-Quads output: angle-bracketed URIs, not JSON
             self.assertNotIn("{", res.output, msg="Raw nquads output should not be JSON")
@@ -1113,7 +1113,7 @@ name: TestDoc
             source_dir = root / ".wiki" / "sources" / "brain" / "repo" / "wiki"
             source_dir.mkdir(parents=True)
             (root / "wiki.yml").write_text("""wiki:
-  inputs:
+  input:
     - wiki
     - .wiki/sources/brain/repo/wiki
 sources:
@@ -1153,7 +1153,7 @@ sources:
             source_dir.mkdir(parents=True)
             (root / "wiki.yaml").write_text(
                 yaml.dump({
-                    "wiki": {"inputs": ["wiki", ".wiki/sources/brain/repo/wiki"]},
+                    "wiki": {"input": ["wiki", ".wiki/sources/brain/repo/wiki"]},
                     "site": {"base_url": "/wiki"},
                 }),
                 encoding="utf-8",
@@ -1222,7 +1222,7 @@ Bob was born.""", encoding="utf-8")
 
             output_dir = Path(tmpdir) / "_site"
 
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "build", "--output-dir", str(output_dir), "-v"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "build", "--output-dir", str(output_dir), "-v"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("Built", result.output)
 
@@ -1265,7 +1265,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
             output_dir = Path(tmpdir) / "_site"
 
             # Run build with --render and -v
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "build", "--output-dir", str(output_dir), "--render", "-v"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "build", "--output-dir", str(output_dir), "--render", "-v"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("Rendered SPARQL dynamic blocks", result.output)
 
@@ -1301,13 +1301,13 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
             render = runner.invoke(
                 main,
-                ["--wiki-inputs", str(wiki_dir), "render", "--no-inference", str(page)],
+                ["--input", str(wiki_dir), "render", "--no-inference", str(page)],
             )
             self.assertEqual(render.exit_code, 0)
 
             check = runner.invoke(
                 main,
-                ["--wiki-inputs", str(wiki_dir), "render", "--no-inference", "--check", str(page)],
+                ["--input", str(wiki_dir), "render", "--no-inference", "--check", str(page)],
             )
             self.assertEqual(check.exit_code, 0, check.output)
 
@@ -1340,7 +1340,7 @@ Bob was born.""", encoding="utf-8")
 
             output_dir = Path(tmpdir) / "_site"
 
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "build", "--output-dir", str(output_dir), "--site-url-style", "dir", "-v"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "build", "--output-dir", str(output_dir), "--site-url-style", "dir", "-v"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("Built", result.output)
 
@@ -1382,7 +1382,7 @@ Hello from [[alice]].""", encoding="utf-8")
 
             output_dir = Path(tmpdir) / "_site"
 
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "build", "--output-dir", str(output_dir), "--site-base-url", "/my-wiki"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "build", "--output-dir", str(output_dir), "--site-base-url", "/my-wiki"])
             self.assertEqual(result.exit_code, 0)
 
             alice_content = (output_dir / "my-wiki" / "alice" / "index.html").read_text()
@@ -1395,7 +1395,7 @@ Hello from [[alice]].""", encoding="utf-8")
     def test_cli_build_no_wiki_dir(self) -> None:
         """Test that wiki build errors when wiki directory missing."""
         runner = CliRunner()
-        result = runner.invoke(main, ["--wiki-inputs", "nonexistent", "build"])
+        result = runner.invoke(main, ["--input", "nonexistent", "build"])
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Error", result.output)
 
@@ -1408,7 +1408,7 @@ Hello from [[alice]].""", encoding="utf-8")
             wiki_dir.mkdir()
             page = wiki_dir / "page.md"
             page.write_text("# Page\n", encoding="utf-8")
-            (config_dir / "wiki.yaml").write_text("wiki:\n  inputs:\n    - wiki\n", encoding="utf-8")
+            (config_dir / "wiki.yaml").write_text("wiki:\n  input:\n    - wiki\n", encoding="utf-8")
 
             result = runner.invoke(main, [
                 "-c", str(config_dir),
@@ -1432,7 +1432,7 @@ Hello from [[alice]].""", encoding="utf-8")
             page.write_text("# Page\n", encoding="utf-8")
 
             result = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
+                "--input", str(wiki_dir),
                 "build",
                 "--output-dir", str(root),
                 "--site-base-url", "",
@@ -1452,7 +1452,7 @@ Hello from [[alice]].""", encoding="utf-8")
             page.write_text("# Page\n", encoding="utf-8")
 
             result = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
+                "--input", str(wiki_dir),
                 "build",
                 "--output-dir", str(wiki_dir),
                 "--site-base-url", "",
@@ -1463,7 +1463,7 @@ Hello from [[alice]].""", encoding="utf-8")
             self.assertTrue(page.exists())
 
     def test_global_raw_dir_flag(self) -> None:
-        """Test --wiki-inputs with multiple directories: loads files from both."""
+        """Test --input with multiple directories: loads files from both."""
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:
             config_dir = Path(tmpdir)
@@ -1472,7 +1472,7 @@ Hello from [[alice]].""", encoding="utf-8")
             raw_dir = config_dir / "raw"
             raw_dir.mkdir()
             (config_dir / "wiki.yaml").write_text("""wiki:
-  inputs:
+  input:
     - wiki
     - raw
 """, encoding="utf-8")
@@ -1498,7 +1498,7 @@ name: FromRaw
             self.assertIn("FromRaw", result.output)
 
     def test_global_import_dir_flag(self) -> None:
-        """Test repeatable --wiki-inputs: loads external .ttl into the graph."""
+        """Test repeatable --input: loads external .ttl into the graph."""
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:
             wiki_dir = Path(tmpdir) / "wiki"
@@ -1515,8 +1515,8 @@ ex:foo ex:bar "from-import-dir" .
 """, encoding="utf-8")
 
             result = runner.invoke(main, [
-                "--wiki-inputs", str(wiki_dir),
-                "--wiki-inputs", str(imports_dir),
+                "--input", str(wiki_dir),
+                "--input", str(imports_dir),
                 "query", "--no-inference",
                 "SELECT ?o WHERE { ?s <http://example.org/bar> ?o }",
                 "-f", "json",
@@ -1548,7 +1548,7 @@ Hello from server test.
             port = sock.getsockname()[1]
             sock.close()
 
-            config = Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+            config = Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
             server_thread = threading.Thread(
                 target=run_server,
                 args=(config,),
@@ -1588,7 +1588,7 @@ Custom base URL test.
             port = sock.getsockname()[1]
             sock.close()
 
-            config = Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+            config = Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
             server_thread = threading.Thread(
                 target=run_server,
                 args=(config,),
@@ -1619,7 +1619,7 @@ type: schema:WebPage
 id: wiki:doc
 name: ConfigTest
 ---""", encoding="utf-8")
-            (config_dir / "wiki.yaml").write_text("wiki:\n  inputs: ../wiki\n", encoding="utf-8")
+            (config_dir / "wiki.yaml").write_text("wiki:\n  input: ../wiki\n", encoding="utf-8")
 
             result = runner.invoke(main, [
                 "-c", str(config_dir),
@@ -1651,15 +1651,15 @@ name: ConfigTest
             guide = wiki_dir / "Guide.md"
             guide.write_text("# Guide\n\nRead the Wiki CLI guide.\n", encoding="utf-8")
 
-            report = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "link", "--check"])
+            report = runner.invoke(main, ["--input", str(wiki_dir), "link", "--check"])
             self.assertEqual(report.exit_code, 1)
             self.assertIn("Wiki CLI", report.output)
 
-            apply_result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "link", "--apply"])
+            apply_result = runner.invoke(main, ["--input", str(wiki_dir), "link", "--apply"])
             self.assertEqual(apply_result.exit_code, 0)
             self.assertIn("[Wiki CLI](wiki.md)", guide.read_text(encoding="utf-8"))
 
-            clean = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "link", "--check"])
+            clean = runner.invoke(main, ["--input", str(wiki_dir), "link", "--check"])
             self.assertEqual(clean.exit_code, 0)
 
 
@@ -1678,7 +1678,7 @@ name: ConfigTest
                 generic_dir = fake_templates_dir / "generic"
                 generic_dir.mkdir()
                 (generic_dir / "wiki.yml").write_text(
-                    "wiki:\n  inputs:\n    - wiki\n", encoding="utf-8"
+                    "wiki:\n  input:\n    - wiki\n", encoding="utf-8"
                 )
                 (generic_dir / "README.md").write_text(
                     "# Generic Wiki\n", encoding="utf-8"
@@ -1712,7 +1712,7 @@ name: ConfigTest
                 self.assertTrue(Path("README.md").exists())
                 self.assertTrue((Path("wiki") / "Page.md").exists())
                 content = Path("wiki.yml").read_text(encoding="utf-8")
-                self.assertIn("inputs:", content)
+                self.assertIn("input:", content)
                 self.assertIn("wiki", content)
 
     def test_cli_init_with_template_and_repo(self) -> None:
@@ -1729,7 +1729,7 @@ name: ConfigTest
                 generic_dir = fake_templates_dir / "generic"
                 generic_dir.mkdir()
                 (generic_dir / "wiki.yml").write_text(
-                    "wiki:\n  inputs:\n    - wiki\n", encoding="utf-8"
+                    "wiki:\n  input:\n    - wiki\n", encoding="utf-8"
                 )
                 (generic_dir / "README.md").write_text(
                     "# Generic Wiki\n", encoding="utf-8"
@@ -1767,7 +1767,7 @@ name: ConfigTest
         runner = CliRunner()
         with TemporaryDirectory() as tmpdir:
             with runner.isolated_filesystem(temp_dir=tmpdir):
-                Path("wiki.yml").write_text("wiki:\n  inputs:\n    - wiki\n", encoding="utf-8")
+                Path("wiki.yml").write_text("wiki:\n  input:\n    - wiki\n", encoding="utf-8")
                 result = runner.invoke(
                     main,
                     ["init", "--template", "generic"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,7 @@ from wiki.config import (
 )
 from wiki.schemas import FmtConfig
 
-MINIMAL_WIKI_YAML = "wiki:\n  inputs: [wiki]\n"
+MINIMAL_WIKI_YAML = "wiki:\n  input: [wiki]\n"
 
 
 class TestContext(unittest.TestCase):
@@ -54,7 +54,7 @@ class TestConfig(unittest.TestCase):
     def test_Config_default_init(self) -> None:
         """Test Config has proper defaults."""
         config = Config()
-        self.assertEqual(config.wiki.inputs, [config.config_root.absolute() / "wiki"])
+        self.assertEqual(config.wiki.input, [config.config_root.absolute() / "wiki"])
         self.assertEqual(config.wiki.assets, [])
         self.assertFalse(config.graph.include_file_extension)
         self.assertEqual(config.site.base_url, "/wiki")
@@ -71,7 +71,7 @@ class TestConfig(unittest.TestCase):
         """Test Config.load falls back to defaults when no files exist."""
         with TemporaryDirectory() as tmpdir:
             config = Config.load(Path(tmpdir))
-            self.assertEqual(config.wiki.inputs, [config.config_root.absolute() / "wiki"])
+            self.assertEqual(config.wiki.input, [config.config_root.absolute() / "wiki"])
 
     def test_Config_load_yaml(self) -> None:
         """Test Config.load correctly parses wiki.yaml."""
@@ -79,7 +79,7 @@ class TestConfig(unittest.TestCase):
             base_path = Path(tmpdir)
             yaml_content = {
                 "wiki": {
-                    "inputs": "custom_wiki",
+                    "input": "custom_wiki",
                     "assets": ["assets", "media/photos"],
                     "exclude": ["wiki/drafts/**", "assets/private/**"],
                     "filename_pattern": "[A-Za-z0-9_()-]+\\.md",
@@ -107,7 +107,7 @@ class TestConfig(unittest.TestCase):
             (base_path / "wiki.yaml").write_text(yaml.dump(yaml_content), encoding="utf-8")
 
             config = Config.load(base_path)
-            self.assertEqual(config.wiki.inputs, [base_path.absolute() / "custom_wiki"])
+            self.assertEqual(config.wiki.input, [base_path.absolute() / "custom_wiki"])
             self.assertEqual(config.wiki.assets, [base_path.absolute() / "assets", base_path.absolute() / "media/photos"])
             self.assertEqual(config.wiki.exclude, ["wiki/drafts/**", "assets/private/**"])
             self.assertEqual(config.check.missing_layout_file, "error")
@@ -250,7 +250,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             json_content = {
-                "wiki": {"inputs": "json_wiki"},
+                "wiki": {"input": "json_wiki"},
                 "graph": {
                     "@context": {
                         "json_pref": "http://json-pref.org/"
@@ -260,7 +260,7 @@ class TestConfig(unittest.TestCase):
             (base_path / "wiki.json").write_text(json.dumps(json_content), encoding="utf-8")
 
             config = Config.load(base_path)
-            self.assertEqual(config.wiki.inputs, [base_path.absolute() / "json_wiki"])
+            self.assertEqual(config.wiki.input, [base_path.absolute() / "json_wiki"])
             self.assertIn("json_pref", config.namespaces)
 
     def test_Config_load_camel_case_top_level_keys_raise_error(self) -> None:
@@ -287,7 +287,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "check": {"brokenLinks": "error"}}),
+                yaml.dump({"wiki": {"input": "wiki"}, "check": {"brokenLinks": "error"}}),
                 encoding="utf-8",
             )
 
@@ -298,7 +298,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "sparql_service": {"enable": True}}),
+                yaml.dump({"wiki": {"input": "wiki"}, "sparql_service": {"enable": True}}),
                 encoding="utf-8",
             )
 
@@ -309,7 +309,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "serve_api": {"enabled": True}}),
+                yaml.dump({"wiki": {"input": "wiki"}, "serve_api": {"enabled": True}}),
                 encoding="utf-8",
             )
 
@@ -340,7 +340,7 @@ class TestConfig(unittest.TestCase):
             (base_path / "wiki.yaml").write_text(
                 yaml.dump(
                     {
-                        "wiki": {"inputs": "wiki"},
+                        "wiki": {"input": "wiki"},
                         "check": {"filename_pattern": "warning", "broken_links": "warning"},
                     }
                 ),
@@ -360,7 +360,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "lint": {"broken_links": "error"}}),
+                yaml.dump({"wiki": {"input": "wiki"}, "lint": {"broken_links": "error"}}),
                 encoding="utf-8",
             )
 
@@ -371,7 +371,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "lint": {"brokenLinks": "error"}}),
+                yaml.dump({"wiki": {"input": "wiki"}, "lint": {"brokenLinks": "error"}}),
                 encoding="utf-8",
             )
 
@@ -405,7 +405,7 @@ class TestConfig(unittest.TestCase):
             (base_path / "wiki.yaml").write_text(
                 yaml.dump(
                     {
-                        "wiki": {"inputs": "wiki"},
+                        "wiki": {"input": "wiki"},
                         "fmt": {
                             "wrap": "no",
                             "extensions": ["gfm", "front_matters", "wikilink"],
@@ -422,7 +422,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "fmt": "custom.toml"}),
+                yaml.dump({"wiki": {"input": "wiki"}, "fmt": "custom.toml"}),
                 encoding="utf-8",
             )
             config = Config.load(base_path)
@@ -437,7 +437,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "fmt": absolute_fmt}),
+                yaml.dump({"wiki": {"input": "wiki"}, "fmt": absolute_fmt}),
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(ValueError, "fmt path must be relative"):
@@ -447,7 +447,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "fmt": True}),
+                yaml.dump({"wiki": {"input": "wiki"}, "fmt": True}),
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(ValueError, "fmt must be a mapping or path string"):
@@ -457,7 +457,7 @@ class TestConfig(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                yaml.dump({"wiki": {"inputs": "wiki"}, "fmt": {"typo_key": True}}),
+                yaml.dump({"wiki": {"input": "wiki"}, "fmt": {"typo_key": True}}),
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(ValueError, "Invalid key 'typo_key'"):
@@ -469,7 +469,7 @@ class TestConfig(unittest.TestCase):
             (base_path / "wiki.json").write_text(
                 json.dumps(
                     {
-                        "wiki": {"inputs": ["wiki"]},
+                        "wiki": {"input": ["wiki"]},
                         "fmt": {
                             "wrap": "no",
                             "extensions": ["gfm", "front_matters", "wikilink"],

--- a/tests/test_fmt.py
+++ b/tests/test_fmt.py
@@ -48,7 +48,7 @@ class TestWikiFmt(unittest.TestCase):
                 encoding="utf-8"
             )
 
-            result = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "fmt", "-v"])
+            result = runner.invoke(main, ["--input", str(wiki_dir), "fmt", "-v"])
             self.assertEqual(result.exit_code, 0)
             self.assertIn("Formatted unformatted.md", result.output)
 
@@ -68,7 +68,7 @@ class TestWikiFmt(unittest.TestCase):
             )
 
             # 1. Run with --check: should fail since it's not formatted
-            result_stale = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "fmt", "--check", "-v"])
+            result_stale = runner.invoke(main, ["--input", str(wiki_dir), "fmt", "--check", "-v"])
             self.assertEqual(result_stale.exit_code, 1)
             self.assertIn("Error: The following files are not correctly formatted:", result_stale.output)
             self.assertIn("unformatted.md", result_stale.output)
@@ -77,10 +77,10 @@ class TestWikiFmt(unittest.TestCase):
             self.assertEqual(file_path.read_text(encoding="utf-8"), "---\ntype: schema:WebPage\nname: Test\n---\n\n# Header\n\nSome text  \n")
 
             # 2. Run without --check to format it
-            runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "fmt"])
+            runner.invoke(main, ["--input", str(wiki_dir), "fmt"])
 
             # 3. Run with --check again: should succeed
-            result_clean = runner.invoke(main, ["--wiki-inputs", str(wiki_dir), "fmt", "--check", "-v"])
+            result_clean = runner.invoke(main, ["--input", str(wiki_dir), "fmt", "--check", "-v"])
             self.assertEqual(result_clean.exit_code, 0)
             self.assertIn("All files are correctly formatted.", result_clean.output)
 
@@ -129,7 +129,7 @@ class TestWikiFmt(unittest.TestCase):
                 "---\ntype: TechArticle\nname: Catalog page\n---\n\n# Shelf layout\n\nBody.",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             html = build_page_html(page, root, default_layout=write_layout(root, "layouts/fmt.html", seed_template))
@@ -207,7 +207,7 @@ class TestWikiFmt(unittest.TestCase):
             )
             file_path = nested / "page.md"
             file_path.write_text("# Title\n", encoding="utf-8")
-            config = Config(config_root=root, wiki={"inputs": [wiki]})
+            config = Config(config_root=root, wiki={"input": [wiki]})
             source = describe_fmt_source(file_path, config)
             self.assertIn(".mdformat.toml", source)
             self.assertIn("wiki", source.replace("\\", "/"))
@@ -222,7 +222,7 @@ class TestWikiFmt(unittest.TestCase):
             root = Path(tmpdir)
             (root / ".mdformat.toml").write_text(toml, encoding="utf-8")
             (root / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\nfmt: .mdformat.toml\n",
+                "wiki:\n  input: [wiki]\nfmt: .mdformat.toml\n",
                 encoding="utf-8",
             )
             file_path = root / "wiki" / "page.md"
@@ -242,7 +242,7 @@ class TestWikiFmt(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             (root / ".mdformat.toml").write_text(toml, encoding="utf-8")
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
             file_path = root / "wiki" / "page.md"
             file_path.parent.mkdir(parents=True)
             file_path.write_text("# Title\n\nSome text  \n", encoding="utf-8")
@@ -277,7 +277,7 @@ class TestWikiFmt(unittest.TestCase):
             pointer_root.mkdir()
             (pointer_root / ".mdformat.toml").write_text(toml, encoding="utf-8")
             (pointer_root / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\nfmt: .mdformat.toml\n",
+                "wiki:\n  input: [wiki]\nfmt: .mdformat.toml\n",
                 encoding="utf-8",
             )
             pointer_cfg = Config.load(pointer_root)
@@ -286,7 +286,7 @@ class TestWikiFmt(unittest.TestCase):
             omit_root = root / "omit"
             omit_root.mkdir()
             (omit_root / ".mdformat.toml").write_text(toml, encoding="utf-8")
-            (omit_root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (omit_root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
             omit_cfg = Config.load(omit_root)
             omit_out = format_markdown(original, file_path, omit_cfg)
 
@@ -297,7 +297,7 @@ class TestWikiFmt(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\nfmt:\n  wrap: no\n  end_of_line: lf\n"
+                "wiki:\n  input: [wiki]\nfmt:\n  wrap: no\n  end_of_line: lf\n"
                 '  extensions: ["gfm", "front_matters", "wikilink"]\n',
                 encoding="utf-8",
             )
@@ -307,7 +307,7 @@ class TestWikiFmt(unittest.TestCase):
     def test_fmt_absent_uses_wiki_cli_defaults(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
             file_path = root / "page.md"
             original = "# Title\n\nSome text  \n"
             file_path.write_text(original, encoding="utf-8")
@@ -324,7 +324,7 @@ class TestWikiFmt(unittest.TestCase):
             file_path = root / "page.md"
             original = "# Title\n\nSome text  \n"
             file_path.write_text(original, encoding="utf-8")
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
             absent_config = Config.load(root)
             empty_config = Config(config_root=root, fmt={})
             absent_out = format_markdown(original, file_path, absent_config)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -75,7 +75,7 @@ familyName: Smith
 ---""",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+            config = Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
             graph = load_graph(config, infer=False)
             result = graph.query(
                 "SELECT ?givenName ?familyName WHERE { ?s <https://schema.org/givenName> ?givenName ; "
@@ -90,7 +90,7 @@ class CompactJsonLdContextTest(unittest.TestCase):
     def test_compacted_json_ld_context_includes_only_used_prefixes(self) -> None:
         with TemporaryDirectory() as tmpdir:
             wiki_dir = Path(tmpdir)
-            config = Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+            config = Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
             frontmatter = {
                 "type": "TechArticle",
                 "headline": "wiki query",
@@ -126,7 +126,7 @@ familyName: Smith
 ---""",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+            config = Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
             graph = load_graph(config, infer=False)
             output = run_query(
                 graph,
@@ -139,7 +139,7 @@ familyName: Smith
     def test_pretty_table_format_empty_results(self) -> None:
         with TemporaryDirectory() as tmpdir:
             wiki_dir = Path(tmpdir)
-            config = Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+            config = Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
             graph = load_graph(config, infer=False)
             result = graph.query("SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }")
             self.assertEqual(pretty_table_format(result), "(no results)")

--- a/tests/test_frontmatter_schema.py
+++ b/tests/test_frontmatter_schema.py
@@ -97,7 +97,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\ntype: schema:Person\ngivenName: Ada\n---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config)
             self.assertEqual(missing, [])
@@ -123,7 +123,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config)
             self.assertEqual(missing, [])
@@ -157,7 +157,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config)
             self.assertEqual(missing, [])
@@ -181,7 +181,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\ntype: schema:Person\ngivenName: Ada\nfamilyName: Lovelace\n---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config)
             self.assertEqual(validation, [])
@@ -204,7 +204,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
             )
             invalid = wiki / "Invalid.md"
             invalid.write_text("---\ntype: schema:Person\ngivenName: Ada\n---\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config, file_paths=[invalid])
             self.assertEqual(missing, [])
@@ -247,7 +247,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\ntype: schema:Thing\n---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             with patch("wiki.frontmatter_schema.urlopen", return_value=FakeResponse()):
                 missing, validation = check_frontmatter_schema(config)
@@ -270,7 +270,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 encoding="utf-8",
             )
             config = Config(
-                wiki={"inputs": [wiki]},
+                wiki={"input": [wiki]},
                 config_root=root,
                 check={"remote_schema_refs": "deny"},
             )
@@ -296,7 +296,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 encoding="utf-8",
             )
             config = Config(
-                wiki={"inputs": [wiki]},
+                wiki={"input": [wiki]},
                 config_root=root,
                 check={
                     "remote_schema_refs": "allowlist",
@@ -349,7 +349,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 encoding="utf-8",
             )
             config = Config(
-                wiki={"inputs": [wiki]},
+                wiki={"input": [wiki]},
                 config_root=root,
                 check={
                     "remote_schema_refs": "allowlist",
@@ -379,7 +379,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                     "---\n",
                     encoding="utf-8",
                 )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             registry = build_type_schema_registry(config)
             self.assertEqual(registry["https://schema.org/Person"], ["schemas/person.json"])
 
@@ -409,7 +409,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 encoding="utf-8",
             )
             (wiki / "Broken.md").write_text("---\ntype: TechArticle\nheadline: Only\n---\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             results = run_check(config)
             self.assertFalse(results.ok)
@@ -467,7 +467,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             wiki = self._setup_severity_fixture(root)
-            base = {"wiki": {"inputs": [wiki]}, "config_root": root}
+            base = {"wiki": {"input": [wiki]}, "config_root": root}
 
             for severity, expect_errors, expect_warnings, expect_conforms in (
                 ("off", 0, 0, True),
@@ -497,7 +497,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             wiki = self._setup_severity_fixture(root)
-            base = {"wiki": {"inputs": [wiki]}, "config_root": root}
+            base = {"wiki": {"input": [wiki]}, "config_root": root}
 
             for severity, expect_errors, expect_warnings, expect_conforms in (
                 ("off", 0, 0, True),
@@ -537,7 +537,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
             root = Path(tmpdir)
             wiki = self._setup_severity_fixture(root)
             config = Config(
-                wiki={"inputs": [wiki]},
+                wiki={"input": [wiki]},
                 config_root=root,
                 check={"frontmatter_schema": "off", "missing_schema_ref": "off"},
             )
@@ -573,7 +573,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config)
             self.assertEqual(missing, [])
@@ -612,7 +612,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config)
             self.assertEqual(validation, [])
@@ -633,7 +633,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             missing, validation = check_frontmatter_schema(config)
             self.assertEqual(validation, [])
@@ -656,7 +656,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 "---\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             with patch(
                 "wiki.frontmatter_schema.Draft202012Validator",
@@ -682,7 +682,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 encoding="utf-8",
             )
             (wiki / "Page.md").write_text("---\ntype: schema:Thing\nlabel: ok\n---\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             def raise_http_error(*args, **kwargs):
                 raise HTTPError(
@@ -714,7 +714,7 @@ class TestFrontmatterSchemaValidation(unittest.TestCase):
                 encoding="utf-8",
             )
             (wiki / "Page.md").write_text("---\ntype: schema:Thing\nlabel: ok\n---\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             with patch("wiki.frontmatter_schema.urlopen", side_effect=TimeoutError):
                 missing, validation = check_frontmatter_schema(config)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -457,7 +457,7 @@ name: Raw Agent
 Raw Body Text.
 """, encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki, imports]})
+            config = Config(wiki={"input": [wiki, imports]})
             config.graph.content_predicate = "schema:text"
             
             # Load graph should not crash due to bad TTLs or broken syntax, and must ingest everything
@@ -497,7 +497,7 @@ name: Good Page
             bad_ttl = wiki / "broken.ttl"
             bad_ttl.write_text("UNPARSABLE GARBAGE", encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki]})
+            config = Config(wiki={"input": [wiki]})
 
             with self.assertLogs(graph_logger, level="WARNING") as log_cm:
                 g = load_graph(config, infer=False)
@@ -522,7 +522,7 @@ name: Good Page
             (wiki_dir / "gregory.yaml").write_text("type: Person\ngivenName: Gregory\n", encoding="utf-8")
             (wiki_dir / "alice.json").write_text('{"type": "Person", "givenName": "Alice"}', encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
             g = load_graph(config, infer=False)
 
             self.assertTrue((None, None, Literal("Bob")) in g)
@@ -564,7 +564,7 @@ name: Source Doc
                 )
             }).save(root / "wiki.lock")
 
-            config = Config(config_root=root, wiki={"inputs": [wiki_dir, source_dir]})
+            config = Config(config_root=root, wiki={"input": [wiki_dir, source_dir]})
             dataset = load_dataset(config, infer=False)
             source_uri = source_graph_uri(config, "brain")
 
@@ -599,7 +599,7 @@ name: Source Doc
                 )
             }).save(root / "wiki.lock")
 
-            config = Config(config_root=root, wiki={"inputs": [wiki_dir, source_dir]})
+            config = Config(config_root=root, wiki={"input": [wiki_dir, source_dir]})
             source_uri = source_graph_uri(config, "brain")
             load_dataset(config, infer=False, disk_cache=True)
             cached = load_dataset(config, infer=False, disk_cache=True)
@@ -629,7 +629,7 @@ name: Source Doc
                 )
             }).save(root / "wiki.lock")
 
-            config = Config(config_root=root, wiki={"inputs": [wiki_dir, source_dir]})
+            config = Config(config_root=root, wiki={"input": [wiki_dir, source_dir]})
             descriptors = graph_descriptors(config)
 
             self.assertEqual(descriptors[0].kind, "root")
@@ -663,7 +663,7 @@ name: Source Doc
 
             config = Config(
                 config_root=root,
-                wiki={"inputs": [wiki_dir, source_dir]},
+                wiki={"input": [wiki_dir, source_dir]},
                 sources=[{"name": "brain", "type": "git", "url": "https://example.com/brain.git"}],
             )
 
@@ -678,7 +678,7 @@ name: Source Doc
             source_dir = root / ".wiki" / "sources" / "brain" / "repo" / "wiki"
             source_dir.mkdir(parents=True)
 
-            config = Config(config_root=root, wiki={"inputs": [wiki_dir, source_dir]})
+            config = Config(config_root=root, wiki={"input": [wiki_dir, source_dir]})
             with self.assertLogs("wiki.graph", level="WARNING") as log_cm:
                 descriptors = graph_descriptors(config)
 
@@ -703,7 +703,7 @@ schema:location: wiki:Pokemon_Cartridge_Case
 ---
 """, encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
             g = load_graph(config, infer=False)
 
             place_uri = URIRef("https://wiki.example.org/Pokemon_Cartridge_Case")
@@ -722,7 +722,7 @@ name: Test Page
 ---
 """, encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki_dir]}, graph={"include_file_extension": True})
+            config = Config(wiki={"input": [wiki_dir]}, graph={"include_file_extension": True})
             g = load_graph(config, infer=False)
             expected = URIRef("https://wiki.example.org/test.md")
             self.assertTrue((expected, None, None) in g)
@@ -733,7 +733,7 @@ name: Test Page
             wiki_dir = Path(tmpdir)
             (wiki_dir / "person.yaml").write_text("type: Person\ngivenName: Test\n", encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki_dir]}, graph={"include_file_extension": True})
+            config = Config(wiki={"input": [wiki_dir]}, graph={"include_file_extension": True})
             g = load_graph(config, infer=False)
             expected = URIRef("https://wiki.example.org/person.yaml")
             self.assertTrue((expected, None, None) in g)
@@ -750,7 +750,7 @@ schema:familyName: Smith
 """, encoding="utf-8")
 
             config = Config(
-                wiki={"inputs": [wiki_dir]},
+                wiki={"input": [wiki_dir]},
                 graph={
                     "context": {
                         "@vocab": None,
@@ -803,7 +803,7 @@ sh:property:
 ---
 """, encoding="utf-8")
 
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
             data_graph = load_graph(config, infer=True)
             shapes_graph = load_shapes(data_graph)
 
@@ -827,7 +827,7 @@ name: Alice
 """, encoding="utf-8")
 
             config = Config(
-                wiki={"inputs": [wiki_dir]},
+                wiki={"input": [wiki_dir]},
                 graph={
                     "context": {
                         "@vocab": "https://custom.example.org/vocab/",

--- a/tests/test_graph_cache.py
+++ b/tests/test_graph_cache.py
@@ -27,7 +27,7 @@ class TestGraphCache(unittest.TestCase):
         clear_all_process_graphs()
 
     def _config(self, wiki_dir: Path) -> Config:
-        return Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+        return Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
 
     def test_second_load_reuses_cached_graph(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -94,8 +94,8 @@ class TestGraphCache(unittest.TestCase):
                 "---\ntype: Person\ngivenName: Ada\n---\n",
                 encoding="utf-8",
             )
-            config_a = Config(wiki={"inputs": [wiki_dir]}, graph={"base_iri": "https://a.example/"}, config_root=wiki_dir)
-            config_b = Config(wiki={"inputs": [wiki_dir]}, graph={"base_iri": "https://b.example/"}, config_root=wiki_dir)
+            config_a = Config(wiki={"input": [wiki_dir]}, graph={"base_iri": "https://a.example/"}, config_root=wiki_dir)
+            config_b = Config(wiki={"input": [wiki_dir]}, graph={"base_iri": "https://b.example/"}, config_root=wiki_dir)
 
             self.assertNotEqual(wiki_fingerprint(config_a), wiki_fingerprint(config_b))
 

--- a/tests/test_headings.py
+++ b/tests/test_headings.py
@@ -53,7 +53,7 @@ class TestHeadings(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
             warnings = lint_heading_levels(config)
 
             self.assertEqual(len(warnings), 1)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -32,7 +32,7 @@ givenName: Gregory
 """, encoding="utf-8")
             
             # 1. Configure and Load
-            config = Config(wiki={"inputs": [wiki_dir]})
+            config = Config(wiki={"input": [wiki_dir]})
             
             # Disable auto inference in loader to confirm pre/post state
             graph = load_graph(config, infer=False)

--- a/tests/test_init_scaffold.py
+++ b/tests/test_init_scaffold.py
@@ -210,7 +210,7 @@ INIT_OPTIONS_TO_CONFIG_PATH = {
     "site_layout": ("site", "layout"),
     "graph_content_predicate": ("graph", "content_predicate"),
     "link_style": ("link", "style"),
-    "wiki_inputs": ("wiki", "inputs"),
+    "wiki_inputs": ("wiki", "input"),
     "graph_base_iri": ("graph", "base_iri"),
     "graph_implicit_types": ("graph", "implicit_types"),
     "graph_implicit_types_policy": ("graph", "implicit_types_policy"),
@@ -220,6 +220,11 @@ INIT_OPTIONS_TO_CONFIG_PATH = {
 # Init-only CLI flags with no matching config path (used only during init).
 INIT_ONLY_OPTIONS: frozenset[str] = frozenset({"template"})
 
+# Fields whose flag does not follow the --kebab-case-of-field convention.
+# wiki_inputs stays snake internally (shape of the #227 rename) while its
+# Click flag is --input, not --wiki-inputs.
+FIELD_TO_FLAG_OVERRIDES: dict[str, str] = {"wiki_inputs": "--input"}
+
 
 class TestInitLockstep(TestCase):
     def test_init_options_fields_match_cli_options(self) -> None:
@@ -227,7 +232,7 @@ class TestInitLockstep(TestCase):
         from wiki.cli import init as init_cmd
         cli_option_names = {opt.opts[0] for opt in init_cmd.params if opt.opts}
         for field in InitOptions.model_fields.keys():
-            expected_opt = "--" + field.replace("_", "-")
+            expected_opt = FIELD_TO_FLAG_OVERRIDES.get(field, "--" + field.replace("_", "-"))
             # We allow options with both / and without / (e.g. --graph-include-file-extension/--no-graph-include-file-extension)
             # Click splits these but let's check prefix or inclusion
             found = False
@@ -318,7 +323,7 @@ class TestFetchTemplate(TestCase):
             generic_dir = fake_templates / "generic"
             generic_dir.mkdir()
             (generic_dir / "wiki.yml").write_text(
-                "wiki:\n  inputs:\n    - wiki\n", encoding="utf-8"
+                "wiki:\n  input:\n    - wiki\n", encoding="utf-8"
             )
             (generic_dir / "README.md").write_text(
                 "# Generic Wiki\n", encoding="utf-8"

--- a/tests/test_layout_context.py
+++ b/tests/test_layout_context.py
@@ -39,7 +39,7 @@ class TestLayoutContext(unittest.TestCase):
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "Bob.md").write_text("# Bob\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
 

--- a/tests/test_library_ops.py
+++ b/tests/test_library_ops.py
@@ -16,7 +16,7 @@ class TestLibraryOps(unittest.TestCase):
         root = Path(tmpdir.name)
         wiki_dir = root / "wiki"
         wiki_dir.mkdir()
-        (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+        (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
         page = wiki_dir / "Page.md"
         page.write_text(
             "---\ntype: schema:WebPage\nname: Page\n---\n\n# Page\n\nContent.\n",

--- a/tests/test_link_fix.py
+++ b/tests/test_link_fix.py
@@ -14,7 +14,7 @@ from wiki.link_fix import (
 class TestLinkFix(unittest.TestCase):
     def test_fixes_typo_slug_with_unique_fuzzy_match(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             (Path(tmpdir) / "target-page.md").write_text("content", encoding="utf-8")
             source = Path(tmpdir) / "source-page.md"
             source.write_text("See [[target-pag]] for details.\n", encoding="utf-8")
@@ -30,7 +30,7 @@ class TestLinkFix(unittest.TestCase):
     def test_link_renames_take_precedence(self) -> None:
         with TemporaryDirectory() as tmpdir:
             config = Config(
-                wiki={"inputs": [tmpdir]},
+                wiki={"input": [tmpdir]},
                 link={"renames": {"Old_Name": "New_Name"}},
             )
             (Path(tmpdir) / "New_Name.md").write_text("content", encoding="utf-8")
@@ -43,7 +43,7 @@ class TestLinkFix(unittest.TestCase):
 
     def test_skips_ambiguous_fuzzy_matches(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             (Path(tmpdir) / "ab-page.md").write_text("a", encoding="utf-8")
             (Path(tmpdir) / "ac-page.md").write_text("b", encoding="utf-8")
             Path(tmpdir, "source-page.md").write_text("See [[a-page]].\n", encoding="utf-8")
@@ -52,7 +52,7 @@ class TestLinkFix(unittest.TestCase):
 
     def test_remaining_broken_links_after_virtual_fix(self) -> None:
         with TemporaryDirectory() as tmpdir:
-            config = Config(wiki={"inputs": [tmpdir]})
+            config = Config(wiki={"input": [tmpdir]})
             (Path(tmpdir) / "target-page.md").write_text("content", encoding="utf-8")
             Path(tmpdir, "source-page.md").write_text(
                 "Broken [[target-pag]] and [[missing-page]].\n",

--- a/tests/test_link_suggest.py
+++ b/tests/test_link_suggest.py
@@ -18,7 +18,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "# Getting started\n\nRead the Wiki CLI guide before you begin.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             opportunities = find_link_opportunities(config)
 
@@ -38,7 +38,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "# Guide\n\nAlready linked [[Wiki_CLI]] and literal `Wiki CLI` in code.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             opportunities = find_link_opportunities(config)
 
@@ -54,7 +54,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "# Guide\n\nPages are served as HTML documents.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             opportunities = find_link_opportunities(config)
 
@@ -71,7 +71,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "# Guide\n\nInstall the Wiki CLI first.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             opportunities = find_link_opportunities(config)
 
@@ -90,7 +90,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "# Getting started\n\nRead the Wiki CLI guide before you begin.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             opportunities = find_link_opportunities(config)
             changed = apply_link_opportunities(config, opportunities, dry_run=False)
@@ -111,7 +111,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "---\ntype: TechArticle\n---\n\nInstall the Wiki CLI first.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             apply_link_opportunities(config, find_link_opportunities(config), dry_run=False)
 
@@ -130,7 +130,7 @@ class TestLinkSuggest(unittest.TestCase):
                 "# Getting started\n\nRead the Wiki CLI guide before you begin.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, link={"style": "wikilink"}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, link={"style": "wikilink"}, config_root=root)
 
             opportunities = find_link_opportunities(config)
             apply_link_opportunities(config, opportunities, dry_run=False)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -23,7 +23,7 @@ class TestWikiMcp(unittest.TestCase):
         wiki_dir = root / "docs" / "wiki"
         wiki_dir.mkdir(parents=True)
         (root / "docs" / "wiki.yml").write_text(
-            "wiki:\n  inputs: wiki\n",
+            "wiki:\n  input: wiki\n",
             encoding="utf-8",
         )
         (wiki_dir / "Alice.md").write_text(

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -27,7 +27,7 @@ class TestWikiPaths(unittest.TestCase):
             games.mkdir(parents=True)
             page = games / "Pokemon_Diamond_(copy_1).md"
             page.write_text("# Pokemon", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             self.assertEqual(route_for_document_file(config, page), "games/Pokemon_Diamond_(copy_1)")
 
@@ -41,7 +41,7 @@ class TestWikiPaths(unittest.TestCase):
             folder_index = games / "index.md"
             root_index.write_text("# Home", encoding="utf-8")
             folder_index.write_text("# Games", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             self.assertEqual(route_for_document_file(config, root_index), "")
             self.assertEqual(route_for_document_file(config, folder_index), "games")
@@ -64,7 +64,7 @@ class TestWikiPaths(unittest.TestCase):
             wiki.mkdir()
             (wiki / "Bad Page.md").write_text("# Bad", encoding="utf-8")
             (wiki / "Bad#Page.md").write_text("# Bad", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             issues = validate_route_safety(config)
             self.assertEqual(len(issues), 2)
@@ -87,7 +87,7 @@ class TestWikiPaths(unittest.TestCase):
             drafts.mkdir(parents=True)
             (wiki / "Published.md").write_text("# Published", encoding="utf-8")
             (drafts / "Draft.md").write_text("# Draft", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki], "exclude": ["wiki/drafts/**"]}, config_root=root)
+            config = Config(wiki={"input": [wiki], "exclude": ["wiki/drafts/**"]}, config_root=root)
 
             self.assertEqual([route.route for route in page_routes(config)], ["Published"])
 
@@ -99,7 +99,7 @@ class TestWikiPaths(unittest.TestCase):
             about.mkdir(parents=True)
             (wiki / "About.md").write_text("# About", encoding="utf-8")
             (about / "index.md").write_text("# About", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             entries = build_page_manifest(config, root / "_site" / "wiki", "/wiki", "dir")
             issues = detect_output_collisions(entries)
@@ -113,7 +113,7 @@ class TestWikiPaths(unittest.TestCase):
             wiki.mkdir(parents=True)
             (wiki / "About.md").write_text("# About", encoding="utf-8")
             (wiki / "About.yaml").write_text("type: Thing\nname: About data\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             entries = build_page_manifest(config, root / "_site" / "wiki", "/wiki", "dir")
             issues = detect_output_collisions(entries)
@@ -151,7 +151,7 @@ class TestWikiPaths(unittest.TestCase):
             games.mkdir()
             (people / "Ethan_Davidson.md").write_text("# Ethan\n\nSee [[../games/Pokemon_Diamond#Release History]].", encoding="utf-8")
             (games / "Pokemon_Diamond.md").write_text("# Pokemon\n\n## Release History", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             self.assertEqual(lint_broken_links(config), [])
 
@@ -162,7 +162,7 @@ class TestWikiPaths(unittest.TestCase):
             wiki.mkdir()
             (wiki / "A.md").write_text("# A\n\nSee [[B#Missing]].", encoding="utf-8")
             (wiki / "B.md").write_text("# B\n\n## Present", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             issues = lint_broken_links(config)
             self.assertEqual(len(issues), 1)
@@ -207,7 +207,7 @@ class TestWikiPaths(unittest.TestCase):
                 "---\nimage: ../assets/items/label.jpg\n---\n# Item\n\n![label](../assets/items/label.jpg)",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki], "assets": [root / "assets"]}, config_root=root)
+            config = Config(wiki={"input": [wiki], "assets": [root / "assets"]}, config_root=root)
 
             self.assertEqual(lint_broken_links(config), [])
 
@@ -219,7 +219,7 @@ class TestWikiPaths(unittest.TestCase):
             wiki.mkdir()
             assets.mkdir()
             (wiki / "Item.md").write_text("# Item\n\n[manual](../assets/missing.pdf)", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki], "assets": [assets]}, config_root=root)
+            config = Config(wiki={"input": [wiki], "assets": [assets]}, config_root=root)
 
             issues = lint_broken_links(config)
             self.assertEqual(len(issues), 1)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -45,7 +45,7 @@ SELECT ?givenName WHERE {
                 encoding="utf-8",
             )
             config = Config(
-                wiki={"inputs": [wiki_dir]},
+                wiki={"input": [wiki_dir]},
                 config_root=wiki_dir,
                 graph={
                     "context": {
@@ -91,7 +91,7 @@ SELECT ?givenName WHERE {
                 encoding="utf-8",
             )
             config = Config(
-                wiki={"inputs": [wiki_dir]},
+                wiki={"input": [wiki_dir]},
                 config_root=wiki_dir,
                 graph={
                     "context": {
@@ -140,7 +140,7 @@ SELECT ?graph ?name WHERE { GRAPH ?graph { ?s <https://schema.org/name> ?name } 
                 '"required_by":["root"]}}}',
                 encoding="utf-8",
             )
-            config = Config(config_root=root, wiki={"inputs": [wiki_dir, source_dir]})
+            config = Config(config_root=root, wiki={"input": [wiki_dir, source_dir]})
 
             render_markdown_files(
                 config,

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -69,7 +69,7 @@ _METADATA_TEMPLATE = """<!DOCTYPE html>
 
 def _serve_in_thread(wiki_dir: Path) -> Generator[int, None, None]:
     port = _free_port()
-    config = Config(wiki={"inputs": [wiki_dir]}, config_root=wiki_dir)
+    config = Config(wiki={"input": [wiki_dir]}, config_root=wiki_dir)
     server = create_server(config, host="127.0.0.1", port=port)
     t = threading.Thread(target=server.serve_forever, daemon=True)
     t.start()
@@ -90,7 +90,7 @@ def _serve_with_template(wiki_dir: Path, template: str = _RICH_TEMPLATE) -> Gene
     port = _free_port()
     template_path = write_layout(wiki_dir, "test_shell.html", template)
     config = Config(
-        wiki={"inputs": [wiki_dir]},
+        wiki={"input": [wiki_dir]},
         site={"layout": template_path},
         config_root=wiki_dir,
     )
@@ -144,7 +144,7 @@ class TestServe(unittest.TestCase):
 
     def test_index_links_use_config_file_url_style(self) -> None:
         self._write("hello-world.md", "# Hello World\n\nSome content.")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, site={"url_style": "file"}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, site={"url_style": "file"}, config_root=self.wiki_dir)
         port = _free_port()
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
@@ -349,7 +349,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 """
         page = self.wiki_dir / "gregory.md"
         page.write_text(source, encoding="utf-8")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, config_root=self.wiki_dir)
 
         site = refresh_wiki(config, changed_paths={page})
 
@@ -358,7 +358,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_sparql_endpoint_get_service_description_turtle(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
         port = _free_port()
         server = create_server(config, host="127.0.0.1", port=port)
         threading.Thread(target=server.serve_forever, daemon=True).start()
@@ -413,7 +413,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_sparql_endpoint_get_service_description_rdf_xml(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
         port = _free_port()
         server = create_server(config, host="127.0.0.1", port=port)
         threading.Thread(target=server.serve_forever, daemon=True).start()
@@ -440,7 +440,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_sparql_endpoint_get_select_json(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
         port = _free_port()
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
@@ -486,7 +486,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
             },
         }), encoding="utf-8")
         config = Config(
-            wiki={"inputs": [wiki_dir, source_dir]},
+            wiki={"input": [wiki_dir, source_dir]},
             sparql_service={"enabled": True},
             config_root=root,
         )
@@ -521,7 +521,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_sparql_endpoint_post_construct_turtle(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
         port = _free_port()
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
@@ -558,7 +558,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
     def test_sparql_endpoint_can_be_disabled(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
         port = _free_port()
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": False}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": False}, config_root=self.wiki_dir)
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
         t.start()
@@ -584,7 +584,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
     def test_sparql_endpoint_custom_path(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
         port = _free_port()
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/sparql"}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/sparql"}, config_root=self.wiki_dir)
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
         t.start()
@@ -609,7 +609,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_sparql_endpoint_rejects_update_queries(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
         port = _free_port()
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
@@ -643,7 +643,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_sparql_endpoint_allows_literals_with_update_keywords(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Delete\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True}, config_root=self.wiki_dir)
         port = _free_port()
         server = create_server(config, host="127.0.0.1", port=port)
         t = threading.Thread(target=server.serve_forever, daemon=True)
@@ -673,25 +673,25 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_sparql_endpoint_invalid_root_path_rejected(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/"}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/"}, config_root=self.wiki_dir)
         with self.assertRaisesRegex(ValueError, "shadow the entire server"):
             create_server(config, host="127.0.0.1", port=_free_port())
 
     def test_sparql_endpoint_invalid_base_url_path_rejected(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/wiki"}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/wiki"}, config_root=self.wiki_dir)
         with self.assertRaisesRegex(ValueError, "collides with page routes"):
             create_server(config, host="127.0.0.1", port=_free_port())
 
     def test_sparql_endpoint_invalid_page_subpath_rejected(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/wiki/foo"}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/wiki/foo"}, config_root=self.wiki_dir)
         with self.assertRaisesRegex(ValueError, "collides with page routes"):
             create_server(config, host="127.0.0.1", port=_free_port())
 
     def test_sparql_endpoint_invalid_watch_path_rejected(self) -> None:
         self._write("person.md", "---\ntype: Person\ngivenName: Alice\n---\n")
-        config = Config(wiki={"inputs": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/wiki/__watch"}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, sparql_service={"enabled": True, "path": "/wiki/__watch"}, config_root=self.wiki_dir)
         with self.assertRaisesRegex(ValueError, "collides with the watch endpoint"):
             create_server(config, host="127.0.0.1", port=_free_port())
 
@@ -719,7 +719,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
         refreshed_sites = [object(), object()]
         with patch("wiki.serve.refresh_wiki", side_effect=refreshed_sites) as refresh_mock, patch("wiki.serve.time.sleep", return_value=None):
             _watch_for_changes(
-                Config(wiki={"inputs": [self.wiki_dir]}, config_root=self.wiki_dir),
+                Config(wiki={"input": [self.wiki_dir]}, config_root=self.wiki_dir),
                 watch_dirs=watch_dirs,
                 base_url="/wiki",
                 url_style="dir",
@@ -750,7 +750,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
                 self.server_close_called = True
 
         fake_server = FakeServer()
-        config = Config(wiki={"inputs": [self.wiki_dir]}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, config_root=self.wiki_dir)
 
         with patch("wiki.serve.create_server", return_value=fake_server):
             run_server(config)
@@ -760,7 +760,7 @@ SELECT ?givenName WHERE { ?s <https://schema.org/givenName> ?givenName }
 
     def test_serve_does_not_mutate_loaded_config_site_overrides(self) -> None:
         runner = CliRunner()
-        config = Config(wiki={"inputs": [self.wiki_dir]}, site={"base_url": "/wiki", "url_style": "dir"}, config_root=self.wiki_dir)
+        config = Config(wiki={"input": [self.wiki_dir]}, site={"base_url": "/wiki", "url_style": "dir"}, config_root=self.wiki_dir)
 
         with patch("wiki.cli.Wiki.load", return_value=Wiki(config)), patch(
             "wiki.serve.run_server"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -49,7 +49,7 @@ class TestWikiSite(unittest.TestCase):
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "Bob.md").write_text("# Bob\n\n## Early Life\n\nBorn.\n\n## Early Life\n\nAgain.", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             site = build_site(config, base_url="/wiki", url_style="dir")
 
@@ -70,7 +70,7 @@ class TestWikiSite(unittest.TestCase):
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "Pokemon_Diamond_(copy_1).md").write_text("No heading.", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             site = build_site(config)
 
@@ -84,7 +84,7 @@ class TestWikiSite(unittest.TestCase):
             (wiki / "person.yaml").write_text("type: Person\nname: Gregory Davidson\n", encoding="utf-8")
             (wiki / "place.yml").write_text("type: Place\nname: Princeton\n", encoding="utf-8")
             (wiki / "index.md").write_text("# Home", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             site = build_site(config)
 
@@ -127,7 +127,7 @@ name: Bella Davidson
 """,
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             site = build_site(config, base_url="/wiki", url_style="dir")
             page = next(page for page in site.pages if page.full_slug == "Gregory_Davidson")
@@ -168,7 +168,7 @@ name: Project Atlas Record
 """,
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             site = build_site(config, base_url="/wiki", url_style="dir")
             page = next(page for page in site.pages if page.full_slug == "project")
@@ -196,7 +196,7 @@ name: Project Atlas
 """,
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             site = build_site(config, base_url="/wiki", url_style="dir")
             page = next(page for page in site.pages if page.full_slug == "project")
@@ -231,7 +231,7 @@ name: Project Atlas
                 "## Importance in the [[Semantic_Web|semantic web]]\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             page_layout = _full_test_layout(root)
@@ -343,7 +343,7 @@ name: Project Atlas
                 "# Page\n\n## Safe section\n\n### <script>alert(1)</script>\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             page_layout = _full_test_layout(root)
@@ -377,7 +377,7 @@ specialty: Diagnostics
 """,
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
 
             site = build_site(config, base_url="/wiki", url_style="dir")
             page = next(page for page in site.pages if page.full_slug == "person")
@@ -418,7 +418,7 @@ specialty: Diagnostics
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "Alice.md").write_text("# Alice\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             html = build_index_html(site, root)
             self.assertIn('<ul class="pages-list">', html)
@@ -458,7 +458,7 @@ specialty: Diagnostics
                 "# Content negotiation\n\nLead paragraph.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             self.assertIn("Lead paragraph.", page.html)
@@ -471,7 +471,7 @@ specialty: Diagnostics
             wiki = root / "wiki"
             wiki.mkdir()
             (root / "wiki.yaml").write_text(
-                "wiki:\n  inputs: [wiki]\ngraph:\n  context:\n    wiki: https://wiki.example.org/\n"
+                "wiki:\n  input: [wiki]\ngraph:\n  context:\n    wiki: https://wiki.example.org/\n"
                 "  context:\n    wiki: https://wiki.example.org/\n",
                 encoding="utf-8",
             )
@@ -496,7 +496,7 @@ specialty: Diagnostics
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "page.md").write_text("---\ntype: Article\n---\n\n# My Article\n\nContent.", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             html = build_page_html(page, root)
@@ -518,7 +518,7 @@ specialty: Diagnostics
                 "# Wiki CLI\n\nLead paragraph.\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             html = build_page_html(page, root, default_layout=_default_layout(root))
@@ -531,7 +531,7 @@ specialty: Diagnostics
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "page.md").write_text("# Page\n\nBody.", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             html = build_page_html(page, root, default_layout=_default_layout(root))
@@ -543,7 +543,7 @@ specialty: Diagnostics
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "page.md").write_text("# Page\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             index_html = build_index_html(site, root)
             self.assertIn("All Pages", index_html)
@@ -563,7 +563,7 @@ specialty: Diagnostics
                 "| `{metadata_pane_html}` | Metadata pane |\n",
                 encoding="utf-8",
             )
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             page = site.pages[0]
             html = build_page_html(page, root, default_layout=_default_layout(root))
@@ -578,14 +578,14 @@ specialty: Diagnostics
             (wiki / "alice.md").write_text("# Alice\n", encoding="utf-8")
             (wiki / "bob.md").write_text("# Bob\n", encoding="utf-8")
 
-            dir_config = Config(wiki={"inputs": [wiki]}, site={"url_style": "dir"}, config_root=root)
+            dir_config = Config(wiki={"input": [wiki]}, site={"url_style": "dir"}, config_root=root)
             dir_site = build_site(dir_config)
             dir_index = build_index_html(dir_site, root, base_url="/wiki", url_style=dir_config.site.url_style)
             self.assertIn('href="/wiki/alice/"', dir_index)
             self.assertIn('href="/wiki/bob/"', dir_index)
             self.assertNotIn(".html", dir_index)
 
-            file_config = Config(wiki={"inputs": [wiki]}, site={"url_style": "file"}, config_root=root)
+            file_config = Config(wiki={"input": [wiki]}, site={"url_style": "file"}, config_root=root)
             file_site = build_site(file_config)
             file_index = build_index_html(file_site, root, base_url="/wiki", url_style=file_config.site.url_style)
             self.assertIn('href="/wiki/alice.html"', file_index)
@@ -597,7 +597,7 @@ specialty: Diagnostics
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "Alice.md").write_text("# Alice\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             html = build_index_html(site, root, default_layout=_full_test_layout(root))
             self.assertNotIn("%wiki.", html)
@@ -610,7 +610,7 @@ specialty: Diagnostics
             wiki.mkdir()
             (wiki / "Person_A.md").write_text("---\ntype: Person\n---\n# Person A\n", encoding="utf-8")
             (wiki / "Plain.md").write_text("# Plain\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             html = build_index_html(site, root, default_layout=_full_test_layout(root))
             article_start = html.index('<article id="article-top">')
@@ -626,7 +626,7 @@ specialty: Diagnostics
             wiki.mkdir()
             (wiki / "page.md").write_text("# Page\n", encoding="utf-8")
             config = Config(
-                wiki={"inputs": [wiki]},
+                wiki={"input": [wiki]},
                 site={"base_url": "/wiki"},
                 config_root=root,
             )
@@ -650,7 +650,7 @@ specialty: Diagnostics
             wiki = root / "wiki"
             wiki.mkdir()
             (wiki / "page.md").write_text("# Page\n", encoding="utf-8")
-            config = Config(wiki={"inputs": [wiki]}, config_root=root)
+            config = Config(wiki={"input": [wiki]}, config_root=root)
             site = build_site(config)
             html = build_index_html(
                 site,

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -184,7 +184,7 @@ class TestConfigSources(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
             yaml_content = {
-                "wiki": {"inputs": "wiki"},
+                "wiki": {"input": "wiki"},
                 "sources": [
                     {"name": "taxonomy", "type": "git", "url": "https://example.com/taxonomy.git", "ref": "v1.0"},
                     {"name": "community", "type": "git", "url": "https://example.com/community.git"},
@@ -201,7 +201,7 @@ class TestConfigSources(unittest.TestCase):
             base_path = Path(tmpdir)
             (base_path / "wiki.yaml").write_text(
                 yaml.dump({
-                    "wiki": {"inputs": "wiki"},
+                    "wiki": {"input": "wiki"},
                     "sources": [{"name": "bad", "type": "git", "url": "https://x.com", "extra": True}],
                 }),
                 encoding="utf-8",
@@ -257,7 +257,7 @@ class TestDiscoverSources(unittest.TestCase):
     def test_no_sources_block(self) -> None:
         with TemporaryDirectory() as tmpdir:
             (Path(tmpdir) / "wiki.yml").write_text(
-                yaml.dump({"wiki": {"inputs": "pages"}}), encoding="utf-8"
+                yaml.dump({"wiki": {"input": "pages"}}), encoding="utf-8"
             )
             sources = _discover_sources(Path(tmpdir))
             self.assertEqual(sources, [])
@@ -266,7 +266,7 @@ class TestDiscoverSources(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             (Path(tmpdir) / "wiki.yml").write_text(
                 yaml.dump({
-                    "wiki": {"inputs": "pages"},
+                    "wiki": {"input": "pages"},
                     "sources": [
                         {"name": "dep-a", "type": "git", "url": "https://example.com/a.git"},
                         {"name": "dep-b", "type": "git", "url": "https://example.com/b.git", "ref": "v1.0"},
@@ -322,7 +322,7 @@ def _make_mock_git(
         if deps:
             (repo_dir / "wiki.yml").write_text(
                 yaml.dump({
-                    "wiki": {"inputs": "pages"},
+                    "wiki": {"input": "pages"},
                     "sources": [d.model_dump() for d in deps],
                 }),
                 encoding="utf-8",
@@ -346,7 +346,7 @@ class TestInstallTree(unittest.TestCase):
     def _make_config(self, root: Path, sources: list[dict]) -> Config:
         return Config(
             config_root=root,
-            wiki={"inputs": ["wiki"]},
+            wiki={"input": ["wiki"]},
             sources=sources,
         )
 
@@ -533,7 +533,7 @@ class TestRemoveOrphans(unittest.TestCase):
     def _make_config(self, root: Path, sources: list[dict]) -> Config:
         return Config(
             config_root=root,
-            wiki={"inputs": ["wiki"]},
+            wiki={"input": ["wiki"]},
             sources=sources,
         )
 

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -27,7 +27,7 @@ class TestWiki(unittest.TestCase):
             wiki_dir = root / "wiki"
             wiki_dir.mkdir()
             (wiki_dir / "Page.md").write_text("# Page\n\nContent.", encoding="utf-8")
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
 
             wiki = Wiki.load(root)
             with patch("wiki.wiki._run_check", return_value=AuditReport.empty()) as mock_check:
@@ -42,7 +42,7 @@ class TestWiki(unittest.TestCase):
             wiki_dir.mkdir()
             page = wiki_dir / "Page.md"
             page.write_text("---\ntype: schema:WebPage\n---\n", encoding="utf-8")
-            (root / "wiki.yaml").write_text("wiki:\n  inputs: [wiki]\n", encoding="utf-8")
+            (root / "wiki.yaml").write_text("wiki:\n  input: [wiki]\n", encoding="utf-8")
 
             wiki = Wiki.load(root)
             with patch("wiki.wiki._run_check", return_value=AuditReport.empty()) as mock_check:
@@ -51,7 +51,7 @@ class TestWiki(unittest.TestCase):
             self.assertIsNotNone(kwargs.get("file_paths"))
 
     def test_with_runtime_overrides_site(self) -> None:
-        config = Config(wiki={"inputs": [Path("/tmp/wiki")]}, site={"base_url": "/wiki"})
+        config = Config(wiki={"input": [Path("/tmp/wiki")]}, site={"base_url": "/wiki"})
         wiki = Wiki(config)
         runtime = wiki.with_runtime(base_url="/custom", url_style="file")
         self.assertEqual(runtime.config.site.base_url, "/custom")
@@ -59,7 +59,7 @@ class TestWiki(unittest.TestCase):
         self.assertEqual(wiki.config.site.base_url, "/wiki")
 
     def test_preflight_merges_lint_and_check(self) -> None:
-        config = Config(wiki={"inputs": [Path("/tmp/wiki")]})
+        config = Config(wiki={"input": [Path("/tmp/wiki")]})
         wiki = Wiki(config)
         lint_report = AuditReport(
             warnings=[Issue(code="headings", message="warn", severity="warning")],

--- a/tests/test_wiki_links.py
+++ b/tests/test_wiki_links.py
@@ -9,7 +9,7 @@ from wiki.wiki_links import LinkIndex
 
 class TestVaultLinks(unittest.TestCase):
     def _config(self, root: Path, wiki: Path) -> Config:
-        return Config(wiki={"inputs": [wiki]}, config_root=root)
+        return Config(wiki={"input": [wiki]}, config_root=root)
 
     def test_wikilink_backlink(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Fixes #227

# Rename `--wiki-inputs` → `--input` and `wiki.inputs` → `wiki.input`

Landing shape (b): public surface renamed end-to-end (Click flags, config key, JSON-schema aliases, generated + hand-authored TS), Python parameter/field names stay `wiki_inputs` (no builtin shadowing, no churn).

## Stress test: four tamper negatives (throwaway edits, captured + restored)

Each partial-rename direction fires its gate with exit 1 and precise diagnostics:

| Tamper | What was changed | Gate fired | Result |
|---|---|---|---|
| 1. Click-only | Both `--wiki-inputs` defs → `--input` in `cli.py`, TS untouched | **Stage 4** | `args()`/`init()` emit `--wiki-inputs`, not a real opt of `wiki (root)`/`init` |
| 2. Wrapper-only | Both `wiki.ts` emissions → `--input`, Click untouched | **Stage 4** | Emitted flag not in Click opts (opposite direction) |
| 3. Alias-only | `InitOptions` alias → `input` without regenerating | **Stage 3** | Generated types freshness failure |
| 4. Config-only | `wiki.inputs` → `wiki.input` alone | **Stage 5** | 24 config-key reference failures across template + docs |

## The rename (one atomic change, 63 files, +559/−391)

- **Click flags**: root + init `--wiki-inputs` → `--input` (`src/wiki/cli.py`)
- **Model aliases**: `MainOptions`/`InitOptions` `wikiInputs` → `input` aliases + descriptions (`schemas/cli.py`, `schemas/init.py`) — regeneration propagates to `types.generated.ts`
- **Config key**: `wiki.inputs` → `wiki.input` (`wiki_config.py` field + validator, template, `site/build.py`, all consumers)
- **TS**: `wiki.ts` flag strings + `wikiInputs` → `input` refs, `WikiLoadOptions` in `types.ts`, regenerated types
- **Tests/docs/skills**: fixtures, YAML strings, argv assertions, wiki_init docs, README, skills references
- **CHANGELOG Migration entry** added (breaking: `WikiLoadOptions.wikiInputs` → `input`)

## Verification

- **Drift (5 stages) green**: `15 commands mirrored; 63 wrapper flag emissions verified` against `--input`; `247 config-key references verified` against `wiki.input`
- **Static gates**: ruff clean, eslint clean, prettier clean, docs gates (fmt/lint/check/render) all green
- **Empirical CLI**: `wiki --help` / `wiki init --help` show `--input`; fresh scaffold emits `input: [wiki]`
- **Tests**: 545/545 unit tests, `test:npm` green
