### PR TITLE
docs: fix stale references in docs wiki pages

### DIFF
--- a/docs/wiki/Linked_Markdown.md
+++ b/docs/wiki/Linked_Markdown.md
@@ -3,7 +3,7 @@ type:
   - schema:TechArticle
   - schema:SoftwareApplication
 headline: Linked Markdown
-name: Linked Markdown
+name: Linked_Markdown
 description: The protocol specifying how semantic frontmatter and Markdown cross-links compile to an RDF graph.
 codeRepository: https://github.com/wazootech/linked-markdown
 ---

--- a/docs/wiki/Wiki_Configuration.md
+++ b/docs/wiki/Wiki_Configuration.md
@@ -501,7 +501,7 @@ Top-level **`fmt`** configures `wiki fmt` (mdformat). Two shapes are allowed —
 | Inline mapping | `fmt: { wrap: "no" }` | Default; what `wiki init` writes            |
 | Relative path  | `fmt: custom.toml`    | Share one TOML file or keep fmt out of yaml |
 
-Omit `fmt` entirely to use fallbacks: `config_root/.mdformat.toml`, then upward search from each markdown file, then **Wiki CLI fmt defaults** (`wrap: "no"`, `end_of_line: lf`, extensions `gfm`, `front_matters`, `wikilink`). See [wiki fmt](wiki_fmt.md) for the full resolution order.
+Omit `fmt` entirely to use fallbacks: `config_root/.mdformat.toml`, then upward search from each markdown file, then **Wiki CLI fmt defaults** (`wrap: "no"`, `end_of_line: lf`, extensions `gfm`, `front_matters`, `wikilink`, `toc`, `footnote`). See [wiki fmt](wiki_fmt.md) for the full resolution order.
 
 Invalid inline keys or values fail when the config loads. Invalid TOML syntax fails when `wiki fmt` reads the file.
 

--- a/docs/wiki/Wiki_Programmatic_API.md
+++ b/docs/wiki/Wiki_Programmatic_API.md
@@ -67,7 +67,7 @@ for graph in w.graphs():
 
 SPARQL `GRAPH` clauses are supported through `Wiki.query()` and the CLI query command. Unscoped queries continue to read the default union view.
 
-Runtime overrides (global `-b` / `--url-style`):
+Runtime overrides (CLI `--site-base-url` / `--site-url-style`; Python `base_url` / `url_style` kwargs):
 
 ```python
 w = w.with_runtime(base_url="/wiki", url_style="dir")
@@ -185,7 +185,7 @@ CommonJS usage:
 const { Wiki } = require("wazootech-wiki");
 ```
 
-The SDK exposes methods that mirror the CLI surface: `check`, `lint`, `fmt`, `render`, `build`, `export`, `link`, `query`, `graphList`, `serve`, `init`, and `upgrade`. Options use TypeScript-friendly camelCase names and map to the corresponding CLI flags.
+The SDK exposes methods that mirror the CLI surface: `check`, `lint`, `fmt`, `render`, `build`, `export`, `link`, `query`, `graphList`, `serve`, `init`, `install`, `update`, `remove`, `mcp`, and `upgrade`. Options use TypeScript-friendly camelCase names and map to the corresponding CLI flags.
 
 Most report-producing methods return a `WikiCommandResult` containing `ok`, `exitCode`, `stdout`, `stderr`, and the executed command argv. JSON-capable commands can parse structured output: `query({ format: "json" })` returns parsed JSON by default, and `export({ format: "dict" })` or `export({ format: "json-ld" })` includes parsed `data`.
 

