### PR TITLE
fix(sources): make update/remove work for git sources on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
   GitHub's `macos-13` runner pool is unavailable; the README download list
   reflects the current set.
 
+### Fixed
+
+- `wiki update` now works for unpinned git sources: the cache clone is
+  detached before fetching so git no longer refuses to update its own
+  checked-out branch, and the working tree is re-checked-out afterward.
+  ([#298](https://github.com/wazootech/wiki/issues/298))
+- `wiki remove` no longer crashes on Windows when read-only git object
+  files block cache deletion, and it removes the cache first so a failure
+  leaves `wiki.yml` and `wiki.lock` consistent.
+  ([#299](https://github.com/wazootech/wiki/issues/299))
+
 ## 0.1.23 — 2026-09-04
 
 ### Changed

--- a/src/wiki/sources.py
+++ b/src/wiki/sources.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
+import stat
 import subprocess
 import tomllib
 from dataclasses import dataclass, field
@@ -122,6 +124,22 @@ def _git_clone_or_fetch(source: SourceConfig, cache_dir: Path) -> Path:
                 "Updated remote URL for source from %s to %s",
                 url_result.stdout.strip(),
                 source.url,
+            )
+
+        # The cache repo may have a local branch checked out (the default
+        # branch from the initial clone). Fetching into refs/heads/* is
+        # refused by git when it would update the currently checked-out
+        # branch, so detach HEAD first; _git_prepare_ref re-attaches and
+        # re-checks-out the working tree afterward.
+        detach = subprocess.run(
+            ["git", "checkout", "--detach"],
+            capture_output=True,
+            text=True,
+            cwd=repo_dir,
+        )
+        if detach.returncode != 0:
+            raise RuntimeError(
+                f"Failed to prepare {source.url}: {detach.stderr.strip()}"
             )
 
         result = subprocess.run(
@@ -614,6 +632,22 @@ def update(
     return result
 
 
+def _rmtree_force(path: Path) -> None:
+    """Remove a directory tree, clearing the read-only attribute as needed.
+
+    Git object files are created read-only, and ``shutil.rmtree`` cannot
+    delete read-only files on Windows (PermissionError: [WinError 5]);
+    POSIX unlinks them regardless. Clear the write bit and retry any
+    failed entry so removals behave the same on both platforms.
+    """
+
+    def _clear_readonly(func: Any, entry: Path, exc_info: object) -> None:
+        os.chmod(entry, stat.S_IWRITE)
+        func(entry)
+
+    shutil.rmtree(path, onerror=_clear_readonly)
+
+
 def _remove_orphans(
     config: Config, lockfile: Lockfile, removed_name: str
 ) -> None:
@@ -641,7 +675,7 @@ def _remove_orphans(
     for orphan in orphaned:
         cache_dir = _source_cache_dir(config, orphan)
         if cache_dir.exists():
-            shutil.rmtree(cache_dir)
+            _rmtree_force(cache_dir)
             logger.info("Removed cache for orphaned transitive source %r", orphan)
         del lockfile.sources[orphan]
         logger.info(
@@ -656,13 +690,18 @@ def remove(config: Config, name: str) -> None:
     Transitive dependencies that are no longer required by any remaining
     top-level source are automatically cleaned up (cache and lockfile
     entry removed).
-    """
-    _remove_from_wiki_yml(config, name)
 
+    The cache deletion is the step most likely to fail (read-only files on
+    Windows, antivirus locks), so it runs first: a failure then leaves
+    wiki.yml and wiki.lock untouched and consistent, and the source can be
+    re-installed cleanly.
+    """
     cache_dir = _source_cache_dir(config, name)
     if cache_dir.exists():
-        shutil.rmtree(cache_dir)
+        _rmtree_force(cache_dir)
         logger.info("Removed cache for source %r", name)
+
+    _remove_from_wiki_yml(config, name)
 
     lockfile = _load_lockfile(config)
     if name in lockfile.sources:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,4 +1,7 @@
 import json
+import os
+import shutil
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -13,6 +16,9 @@ from wiki.sources import (
     _expand_source_url,
     _install_tree,
     _remove_orphans,
+    install,
+    remove,
+    update,
 )
 
 
@@ -631,6 +637,138 @@ class TestRemoveOrphans(unittest.TestCase):
             self.assertFalse((root / ".wiki" / "sources" / "B").exists())
             # A's cache is still there (the caller removed A separately)
             self.assertTrue((root / ".wiki" / "sources" / "A").exists())
+
+
+class TestSourceGitLifecycle(unittest.TestCase):
+    """End-to-end install → update → remove against real git repos.
+
+    Regression coverage for two shipped bugs:
+
+    * ``wiki update`` failing on unpinned sources because the cache clone's
+      mirror fetch tried to update its own checked-out branch, which git
+      refuses ("refusing to fetch into branch ... checked out at ...").
+    * ``wiki remove`` crashing on Windows where read-only git object files
+      block ``shutil.rmtree`` with PermissionError.
+    """
+
+    @unittest.skipUnless(shutil.which("git"), "git executable not available")
+    def test_install_update_remove_unpinned_source(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "root"
+            src = Path(tmpdir) / "src"
+            initial = self._init_source(src)
+            config = self._root_config(root)
+
+            installed = install(config, url=src.as_posix())
+            name = src.name
+            self.assertIn(name, installed.sources)
+            self.assertEqual(installed.sources[name].resolved_ref, initial)
+            repo_dir = root / ".wiki" / "sources" / name / "repo"
+            self.assertTrue(repo_dir.exists())
+            self.assertEqual(
+                (repo_dir / "data.txt").read_text(encoding="utf-8"), "v1\n"
+            )
+
+            # A newer upstream commit must be picked up by update. This
+            # used to raise "Failed to fetch ... refusing to fetch into
+            # branch" for unpinned sources.
+            new = self._commit(src, "v2\n")
+            result = update(config)
+            self.assertEqual([u.name for u in result.changed], [name])
+            relocked = Lockfile.load(root / "wiki.lock")
+            self.assertEqual(relocked.sources[name].resolved_ref, new)
+            # The working tree advanced, not just the lockfile entry.
+            self.assertEqual(
+                (repo_dir / "data.txt").read_text(encoding="utf-8"), "v2\n"
+            )
+
+            # A second update with nothing new upstream is a no-op.
+            self.assertEqual(update(config).changed, [])
+
+            # Removal cleans wiki.yml, wiki.lock, and the cache directory.
+            remove(config, name)
+            self.assertFalse(repo_dir.exists())
+            self.assertNotIn(name, Lockfile.load(root / "wiki.lock").sources)
+            self.assertNotIn(
+                "sources", (root / "wiki.yml").read_text(encoding="utf-8")
+            )
+
+    @unittest.skipUnless(shutil.which("git"), "git executable not available")
+    def test_install_update_pinned_branch_source(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "root"
+            src = Path(tmpdir) / "src"
+            self._init_source(src)
+            config = self._root_config(root)
+
+            installed = install(config, url=f"{src.as_posix()}#main")
+            self.assertIn(src.name, installed.sources)
+
+            new = self._commit(src, "v2\n")
+            result = update(config)
+            self.assertEqual([u.name for u in result.changed], [src.name])
+            relocked = Lockfile.load(root / "wiki.lock")
+            self.assertEqual(relocked.sources[src.name].resolved_ref, new)
+
+    @unittest.skipUnless(shutil.which("git"), "git executable not available")
+    def test_remove_survives_read_only_cache_files(self) -> None:
+        """Removal clears read-only attributes on cache files (Windows)."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "root"
+            src = Path(tmpdir) / "src"
+            self._init_source(src)
+            config = self._root_config(root)
+            install(config, url=src.as_posix())
+            name = src.name
+
+            cache_dir = root / ".wiki" / "sources" / name
+            for p in cache_dir.rglob("*"):
+                if p.is_file():
+                    os.chmod(p, 0o444)
+
+            remove(config, name)
+            self.assertFalse(cache_dir.exists())
+            self.assertNotIn(name, Lockfile.load(root / "wiki.lock").sources)
+            self.assertNotIn(
+                name, (root / "wiki.yml").read_text(encoding="utf-8")
+            )
+
+    def _root_config(self, root: Path) -> Config:
+        root.mkdir(parents=True)
+        (root / "wiki.yml").write_text(
+            yaml.dump({"wiki": {"input": "pages"}}), encoding="utf-8"
+        )
+        return Config.load(root)
+
+    def _init_source(self, src: Path) -> str:
+        src.mkdir(parents=True)
+        self._git(src, "init", "-b", "main")
+        (src / "wiki.yml").write_text(
+            yaml.dump({"wiki": {"input": "pages"}}), encoding="utf-8"
+        )
+        return self._commit(src, "v1\n", message="init")
+
+    def _commit(self, repo: Path, content: str, message: str = "update") -> str:
+        (repo / "data.txt").write_text(content, encoding="utf-8")
+        self._git(repo, "add", "-A")
+        self._git(
+            repo,
+            "-c", "user.name=Test",
+            "-c", "user.email=test@example.com",
+            "-c", "commit.gpgsign=false",
+            "commit", "-m", message,
+        )
+        return self._git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    def _git(self, repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ["git", *args], cwd=repo, capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"git {' '.join(args)} failed: {result.stderr.strip()}"
+            )
+        return result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #298 and Fixes #299 — two source-management bugs found by end-to-end smoke testing the published package.

## What's broken
1. **`wiki update` fails on unpinned git sources** (#298): after `wiki install <url>` the cache clone (`.wiki/sources/<name>/repo`) keeps its default branch checked out, so the mirror fetch `+refs/heads/*:refs/heads/*` is refused by git — `fatal: refusing to fetch into branch 'refs/heads/main' checked out at ...`. Pinned branch refs hit the same wall; pinned commit SHAs only work because `_git_prepare_ref` leaves HEAD detached.
2. **`wiki remove` crashes on Windows** (#299): git object files are read-only, and `shutil.rmtree` can't delete them on Windows (`PermissionError: [WinError 5]`). `remove()` also edited `wiki.yml` *before* deleting the cache, so the crash left config and lockfile inconsistent with phantom source content still resolvable.

## The fix
- `_git_clone_or_fetch` now runs `git checkout --detach` before the mirror fetch, so no local branch is ever checked out while fetching (fetch is always allowed); `_git_prepare_ref` re-attaches/re-checks-out afterward. This also closes a latent stale-working-tree gap on git versions that permitted the old fetch (branch ref moves but files don't).
- New `_rmtree_force()` helper clears the read-only attribute and retries (`onerror` + `os.chmod(stat.S_IWRITE)`), used in `remove()` and `_remove_orphans()`.
- `remove()` deletes the cache **first** so any remaining failure leaves `wiki.yml`/`wiki.lock` untouched and consistent.

## Tests (all verified)
New `TestSourceGitLifecycle` in `tests/test_sources.py` runs against real git repos:
- `test_install_update_remove_unpinned_source` — full lifecycle; update advances lockfile **and** working tree, second update is a no-op, remove cleans everything.
- `test_install_update_pinned_branch_source` — same for a `#branch`-pinned source.
- `test_remove_survives_read_only_cache_files` — chmods the whole cache read-only, then removes (fails with the exact WinError 5 on unfixed code; passes with the fix — verified both directions on Windows).

Local: 548/548 unit tests pass, ruff clean. CI runs the same `unittest discover -s tests` gate.