### PR TITLE
chore: release v0.1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.23 — 2026-09-04
+
 ### Changed
 
 - Renamed the `--wiki-inputs` CLI flag to `--input` and the `wiki.inputs`

--- a/docs/wiki/wiki.md
+++ b/docs/wiki/wiki.md
@@ -1,7 +1,7 @@
 ---
 type: schema:SoftwareApplication
 name: wiki
-softwareVersion: 0.1.22
+softwareVersion: 0.1.23
 description: Command-line interface for querying, validating, and publishing semantic markdown wikis.
 codeRepository: https://github.com/wazootech/wiki
 ---

--- a/docs/wiki/wiki_render.md
+++ b/docs/wiki/wiki_render.md
@@ -89,7 +89,7 @@ ORDER BY ?name
 | [Linked_Markdown](Linked_Markdown.md) | Linked Markdown |  |
 | [Obsidian](Obsidian.md) | Obsidian |  |
 | [Vivary](Vivary.md) | Vivary | 0.1.0 |
-| [wiki](wiki.md) | wiki | 0.1.22 |
+| [wiki](wiki.md) | wiki | 0.1.23 |
 
 <!-- sparql:end -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wazootech-wiki",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wazootech-wiki",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazootech-wiki",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Clean, pure, idiomatic CLI for managing a semantic LLM wiki",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wazootech-wiki"
-version = "0.1.22"
+version = "0.1.23"
 description = "Clean, pure, idiomatic Python CLI for managing a semantic LLM wiki"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -19,7 +19,7 @@ from .schemas import (
 )
 from .wiki import Wiki
 
-__version__ = "0.1.22"
+__version__ = "0.1.23"
 
 __all__ = [
     "__version__",

--- a/uv.lock
+++ b/uv.lock
@@ -1186,7 +1186,7 @@ wheels = [
 
 [[package]]
 name = "wazootech-wiki"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Ships the #227 breaking rename (`--wiki-inputs` → `--input`, `wiki.inputs` → `wiki.input`, TS `wikiInputs` → `input`) plus the docs/drift work since v0.1.22.

- Version bumped 0.1.22 → 0.1.23 across all enforced surfaces
- CHANGELOG 0.1.23 section carries the #227 migration entry
- Verified: ruff clean, 545/545 pytest, npm regression green, all four docs gates green

Merge, then the v0.1.23 tag is pushed at the merged commit to trigger the Release workflow (PyPI/npm/GitHub Release).