--- a/docs/wiki/Wiki_Skills.md
+++ b/docs/wiki/Wiki_Skills.md
@@ -104,6 +104,7 @@ See `skills/wiki/references/deploy.md` (which includes the Deploy Alignment Chec
 ```
 skills/
   wiki/SKILL.md
+  wiki/evals/evals.json
   wiki/scripts/audit.sh
   wiki/scripts/verify.sh
   wiki/references/install.md
@@ -113,6 +114,7 @@ skills/
   wiki/references/plan.md
   wiki/references/loop.md
   wiki/references/deploy.md
+  wiki/references/enrich.md
   wiki/references/sync.md
   wiki/references/workflow-template-uv.yml
   wiki/references/workflow-template-pip.yml

--- a/docs/wiki/wiki.md
+++ b/docs/wiki/wiki.md
@@ -210,7 +210,7 @@ Procedural knowledge for coding agents: [Wiki Skills](Wiki_Skills.md) (`skills/w
 
 ## Global Options
 
-These options apply to config-loading subcommands (`check`, `lint`, `link`, `query`, `mcp`, `render`, `build`, `export`, `serve`, `fmt`, `install`, `remove`). `init` and `upgrade` do not load a config file.
+These options apply to all subcommands. Config-driven commands include `check`, `lint`, `link`, `query`, `mcp`, `render`, `build`, `export`, `serve`, `fmt`, `install`, `remove`, `update`, and `graph`; `init` and `upgrade` run with defaults when no config file exists.
 
 ### `-c, --config PATH`
 

--- a/docs/wiki/wiki_init.md
+++ b/docs/wiki/wiki_init.md
@@ -34,6 +34,7 @@ wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywi
 | `--graph-context-wiki`           | Override `graph.context.wiki` (overrides `--repo` inference)                                   | `graph.context.wiki`                             |
 | `--site-base-url`                | Override `site.base_url` (default `/wiki` or inferred from `--repo`)                           | `site.base_url`                                  |
 | `--site-url-style`               | Override `site.url_style`: `dir` or `file` (default `dir`)                                     | `site.url_style`                                 |
+| `--site-layout`                  | Override `site.layout` (default depends on the selected scaffold or template)                  | `site.layout`                                    |
 | `--graph-content-predicate`      | Override `graph.content_predicate` CURIE (e.g. `schema:articleBody`)                           | `graph.content_predicate`                        |
 | `--link-style`                   | Override `link.style`: standard page links (`standard`) or wikilinks (`wikilink`)              | `link.style`                                     |
 | `--input`                        | Override `wiki.input` list (can be specified multiple times, default `[wiki]`)                 | `wiki.input`                                     |
@@ -41,6 +42,7 @@ wiki init --graph-context-wiki https://example.org/mywiki/ --site-base-url /mywi
 | `--graph-implicit-types`         | Override `graph.implicit_types` (can be specified multiple times)                              | `graph.implicit_types`                           |
 | `--graph-implicit-types-policy`  | Override `graph.implicit_types_policy`: `fallback` or `append`                                 | `graph.implicit_types_policy`                    |
 | `--graph-include-file-extension` | Override `graph.include_file_extension` flag (defaults to `--no-graph-include-file-extension`) | `graph.include_file_extension`                   |
+| `--template`                     | Use a starter template from wazootech/wiki-templates (e.g. generic, llm-wiki, astro)           | —                                                |
 
 ## URL resolution
 

--- a/docs/wiki/wiki_mcp.md
+++ b/docs/wiki/wiki_mcp.md
@@ -88,7 +88,7 @@ Example shape:
 
 ```json
 {
-  "version": "0.1.22",
+  "version": "0.1.23",
   "config": "docs/wiki.yml",
   "inputs": ["docs/wiki"],
   "namespaces": {

--- a/docs/wiki/wiki_render.md
+++ b/docs/wiki/wiki_render.md
@@ -86,7 +86,7 @@ ORDER BY ?name
 
 | app | name | version |
 | --- | --- | --- |
-| [Linked_Markdown](Linked_Markdown.md) | Linked Markdown |  |
+| [Linked_Markdown](Linked_Markdown.md) | Linked_Markdown |  |
 | [Obsidian](Obsidian.md) | Obsidian |  |
 | [Vivary](Vivary.md) | Vivary | 0.1.0 |
 | [wiki](wiki.md) | wiki | 0.1.23 |


### PR DESCRIPTION
## Summary

Read-only audit of all 86 `docs/wiki/` pages landed a while ago; this PR applies the eight minor drifts it found so the documentation is accurate against v0.1.23. Docs-only; all validators pass (`fmt --check`, `lint --strict`, `check --strict`, `render --check`).

## Fixes

- `docs/wiki/wiki_mcp.md` — example `listTools` response now shows `"version": "0.1.23"` (was `0.1.22`).
- `docs/wiki/Wiki_Programmatic_API.md` — runtime-override parenthetical now names the real CLI flags (`--site-base-url` / `--site-url-style`) and Python kwargs (`base_url` / `url_style`) instead of the nonexistent global `-b` / `--url-style`.
- `docs/wiki/Wiki_Programmatic_API.md` — SDK method roster now includes `install`, `update`, `remove`, and `mcp`.
- `docs/wiki/Wiki_Configuration.md` — documented `fmt` defaults now list all five extensions (`gfm`, `front_matters`, `wikilink`, `toc`, `footnote`).
- `docs/wiki/wiki_init.md` — options table now includes `--site-layout` and `--template` (both verified against `src/wiki/cli.py`).
- `docs/wiki/wiki.md` — Global Options: config-driven command list now includes `update` and `graph`, and the "init/upgrade do not load a config file" claim is corrected (all subcommands run through the shared load; missing config falls back to defaults).
- `docs/wiki/Linked_Markdown.md` — frontmatter `name` now matches the filename (`Linked_Markdown`).
- `docs/wiki/Wiki_Skills.md` — repository-layout tree now lists `wiki/evals/evals.json` and `wiki/references/enrich.md`.
- `docs/wiki/wiki_render.md` — regenerated inline SPARQL result block (cascade of the `name` fix).

## Validation

```bash
wiki -c docs/wiki.yml fmt --check
wiki -c docs/wiki.yml lint --strict
wiki -c docs/wiki.yml check --strict
wiki -c docs/wiki.yml render --check
```

All pass.