### PR TITLE
docs: update Vivary page to current thin v0.3 contract

### DIFF
--- a/docs/wiki/Agent_Memory_Filesystems.md
+++ b/docs/wiki/Agent_Memory_Filesystems.md
@@ -41,7 +41,7 @@ These are not always mutually exclusive. A team might maintain a published **[wi
 
 ## Related pages
 
-- [Vivary](Vivary.md) — agent workspace stack (tropo typed graph + strato loop)
+- [Vivary](Vivary.md) — agent workspace standard (thin .vivary/ contract + tropo typed graph)
 - [LLM Wiki](LLM_Wiki.md) — pattern origins (Andrej Karpathy, Farza Majeed)
 - [Second Brain](Second_Brain.md) — PKM goals
 - [Style Guide](Style_Guide.md) — conventions for this wiki

--- a/docs/wiki/Jeff_Kazzee.md
+++ b/docs/wiki/Jeff_Kazzee.md
@@ -10,14 +10,14 @@ familyName: Kazzee
 
 ## Software in this wiki
 
-| Tool                | Role                                                                                |
-| ------------------- | ----------------------------------------------------------------------------------- |
-| [Vivary](Vivary.md) | Agent workspace standard — tropo graph, strato loop, ozone review, exo coordination |
+| Tool                | Role                                                                                                     |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
+| [Vivary](Vivary.md) | Agent workspace standard — thin .vivary/ contract, tropo typed graph, verification receipts, human gates |
 
 ## Lineage
 
 - **braincheck → loam → tropo** — knowledge-layer validation lineage evolving to typed graph edges in [Vivary](Vivary.md)
-- **throughline + flywheel → strato** — self-improving loop at turn speed and heartbeat speed, fused inside Vivary workspace templates
+- **throughline + flywheel** — per-turn and heartbeat loops that shaped Vivary's agent-facing workspace contract
 
 ## Other repositories
 

--- a/docs/wiki/Learning_Systems.md
+++ b/docs/wiki/Learning_Systems.md
@@ -27,8 +27,8 @@ The key property: **knowledge persists and compounds forward**. The agent does n
 
 In this ecosystem, recursive learning manifests as:
 
-- The **[Vivary](Vivary.md) strato loop** — `Ask → retrieve → act → verify → learn → gate`. The "learn" step examines verification results and the gated outcome, then distills improvements into memory, skills, or the graph itself.
-- **[Vivary ozone](Vivary.md#ozone--review-by-blast-radius)** — graph-aware review that checks not just individual documents but the relationships between them, surfacing gaps a per-document check cannot see.
+- The **[Vivary](Vivary.md) agent loop** — read `.vivary/context.md` first, act, verify with `tropo check`, and stop at deliberate human gates. Verification results and gate outcomes are recorded as receipts that later turns reuse.
+- **[Vivary governance](Vivary.md#governance--capsules-receipts-and-policy)** — `tropo check` gates the whole graph, and Task Capsules + Execution Receipts bind what ran to one question and scope, so verification feeds the next cycle.
 - **[Procedural Knowledge](Procedural_Knowledge.md)** — self-updating workflows: [SPARQL](SPARQL.md) blocks that [render](wiki_render.md) live results, [SHACL](SHACL.md) shapes that validate structure, and [wiki skills](Wiki_Skills.md) that encode repeatable processes.
 - **[wiki render](wiki_render.md)** — `wiki render --check` detects stale SPARQL result blocks from a prior run and flags them for regeneration, closing the recursive loop.
 
@@ -36,14 +36,14 @@ The key property: **the system improves its own process by examining its output*
 
 ## Comparison
 
-| Dimension         | Continual learning                                          | Recursive learning                                                     |
-| ----------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------- |
-| **Time axis**     | Forward accumulation — each session adds                    | Cyclical refinement — each loop re-evaluates                           |
-| **Storage model** | Growing corpus of documents and graph triples               | Self-modifying workflows, skills, and memory                           |
-| **Agent role**    | Gardener — tends and expands the wiki                       | Meta-cognitive — reflects on and improves its own process              |
-| **Scale**         | Sessions to months                                          | Single turn to a few turns                                             |
-| **Risk**          | Stale or contradictory pages if unchecked                   | Infinite loops or over-optimization without gates                      |
-| **Examples**      | Adding a new page, enriching frontmatter, growing the graph | `verify → learn → gate` in Vivary, `wiki render --check`, ozone review |
+| Dimension         | Continual learning                                          | Recursive learning                                                          |
+| ----------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Time axis**     | Forward accumulation — each session adds                    | Cyclical refinement — each loop re-evaluates                                |
+| **Storage model** | Growing corpus of documents and graph triples               | Self-modifying workflows, skills, and memory                                |
+| **Agent role**    | Gardener — tends and expands the wiki                       | Meta-cognitive — reflects on and improves its own process                   |
+| **Scale**         | Sessions to months                                          | Single turn to a few turns                                                  |
+| **Risk**          | Stale or contradictory pages if unchecked                   | Infinite loops or over-optimization without gates                           |
+| **Examples**      | Adding a new page, enriching frontmatter, growing the graph | `tropo check` gates in Vivary, `wiki render --check`, receipt-driven review |
 
 ## How they compose
 
@@ -53,12 +53,12 @@ Continual and recursive learning are complementary, not competing. A healthy age
 1. On each turn (or heartbeat), the agent verifies its latest output, learns from verification results, and updates its skills or memory — **recursive** refinement of process.
 1. The recursive loop feeds the continual corpus: insights from verification become new frontmatter, corrected links, or updated shapes.
 
-The **[LLM Wiki](LLM_Wiki.md)** pattern is the continual surface; the **[Vivary](Vivary.md) strato loop** is the recursive engine. They meet in the middle: a wiki that grows perpetually and improves itself on every interaction.
+The **[LLM Wiki](LLM_Wiki.md)** pattern is the continual surface; the **[Vivary](Vivary.md) agent loop** is the recursive engine. They meet in the middle: a wiki that grows perpetually and improves itself on every interaction.
 
 ## Related
 
 - [LLM Wiki](LLM_Wiki.md) — pattern origins and compounding knowledge base design
-- [Vivary](Vivary.md) — agent workspace with the strato loop and ozone review
+- [Vivary](Vivary.md) — agent workspace with typed records, verification gates, and receipts
 - [Agent Memory Filesystems](Agent_Memory_Filesystems.md) — persistent memory across sessions
 - [Declarative Knowledge](Declarative_Knowledge.md) — facts and structures that accumulate
 - [Procedural Knowledge](Procedural_Knowledge.md) — workflows and processes that self-improve

--- a/docs/wiki/Vivary.md
+++ b/docs/wiki/Vivary.md
@@ -1,213 +1,135 @@
 ---
 type: schema:SoftwareApplication
 name: Vivary
-softwareVersion: 0.1.0
-description: A standard and scaffolder for agent-native workspaces — typed knowledge graph, self-improving loop, graph-aware review, and blast-radius impact.
-codeRepository: https://github.com/Jeff-Kazzee/vivary
+softwareVersion: 0.4.2
+description: An agent-native workspace standard and scaffolder — a thin .vivary/ governed-context contract, typed Markdown records, verification receipts, and deliberate human gates.
+codeRepository: https://github.com/vivary-dev/vivary
 ---
 
 # Vivary
 
-[Vivary](https://vivary.vercel.app/) is **the create-t3-app for agent workspaces**: a standard plus scaffolder that wires standalone modules into a normalized, portable workspace your AI agent can navigate, verify, and improve. Plain Markdown, any editor, any agent runtime — no lock-in.
+[Vivary](https://vivary.vercel.app/) is a **standard plus scaffolder for agent-native workspaces**: `create-vivary` seeds a thin governed `.vivary/` contract that agents read first, a typed knowledge graph of Markdown records, verification receipts, and deliberate human gates — plain Markdown and TOML, any editor, any agent runtime, no lock-in.
 
-Source and docs: [github.com/Jeff-Kazzee/vivary](https://github.com/Jeff-Kazzee/vivary), by [Jeff Kazzee](Jeff_Kazzee.md). PyPI packages use the `vivary-*` prefix; npm scaffolds use `@vivary/*`.
+Source and docs: [github.com/vivary-dev/vivary](https://github.com/vivary-dev/vivary). PyPI packages use the `vivary-*` prefix (for example `create-vivary`, `vivary-tropo`); npm scaffolds use `@vivary/*`.
 
 ```bash
 npm create @vivary my-workspace
-pip install vivary-tropo vivary-ozone vivary-exo create-vivary
+# or: npx @vivary/create my-workspace
+pip install create-vivary vivary-tropo
 create-vivary init my-workspace --preset coding
+create-vivary doctor my-workspace
 ```
 
-MIT · Python 3.11+ · zero third-party dependencies on the core engines · on [PyPI](https://pypi.org/project/vivary-tropo/) and npm.
+MIT · Python 3.11+ · zero third-party dependencies on the core engines · on [PyPI](https://pypi.org/project/create-vivary/) and npm.
 
 ## The problem Vivary solves
 
 Every AI-agent project starts the same way: a pile of spec files, a `notes.md`, some rules, a memory dump. Then it rots. Vivary makes the workspace a **known, structured, navigable thing** — the way [create-t3-app](https://create.t3.gg/) did for web stacks.
 
-The irreducible baseline for any agent workspace:
+The design law: the framework must cost almost nothing to load, or it steals the context the work needs.
 
-> A self-improving loop running over a typed, navigable knowledge graph, with one visible state surface and human gates.
+## The thin workspace contract (v0.3)
 
-Everything Vivary ships is a facet of that sentence. The design law (from [Jeff Kazzee](Jeff_Kazzee.md)'s [throughline](https://github.com/Jeff-Kazzee/throughline)): the framework must cost almost nothing to load, or it steals the context the work needs.
+Current Vivary workspaces (0.4.x) run a deliberately **thin** contract. A default greenfield `init` writes exactly five files — `AGENTS.md`, `STATE.md`, `.gitignore`, and two under `.vivary/`:
 
-## Four layers, named for the sky
+| File                     | Purpose                                                 |
+| ------------------------ | ------------------------------------------------------- |
+| `.vivary/context.md`     | The first typed project node / governed-context capsule |
+| `.vivary/workspace.toml` | The thin workspace contract and policy                  |
 
-A *vivary* is a self-contained world with stacked atmospheric layers. Each layer is a standalone, zero-dependency CLI. **Baseline = tropo + strato**; ozone and exo snap on when you need review gates or multi-agent coordination.
+Everything else under `.vivary/` appears only as work earns it:
 
-| Layer        | Package                    | Role                                                    |
-| ------------ | -------------------------- | ------------------------------------------------------- |
-| Troposphere  | **tropo** (`vivary-tropo`) | Typed knowledge graph — ground truth                    |
-| Stratosphere | **strato**                 | Agent OS — loop, state, memory, gates, self-improvement |
-| The filter   | **ozone** (`vivary-ozone`) | Graph-aware review and blast-radius impact              |
-| Exosphere    | **exo** (`vivary-exo`)     | Coordination when one agent becomes many                |
+- `.vivary/records/` — typed Markdown records, created one at a time via `create-vivary record` (for example `.vivary/records/changes/verified-slice.md`), never seeded or bulk-loaded
+- `.vivary/private/` — private material, gitignored and excluded from the graph
+- `.vivary/runtime/` — runtime artifacts, gitignored and excluded from the graph
+- `.vivary/receipts.jsonl` — optional local JSONL run-receipt log (`--receipt` or `VIVARY_RECEIPT_LOG`)
+- `.vivary/storage.toml` — optional opt-in storage/vector config (embedded local-hash vectors, cloud backends)
 
-```
-        exo      ── multi-agent orchestration            (optional)
-       ozone     ── review: code + editorial / gates     (optional)
-       strato    ── agent OS: state · memory · loop     (baseline)
-       tropo     ── typed knowledge graph               (baseline)
-```
-
-## Install and scaffold
-
-**Python 3.11+** is required.
-
-```bash
-# Install CLIs
-pip install vivary-tropo vivary-ozone vivary-exo create-vivary
-
-# Run without installing
-uvx vivary-tropo check --root my-workspace
-
-# create-t3-app-style scaffold (npm)
-npm create @vivary my-workspace
-# or: npx @vivary/create my-workspace
-
-# Create a workspace locally
-create-vivary init my-workspace --preset coding
-create-vivary doctor my-workspace
-```
-
-Presets share the same agent-OS shell and differ only by starter graph:
-
-| Preset         | Module              | First change        | Verification       |
-| -------------- | ------------------- | ------------------- | ------------------ |
-| `coding`       | `codebase`          | `local-ci-baseline` | `local-checks`     |
-| `second-brain` | `knowledge-base`    | `capture-routine`   | `retrieval-smoke`  |
-| `writing`      | `manuscript-system` | `draft-review-loop` | `editorial-review` |
-
-`create-vivary init` writes `AGENTS.md`, `SOUL.md`, `STATE.md`, private `USER.md` / `MEMORY.md` boundaries, strato runtime skills (`.claude/skills/`, `.agents/skills/`), `tropo.toml`, and a starter typed graph under `modules/`, `changes/`, `decisions/`, `verification/`, and `gates/`. Pass `--obsidian` for an optional [Obsidian](Obsidian.md) vault config — never required.
+Brownfield `create-vivary adopt` is capped at three Vivary payload files (`.vivary/context.md`, `.vivary/workspace.toml`, and `STATE.md` when absent) plus bounded `AGENTS.md` / `.gitignore` blocks; conflicts fail closed. Older pre-0.4 "legacy-full" workspaces stay read-compatible — Doctor keeps them readable without migrating them.
 
 ## tropo — the typed knowledge graph
 
-**tropo** is the typed knowledge graph layer. The filesystem *is* the schema: a document's type is the folder it lives in; metadata is only what cannot be derived from path, git, or the first `# H1`.
+**tropo** is the typed knowledge graph layer. **Location is type**: a document's type is the folder it lives in, declared by `[types.*]` blocks in `.vivary/workspace.toml` (folder, `required` / `optional` fields, `enum:` values). `id` and `title` are derived, so a record can be fully typed with minimal or no frontmatter; `ref` / `ref-list` fields become graph edges.
 
-```
-people/jeff.md           →  type = person   (the folder says so)
-projects/tropo/README.md →  type = project
-meetings/2026-06-12.md   →  type = meeting
-```
+```toml
+version = 1
+exclude = [".git", ".agents", ".vivary/private", ".vivary/runtime"]
 
-A clean note can have **zero frontmatter** and still be fully typed and valid. Frontmatter is the exception, not the rule.
+[workspace]
+contract = "thin-v0.3"
+preset = "coding"
+state = "STATE.md"
+private = [".vivary/private"]
+runtime = [".vivary/runtime"]
+capabilities = []
 
-### Commands
+[base]
+derive = ["id", "title"]
+allow_untyped = true
 
-| Command            | Purpose                                                                           |
-| ------------------ | --------------------------------------------------------------------------------- |
-| `tropo check`      | Validate every document and the graph — **opinionated: warnings fail by default** |
-| `tropo signal`     | Print only irreducible metadata (noise stripped)                                  |
-| `tropo types`      | Resolved type registry                                                            |
-| `tropo stats`      | Document counts and health summary                                                |
-| `tropo graph`      | Emit typed nodes and edges (`--json`)                                             |
-| `tropo blast <id>` | Blast radius — everything that refs a node transitively                           |
-| `tropo view`       | Self-contained HTML graph visualization                                           |
-| `tropo plan`       | Simulate a change and show semantic delta                                         |
-| `tropo fix`        | Strip redundant frontmatter (`--dry-run` to preview)                              |
-| `tropo init`       | Scaffold `tropo.toml` (optional `--packs`)                                        |
-
-Example gate output:
-
-```text
-$ tropo check
-changes/billing.md:3 error E101: missing required field 'status'
-modules/auth.md:5 warning W220: ref 'sessoin' matches no document id
-tropo: 12 document(s), 1 error(s), 1 warning(s)  →  exit 1
+[types.change]
+folder = "changes"
+required = { project = "string", status = "enum:planned|active|done|blocked|deferred", slice = "string" }
+optional = { branch = "string", related_modules = "ref-list", related_changes = "ref-list" }
 ```
 
-### Finding codes
+Key commands:
 
-| Code | Level   | Meaning                                      |
-| ---- | ------- | -------------------------------------------- |
-| E101 | error   | Missing required field                       |
-| E103 | error   | Field violates type spec                     |
-| W201 | warning | Untyped document                             |
-| W202 | warning | Unknown field for this type                  |
-| W210 | warning | Field equals derived value (run `tropo fix`) |
-| W220 | warning | Broken ref (edge to missing id)              |
+| Command                     | Purpose                                                                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `tropo check`               | Validate every document and the graph — warnings fail by default                                                              |
+| `tropo find --governed`     | Bounded graph-backed context for a question                                                                                   |
+| `tropo query --mode vector` | Vector search, preferring stored embeddings when `.vivary/storage.toml` enables them (`source: stored` / `computed` / `text`) |
 
-Configuration lives in **`tropo.toml`**: composable type **packs**, subtree **overlays** (tighten-only — like `tsconfig` inheritance), derived fields (`id`, `title`, `created`, `updated`), and graph field types `ref` / `ref-list` that become edges.
+## Governance — capsules, receipts, and policy
 
-## strato — the agent OS
+- **Task Capsules** (`vivary.task-capsule/v0`) — fingerprinted governed-context artifacts compiled for one question and declared scope; they carry the context and effective checks but never execute them.
+- **Execution Receipts** (`vivary.execution-receipt/v0`) — records of what actually ran, bound to one capsule and workspace fingerprint; provenance is never treated as proof of correctness.
+- **Local run receipts** — optional JSONL at `.vivary/receipts.jsonl` (`--receipt` / `VIVARY_RECEIPT_LOG`), one `vivary.run_receipt.v1` envelope per line: schema version, tool/version, command, flag names, argument count, exit code, duration, Python version, platform. Not telemetry — no stdout, stderr, file contents, or paths, and nothing is sent anywhere.
+- **Policy** — `.vivary/workspace.toml` is the thin base policy; a root or nested `tropo.toml` may tighten but never expand it, and competing thin roots fail closed.
 
-**strato** is not a separate PyPI engine in v0.1; it ships as workspace templates and runtime skills fused from [throughline](https://github.com/Jeff-Kazzee/throughline) (per-turn loop) and [flywheel](https://github.com/Jeff-Kazzee/flywheel) (heartbeat distillation into memory and skills).
+## Agent integration
 
-The operating loop in `AGENTS.md`:
-
-> **Ask → retrieve → act → verify → learn → gate.**
-
-- **Retrieve** with `tropo graph` / `tropo blast` — the graph is the first source of truth.
-- **Verify** with `tropo check` + `ozone review` before a gate.
-- **Learn** — distill verification results and gate outcomes back into memory, skills, or the graph. See [Learning Systems](Learning_Systems.md) for the distinction between continual and recursive learning.
-- **Gate** — name blast radius (`ozone impact`) for risky changes; stop at human gates (memory writes, publishing, installs, git push/PR, destructive ops).
-
-Visible state surfaces: `STATE.md` (Focus / Status / Next), `SOUL.md` (principles), gitignored `USER.md` and `MEMORY.md` for private identity and durable memory.
-
-## ozone — review by blast radius
-
-Where `tropo check` asks *"is each document valid?"*, **ozone** reviews the **whole graph**: relationship gaps a per-document check cannot see, and the **blast radius** of a change.
-
-```text
-$ ozone impact billing
-billing  →  4 node(s) depend on it
-  1  invoice    (change, via related_changes)
-  1  checkout   (module,  via related_modules)
-  2  receipt    (change,  via related_changes)
-```
-
-| Command             | Purpose                                           |
-| ------------------- | ------------------------------------------------- |
-| `ozone review`      | Advisory graph review ( `--strict` for CI gate )  |
-| `ozone impact <id>` | Dependents of a node with distance and edge field |
-| `ozone packs`       | List rule packs (e.g. `structure`)                |
-
-The `structure` pack flags `change-unverified`, `change-ungated`, orphans, and broken edges. Code review and editorial review are the same layer with different rule packs — medium-agnostic by design.
-
-## exo — multi-agent coordination
-
-**exo** engages only when one agent becomes many. It does not run agents; it reasons read-only over the shared tropo graph.
-
-| Command         | Purpose                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------- |
-| `exo conflicts` | Active work items that share outbound targets                                               |
-| `exo board`     | Work grouped by `status` (and `@assignee` when declared)                                    |
-| `exo roles`     | Bounded contracts — Orchestrator, Scout, Researcher, Builder, Verifier, Reviewer, Archivist |
-
-Most workspaces never need exo. Single-agent setups stop at **tropo + strato**.
+- Generated `AGENTS.md` instructs agents to **read `.vivary/context.md` first**; it routes bounded project context, verification receipts, privacy, current state, and deliberate human gates.
+- One orchestrator or human owns `STATE.md`; workers return receipts instead of editing it concurrently.
+- The CLI is the baseline agent API — every command works non-interactively with structured output; MCP stays off until installed and enabled.
+- Optional MCP: `vivary-mcp --workspace project .` exposes four tools that read and query only, and never authorize a write.
+- `--active-context cocoindex-code` declares a CocoIndex code-index capability — it changes only policy (`capabilities` + excludes in `workspace.toml`, a gitignore rule for `.cocoindex_code/`) and copies no skill, guide, graph node, or template.
 
 ## Design principles
 
-- **Signal over noise.** If a value can be derived, never make a human write it.
-- **Location is type.** The directory tree is the type hierarchy.
-- **Tighten, never loosen.** Overlays and packs add constraints only.
-- **Zero-dependency, CI-clean.** Honest exit codes; `--json` on every command.
-- **No lock-in.** Plain Markdown + YAML; [Obsidian](Obsidian.md), Claude Code, Codex, or no editor at all.
-- **Medium-agnostic.** The same graph and review serve code and prose.
+- **Signal over noise.** If a value can be derived (`id`, `title`), never make a human write it.
+- **Location is type.** The directory tree is the type hierarchy, declared in `workspace.toml`.
+- **Tighten, never loosen.** Overlays and `tropo.toml` add constraints only.
+- **Minimalism law.** The baseline stays zero-dependency; storage and MCP are opt-in.
+- **Fail closed.** Missing or negated privacy rules, unknown config, and competing thin roots refuse to run.
+- **No lock-in.** Plain Markdown + TOML; any editor, any agent runtime.
 
 ## Vivary vs [wiki](wiki.md)
 
-| Dimension       | Vivary (tropo)                                 | [wiki](wiki.md)                          |
-| --------------- | ---------------------------------------------- | ---------------------------------------- |
-| Primary goal    | Standardized **agent workspace**               | Semantic wiki **toolchain**              |
-| Schema model    | Folder-as-type + `tropo.toml` packs            | SHACL, JSON Schema, `wiki.yaml`          |
-| Metadata style  | Derive type, dates, title; minimal frontmatter | YAML-LD frontmatter + shapes             |
-| Graph           | Typed nodes/edges from `ref` fields            | Full RDF compile + [SPARQL](SPARQL.md)   |
-| Validation      | `tropo check` (strict gate)                    | `wiki check`, `wiki lint`                |
-| Review / impact | `ozone review`, `ozone impact`, `tropo blast`  | Link graph, SHACL, broken-link lint      |
-| Agent loop      | strato templates + skills (`AGENTS.md`, loop)  | [Wiki Skills](Wiki_Skills.md) (optional) |
-| Publishing      | Not the focus (workspace OS)                   | `wiki build`, static HTML, RDF export    |
-| Dependencies    | Zero on core engines                           | PyPI `wazootech-wiki`                    |
+| Dimension          | Vivary (tropo)                                                     | [wiki](wiki.md)                          |
+| ------------------ | ------------------------------------------------------------------ | ---------------------------------------- |
+| Primary goal       | Standardized **agent workspace**                                   | Semantic wiki **toolchain**              |
+| Workspace contract | Thin `.vivary/` — `context.md` + `workspace.toml` (v0.3)           | `wiki.yaml` config                       |
+| Schema model       | Folder-as-type + `[types.*]` in `workspace.toml`                   | SHACL, JSON Schema, `wiki.yaml`          |
+| Metadata style     | Derive `id`, `title`; minimal frontmatter                          | YAML-LD frontmatter + shapes             |
+| Graph              | Typed nodes/edges from `ref` fields                                | Full RDF compile + [SPARQL](SPARQL.md)   |
+| Records            | `.vivary/records/` — one typed Markdown per `create-vivary record` | Documents with frontmatter + shapes      |
+| Validation         | `tropo check` + Doctor (strict gate)                               | `wiki check`, `wiki lint`                |
+| Governance         | Task Capsules, Execution Receipts, local run receipts              | Link graph, SHACL                        |
+| Privacy            | `.vivary/private/`, `.vivary/runtime/` gitignored + graph-excluded | Config excludes only                     |
+| Agent loop         | `AGENTS.md` → `.vivary/context.md`, receipts, human gates          | [Wiki Skills](Wiki_Skills.md) (optional) |
+| Publishing         | Not the focus (workspace OS)                                       | `wiki build`, static HTML, RDF export    |
+| MCP                | Optional read-only `vivary-mcp` (4 tools)                          | Optional read-only `wiki mcp` (SPARQL)   |
+| Dependencies       | Zero on core engines; storage/MCP opt-in                           | PyPI `wazootech-wiki`                    |
 
-**Wiki CLI** targets wikis that become queryable, publishable [semantic web](Semantic_Web.md) artifacts; Vivary targets the **agent-native workspace** pattern in the [LLM Wiki](LLM_Wiki.md) era — compounding loop + typed graph + human gates — without RDF compilation.
+**Wiki CLI** targets wikis that become queryable, publishable [semantic web](Semantic_Web.md) artifacts; Vivary targets the **agent-native workspace** pattern in the [LLM Wiki](LLM_Wiki.md) era — thin governed contract + typed graph + verification receipts + human gates — without RDF compilation.
 
 The stacks can complement each other: Vivary for day-to-day agent workspace hygiene; Wiki CLI when the same Markdown should become a validated public wiki with SPARQL and static site output.
 
 ## Lineage
 
-Vivary composes ideas from [Jeff Kazzee](Jeff_Kazzee.md)'s earlier tools:
-
-- **braincheck → loam → tropo** — knowledge-layer validation lineage evolving from frontmatter-everywhere to folder-as-type to typed graph edges
-- **throughline + flywheel → strato** — self-improving loop at turn speed and heartbeat speed
-- **ozone, exo** — graph-native review and coordination (new in Vivary)
+Vivary composes ideas from [Jeff Kazzee](Jeff_Kazzee.md)'s earlier tools — **braincheck → loam → tropo**, the knowledge-layer validation lineage that settled on folder-as-type, and **throughline + flywheel**, per-turn and heartbeat loops that shaped the agent-facing workspace contract. Current development lives at [vivary-dev/vivary](https://github.com/vivary-dev/vivary).
 
 ## Related
 
@@ -215,6 +137,5 @@ Vivary composes ideas from [Jeff Kazzee](Jeff_Kazzee.md)'s earlier tools:
 - [wiki](wiki.md) — semantic compiler for Markdown wikis
 - [LLM Wiki](LLM_Wiki.md) — compounding agent-maintained knowledge pattern
 - [Agent Memory Filesystems](Agent_Memory_Filesystems.md) — filesystem-metaphor memory tools compared
-- [Obsidian](Obsidian.md) — optional authoring surface (`create-vivary init --obsidian`)
-- [Personal Knowledge](Personal_Knowledge.md) — domain context for second-brain presets
-- [Software Application Shape](Software_Application_Shape.md) — SHACL shape for this page
+- [Obsidian](Obsidian.md) — optional authoring surface
+- [Personal Knowledge](Personal_Knowledge.md) — domain context for knowledge-base workspaces

--- a/docs/wiki/Vivary.md
+++ b/docs/wiki/Vivary.md
@@ -81,6 +81,26 @@ Key commands:
 | `tropo find --governed`     | Bounded graph-backed context for a question                                                                                   |
 | `tropo query --mode vector` | Vector search, preferring stored embeddings when `.vivary/storage.toml` enables them (`source: stored` / `computed` / `text`) |
 
+## Adding or changing types — tighten-only overlays
+
+Once a base schema exists, refinement happens through **overlays** — nested `tropo.toml` files that may only *add requirements or narrow enums* for a subtree, never relax inherited ones. That is the **tighten-only law**: a schema's evolution toward being optimal for a project is a directional, one-way tightening process, enforced at config-load time (`E120` on any loosen attempt) and guided by what `tropo check` and `tropo fix` surface as friction — `W210` flags frontmatter that merely repeats a derived value, and `tropo fix` strips it (the only mechanical edit tropo makes).
+
+Add or change a type by editing `tropo.toml`:
+
+```toml
+[types.runbook]
+folder   = "runbooks"
+required = { owner = "string" }
+optional = { related_modules = "ref-list" }
+```
+
+A nested `tropo.toml` tightens the rules for its subtree — it can add requirements or narrow enums, never loosen inherited ones:
+
+```toml
+[types.runbook]
+required = { owner = "string", review_status = "enum:draft|reviewed|approved" }
+```
+
 ## Governance — capsules, receipts, and policy
 
 - **Task Capsules** (`vivary.task-capsule/v0`) — fingerprinted governed-context artifacts compiled for one question and declared scope; they carry the context and effective checks but never execute them.

--- a/docs/wiki/wiki.md
+++ b/docs/wiki/wiki.md
@@ -310,7 +310,7 @@ This repository implements the [LLM Wiki](LLM_Wiki.md) pattern for [Personal Kno
 
 Similar **agent memory filesystem** approaches include [Supermemory SMFS](Supermemory_SMFS.md), [Letta MemFS](Letta_MemFS.md), and [Agent Memory Filesystems](Agent_Memory_Filesystems.md).
 
-For a **standardized agent workspace** (typed graph, loop, blast-radius review), see [Vivary](Vivary.md).
+For a **standardized agent workspace** (thin governed contract, typed graph, verification gates), see [Vivary](Vivary.md).
 
 ## Repository
 

--- a/docs/wiki/wiki_render.md
+++ b/docs/wiki/wiki_render.md
@@ -88,7 +88,7 @@ ORDER BY ?name
 | --- | --- | --- |
 | [Linked_Markdown](Linked_Markdown.md) | Linked_Markdown |  |
 | [Obsidian](Obsidian.md) | Obsidian |  |
-| [Vivary](Vivary.md) | Vivary | 0.1.0 |
+| [Vivary](Vivary.md) | Vivary | 0.4.2 |
 | [wiki](wiki.md) | wiki | 0.1.23 |
 
 <!-- sparql:end -->


### PR DESCRIPTION
## Summary

Updates the docs wiki's Vivary page to describe **current Vivary** (thin v0.3 workspace contract) instead of the outdated 0.1.0 four-layer framing (tropo/strato/ozone/exo).

## Changes

- **`docs/wiki/Vivary.md`** — rewritten: the thin `.vivary/` contract (`context.md` + `workspace.toml` seed, `records/`, `private/`, `runtime/`, `receipts.jsonl`, `storage.toml`), the tropo folder-as-type model, Task Capsules (`vivary.task-capsule/v0`) and Execution Receipts (`vivary.execution-receipt/v0`), local run-receipt envelopes, the `cocoindex-code` active context, and a refreshed **Vivary vs wiki** comparison table. Frontmatter updated to `softwareVersion: 0.4.2` and `codeRepository: vivary-dev/vivary`.
- **`docs/wiki/Jeff_Kazzee.md`**, **`docs/wiki/Learning_Systems.md`**, **`docs/wiki/Agent_Memory_Filesystems.md`**, **`docs/wiki/wiki.md`** — replace stale strato/ozone references with the current contract; the `Learning_Systems.md` anchor now points at the governance section.
- **`docs/wiki/wiki_render.md`** — regenerated SPARQL block (Vivary version `0.1.0` → `0.4.2`).

## Verification

Mirrors CI locally against `docs/wiki.yml`, all green:

- `wiki fmt` / `fmt --check`
- `wiki lint --strict`
- `wiki check --strict`
- `wiki render --check`